### PR TITLE
Add repository link to Cargo manifest

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -10,6 +10,7 @@ description = """\
     a library or component when implementing distributed ledgers, including \
     blockchains.
 """
+repository = "http://github.com/hyperledger/transact"
 
 [dependencies]
 hex = "0.3"


### PR DESCRIPTION
The repository link will appear as part of the links on the crates.io page.