### PR TITLE
Initial implementation of Command transaction family

### DIFF
--- a/libtransact/build.rs
+++ b/libtransact/build.rs
@@ -43,6 +43,7 @@ fn main() {
                 .to_str()
                 .unwrap(),
             proto_path.join("merkle.proto").to_str().unwrap(),
+            proto_path.join("command.proto").to_str().unwrap(),
         ],
         includes: &[proto_path.to_str().unwrap()],
         customize: Customize::default(),
@@ -52,6 +53,6 @@ fn main() {
     // Create mod.rs accordingly
     let mut mod_file = File::create(dest_path.join("mod.rs")).unwrap();
     mod_file
-        .write_all(b"pub mod batch;\npub mod events;\npub mod transaction;\npub mod transaction_receipt;\npub mod merkle;\n")
+        .write_all(b"pub mod batch;\npub mod events;\npub mod transaction;\npub mod transaction_receipt;\npub mod merkle;\npub mod command;\n")
         .unwrap();
 }

--- a/libtransact/protos/command.proto
+++ b/libtransact/protos/command.proto
@@ -1,0 +1,121 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// A transaction payload for the Command Family
+message CommandPayload {
+    // The list of commands to execute
+    repeated Command commands = 1;
+}
+
+// A key-value pair where the value is a bytes field.
+message BytesEntry {
+    // The key, for instance a state address or a string value, depending on
+    // the target of the entry.
+    string key = 1;
+    // The byte value to be stored
+    bytes value = 2;
+}
+
+// The list of state keys to be retrieved via a GET_STATE command.
+message GetState {
+    // a non-empty list of valid state keys
+    repeated string state_keys = 1;
+}
+
+// The list of state entries to be set via a SET_STATE command.
+message SetState {
+    // a non-empty list of BytesEntry instances, where the key field is a
+    // valid state key.
+    repeated BytesEntry state_writes = 1;
+}
+
+// The list of state keys to be deleted via a DELETE_STATE command.
+message DeleteState {
+    // a non-empty list of valid state keys
+    repeated string state_keys = 1;
+}
+
+// Describes an event to add to the receipt via an ADD_EVENT command.
+message AddEvent {
+    // The event type
+    string event_type = 1;
+    // The attribute entries
+    repeated BytesEntry attributes = 2;
+    // Arbitrary opaque event data
+    bytes data = 3;
+}
+
+// The opaque byte data to add to the receipt via an ADD_RECEIPT_DATA
+// command.
+message AddReceiptData {
+    // a non-empty byte array
+    bytes receipt_data = 1;
+}
+
+// The duration and method of sleep to apply during a SLEEP command.
+message Sleep {
+    enum SleepType {
+        // This will wait, releasing cpu utilization to other processes
+        WAIT = 0;
+        // This will consume a cpu core for the specified time
+        BUSY_WAIT = 1;
+    }
+
+    // The duration to sleep, in milliseconds
+    uint32 duration_millis = 1;
+    SleepType sleep_type = 2;
+}
+
+// The details to return on an RETURN_INVALID command.
+message ReturnInvalid {
+    // An optional error message
+    string error_message = 1;
+}
+
+// The details to return on an RETURN_INTERNAL_ERROR command.
+message ReturnInternalError {
+    // An optional error message
+    string error_message = 1;
+}
+
+// A command to be executed
+message Command {
+    enum CommandType {
+        UNSET_COMMAND_TYPE = 0;
+        GET_STATE = 1;
+        SET_STATE = 2;
+        DELETE_STATE = 3;
+        ADD_EVENT = 4;
+        ADD_RECEIPT_DATA = 5;
+        SLEEP = 6;
+        RETURN_INVALID = 7;
+        RETURN_INTERNAL_ERROR = 8;
+    }
+
+    // The type of the command, which indicates which of the following
+    // fields will be set.
+    CommandType command_type = 1;
+
+    GetState get_state = 2;
+    SetState set_state = 3;
+    DeleteState delete_state = 4;
+    AddEvent add_event = 5;
+    AddReceiptData add_receipt_data = 6;
+    Sleep sleep = 7;
+    ReturnInvalid return_invalid = 8;
+    ReturnInternalError return_internal_error = 9;
+}

--- a/libtransact/src/execution/adapter/static_adapter.rs
+++ b/libtransact/src/execution/adapter/static_adapter.rs
@@ -299,9 +299,13 @@ mod test {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
+    use std::time;
 
     use crate::context::ContextLifecycle;
-    use crate::protocol::command::{BytesEntry, Command, GetState, ReturnInvalid, SetState};
+    use crate::protocol::command::{
+        AddEvent, AddReceiptData, BytesEntry, Command, DeleteState, GetState, ReturnInternalError,
+        ReturnInvalid, SetState, Sleep, SleepType,
+    };
     use crate::scheduler::{ExecutionTaskCompletionNotification, InvalidTransactionResult};
     use crate::state::hashmap::HashMapState;
     use crate::workload::command::{make_command_transaction, CommandTransactionHandler};
@@ -331,7 +335,7 @@ mod test {
 
         assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
 
-        // Create and execute a simple transaction
+        // Create and execute a simple transaction.
         let txn_pair = make_command_transaction(&[Command::SetState(SetState::new(
             create_bytes_entry(vec![("abc".into(), b"abc".to_vec())]),
         ))]);
@@ -382,7 +386,7 @@ mod test {
 
         assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
 
-        // Create and execute a failing transaction.
+        // Create and execute a failing transaction, resulting in an invalid error.
         let txn_pair = make_command_transaction(&[
             Command::GetState(GetState::new(vec!["abc".into()])),
             Command::ReturnInvalid(ReturnInvalid::new("Test Fail Succeeded".into())),
@@ -414,6 +418,411 @@ mod test {
             ),
             result.unwrap()
         );
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with a failing transaction which returns an internal error.
+    #[test]
+    fn apply_static_adapter_internal_error() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute a failing transaction, resulting in an internal error.
+        let txn_pair = make_command_transaction(&[
+            Command::GetState(GetState::new(vec!["abc".into()])),
+            Command::ReturnInternalError(ReturnInternalError::new(
+                "Test Internal Fail Succeeded".into(),
+            )),
+        ]);
+
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        assert!(result.is_err());
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with a valid delete transaction.
+    #[test]
+    fn apply_static_adapter_valid_delete() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute a valid delete transaction.
+        let txn_pair = make_command_transaction(&[
+            Command::SetState(SetState::new(create_bytes_entry(vec![(
+                "abc".into(),
+                b"abc".to_vec(),
+            )]))),
+            Command::GetState(GetState::new(vec!["abc".into()])),
+            Command::DeleteState(DeleteState::new(vec!["abc".into()])),
+        ]);
+        let txn_id = txn_pair.transaction().header_signature().to_owned();
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        assert_eq!(
+            ExecutionTaskCompletionNotification::Valid(context_id.clone(), txn_id),
+            result.unwrap()
+        );
+        assert_eq!(
+            context_manager
+                .get(&context_id, &["abc".to_owned()])
+                .unwrap(),
+            vec![],
+        );
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with a valid busy wait command.
+    #[test]
+    fn apply_static_adapter_busy_wait_sleep() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute a busy wait transaction.
+        let txn_pair =
+            make_command_transaction(&[Command::Sleep(Sleep::new(100, SleepType::BusyWait))]);
+        let txn_id = txn_pair.transaction().header_signature().to_owned();
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let time_before_execution = time::Instant::now();
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        let elapsed = time_before_execution.elapsed();
+        assert!(elapsed.ge(&time::Duration::from_millis(100)));
+
+        assert_eq!(
+            ExecutionTaskCompletionNotification::Valid(context_id.clone(), txn_id),
+            result.unwrap()
+        );
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with a valid wait command.
+    #[test]
+    fn apply_static_adapter_wait_sleep() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute a sleep transaction.
+        let txn_pair =
+            make_command_transaction(&[Command::Sleep(Sleep::new(100, SleepType::Wait))]);
+        let txn_id = txn_pair.transaction().header_signature().to_owned();
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let time_before_execution = time::Instant::now();
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        let elapsed = time_before_execution.elapsed();
+        assert!(elapsed.ge(&time::Duration::from_millis(100)));
+
+        assert_eq!(
+            ExecutionTaskCompletionNotification::Valid(context_id.clone(), txn_id),
+            result.unwrap()
+        );
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with a list of commands that will return early with an internal
+    /// error.
+    #[test]
+    fn apply_static_adapter_early_internal_error() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute a Set transaction, followed by an Internal error. This will cause
+        // the rest of the commands to be short-circuited.
+        let txn_pair = make_command_transaction(&[
+            Command::SetState(SetState::new(create_bytes_entry(vec![(
+                "abc".into(),
+                b"abc".to_vec(),
+            )]))),
+            Command::ReturnInternalError(ReturnInternalError::new(
+                "Return internal error between transactions".into(),
+            )),
+            Command::SetState(SetState::new(create_bytes_entry(vec![(
+                "def".into(),
+                b"def".to_vec(),
+            )]))),
+        ]);
+
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        assert!(result.is_err());
+        assert_eq!(
+            vec![("abc".to_owned(), b"abc".to_vec())],
+            context_manager
+                .get(&context_id, &["abc".to_owned()])
+                .unwrap(),
+        );
+        assert_eq!(
+            context_manager
+                .get(&context_id, &["def".to_owned()])
+                .unwrap(),
+            vec![],
+        );
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with several commands to add Events.
+    #[test]
+    fn apply_static_adapter_add_events() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute an Add Event transaction.
+        let txn_pair = make_command_transaction(&[
+            Command::AddEvent(AddEvent::new(
+                "First event".to_string(),
+                create_bytes_entry(vec![
+                    ("key1".to_string(), "value1".as_bytes().to_vec()),
+                    ("key2".to_string(), "value2".as_bytes().to_vec()),
+                ]),
+                b"abc".to_vec(),
+            )),
+            Command::AddEvent(AddEvent::new(
+                "Second event".to_string(),
+                create_bytes_entry(vec![
+                    ("key1".to_string(), "value1".as_bytes().to_vec()),
+                    ("key2".to_string(), "value2".as_bytes().to_vec()),
+                ]),
+                b"def".to_vec(),
+            )),
+        ]);
+        let txn_id = txn_pair.transaction().header_signature().to_owned();
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        assert_eq!(
+            ExecutionTaskCompletionNotification::Valid(context_id.clone(), txn_id.clone()),
+            result.unwrap()
+        );
+
+        let txn_receipt = context_manager
+            .get_transaction_receipt(&context_id, &txn_id)
+            .unwrap();
+        let events = txn_receipt.events;
+        let first_event = events.first().unwrap();
+        assert_eq!(first_event.event_type, "First event".to_string());
+        assert_eq!(
+            first_event.attributes,
+            vec![
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string())
+            ]
+        );
+        assert_eq!(first_event.data, b"abc".to_vec());
+
+        let second_event = events.last().unwrap();
+        assert_eq!(second_event.event_type, "Second event".to_string());
+        assert_eq!(
+            second_event.attributes,
+            vec![
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string())
+            ]
+        );
+        assert_eq!(second_event.data, b"def".to_vec());
+
+        assert!(Box::new(static_adapter).stop().is_ok());
+    }
+
+    /// Apply the static adapter with several commands to add Transaction Receipt data.
+    #[test]
+    fn apply_static_adapter_add_receipt_data() {
+        let registry = MockRegistry::default();
+
+        let state = HashMapState::new();
+        let state_id = HashMapState::state_id(&HashMap::new());
+
+        let mut context_manager: ContextManager = ContextManager::new(Box::new(state));
+
+        let handler = CommandTransactionHandler::new();
+
+        let mut static_adapter =
+            StaticExecutionAdapter::new_adapter(vec![Box::new(handler)], context_manager.clone())
+                .expect("Could not create adapter");
+
+        assert!(static_adapter.start(Box::new(registry.clone())).is_ok());
+
+        // Create and execute an Add Receipt Data transaction.
+        let txn_pair = make_command_transaction(&[
+            Command::AddReceiptData(AddReceiptData::new(b"abc".to_vec())),
+            Command::AddReceiptData(AddReceiptData::new(b"def".to_vec())),
+        ]);
+
+        let txn_id = txn_pair.transaction().header_signature().to_owned();
+        let context_id = context_manager.create_context(&[], &state_id);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        assert!(static_adapter
+            .execute(
+                txn_pair,
+                context_id.clone(),
+                Box::new(move |res| {
+                    send.send(res).expect("Unable to send result");
+                }),
+            )
+            .is_ok());
+        let result = recv.recv().unwrap();
+
+        assert_eq!(
+            ExecutionTaskCompletionNotification::Valid(context_id.clone(), txn_id.clone()),
+            result.unwrap()
+        );
+
+        let txn_receipt = context_manager
+            .get_transaction_receipt(&context_id, &txn_id)
+            .unwrap();
+        let receipt_data = txn_receipt.data;
+        assert_eq!(receipt_data.first().unwrap(), &b"abc".to_vec());
+        assert_eq!(receipt_data.last().unwrap(), &b"def".to_vec());
 
         assert!(Box::new(static_adapter).stop().is_ok());
     }

--- a/libtransact/src/protocol/command.rs
+++ b/libtransact/src/protocol/command.rs
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2019 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+#[derive(Debug)]
+pub struct CommandPayload {
+    commands: Vec<Command>,
+}
+
+impl CommandPayload {
+    pub fn new(commands: Vec<Command>) -> Self {
+        CommandPayload { commands }
+    }
+
+    pub fn commands(&self) -> &[Command] {
+        &self.commands
+    }
+}
+
+/// A command to be executed
+#[derive(Debug, Clone)]
+pub enum Command {
+    SetState(SetState),
+    DeleteState(DeleteState),
+    GetState(GetState),
+    AddEvent(AddEvent),
+    AddReceiptData(AddReceiptData),
+    Sleep(Sleep),
+    ReturnInvalid(ReturnInvalid),
+    ReturnInternalError(ReturnInternalError),
+}
+
+/// Native implementation for BytesEntry
+#[derive(Debug, Clone)]
+pub struct BytesEntry {
+    key: String,
+    value: Vec<u8>,
+}
+
+impl BytesEntry {
+    pub fn new(key: String, value: Vec<u8>) -> Self {
+        BytesEntry { key, value }
+    }
+
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &[u8] {
+        &self.value
+    }
+}
+
+/// Native implementation for SetState
+#[derive(Debug, Clone)]
+pub struct SetState {
+    state_writes: Vec<BytesEntry>,
+}
+
+impl SetState {
+    pub fn new(state_writes: Vec<BytesEntry>) -> Self {
+        SetState { state_writes }
+    }
+
+    pub fn state_writes(&self) -> &[BytesEntry] {
+        &self.state_writes
+    }
+}
+
+/// Native implementation for DeleteState
+#[derive(Debug, Clone)]
+pub struct DeleteState {
+    state_keys: Vec<String>,
+}
+
+impl DeleteState {
+    pub fn new(state_keys: Vec<String>) -> Self {
+        DeleteState { state_keys }
+    }
+
+    pub fn state_keys(&self) -> &[String] {
+        &self.state_keys
+    }
+}
+
+/// Native implementation for GetState
+#[derive(Debug, Clone)]
+pub struct GetState {
+    state_keys: Vec<String>,
+}
+
+impl GetState {
+    pub fn new(state_keys: Vec<String>) -> Self {
+        GetState { state_keys }
+    }
+
+    pub fn state_keys(&self) -> &[String] {
+        &self.state_keys
+    }
+}
+
+/// Native implementation for AddEvent
+#[derive(Debug, Clone)]
+pub struct AddEvent {
+    event_type: String,
+    attributes: Vec<BytesEntry>,
+    data: Vec<u8>,
+}
+
+impl AddEvent {
+    pub fn new(event_type: String, attributes: Vec<BytesEntry>, data: Vec<u8>) -> Self {
+        AddEvent {
+            event_type,
+            attributes,
+            data,
+        }
+    }
+
+    pub fn event_type(&self) -> &str {
+        &self.event_type
+    }
+
+    pub fn attributes(&self) -> &[BytesEntry] {
+        &self.attributes
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+/// Native implementation for AddReceiptData
+#[derive(Debug, Clone)]
+pub struct AddReceiptData {
+    receipt_data: Vec<u8>,
+}
+
+impl AddReceiptData {
+    pub fn new(receipt_data: Vec<u8>) -> Self {
+        AddReceiptData { receipt_data }
+    }
+
+    pub fn receipt_data(&self) -> &[u8] {
+        &self.receipt_data
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SleepType {
+    Wait,
+    BusyWait,
+}
+
+/// Native implementation for Sleep
+#[derive(Debug, Clone)]
+pub struct Sleep {
+    duration_millis: u32,
+    sleep_type: SleepType,
+}
+
+impl Sleep {
+    pub fn new(duration_millis: u32, sleep_type: SleepType) -> Self {
+        Sleep {
+            duration_millis,
+            sleep_type,
+        }
+    }
+
+    pub fn duration_millis(&self) -> &u32 {
+        &self.duration_millis
+    }
+
+    pub fn sleep_type(&self) -> &SleepType {
+        &self.sleep_type
+    }
+}
+
+/// Native implementation for ReturnInvalid
+#[derive(Debug, Clone)]
+pub struct ReturnInvalid {
+    error_message: String,
+}
+
+impl ReturnInvalid {
+    pub fn new(error_message: String) -> Self {
+        ReturnInvalid { error_message }
+    }
+
+    pub fn error_message(&self) -> &str {
+        &self.error_message
+    }
+}
+
+/// Native implementation for ReturnInternalError
+#[derive(Debug, Clone)]
+pub struct ReturnInternalError {
+    error_message: String,
+}
+
+impl ReturnInternalError {
+    pub fn new(error_message: String) -> Self {
+        ReturnInternalError { error_message }
+    }
+
+    pub fn error_message(&self) -> &str {
+        &self.error_message
+    }
+}

--- a/libtransact/src/protocol/command.rs
+++ b/libtransact/src/protocol/command.rs
@@ -15,6 +15,14 @@
  * -----------------------------------------------------------------------------
  */
 
+use protobuf::Message;
+use protobuf::RepeatedField;
+
+use crate::protos;
+use crate::protos::{
+    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+
 #[derive(Debug)]
 pub struct CommandPayload {
     commands: Vec<Command>,
@@ -30,6 +38,62 @@ impl CommandPayload {
     }
 }
 
+impl FromProto<protos::command::CommandPayload> for CommandPayload {
+    fn from_proto(payload: protos::command::CommandPayload) -> Result<Self, ProtoConversionError> {
+        Ok(CommandPayload {
+            commands: payload
+                .get_commands()
+                .to_vec()
+                .into_iter()
+                .map(Command::from_proto)
+                .collect::<Result<Vec<Command>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<CommandPayload> for protos::command::CommandPayload {
+    fn from_native(payload: CommandPayload) -> Result<Self, ProtoConversionError> {
+        let mut proto_payload = protos::command::CommandPayload::new();
+        proto_payload.set_commands(RepeatedField::from_vec(
+            payload
+                .commands()
+                .to_vec()
+                .into_iter()
+                .map(Command::into_proto)
+                .collect::<Result<Vec<protos::command::Command>, ProtoConversionError>>()?,
+        ));
+
+        Ok(proto_payload)
+    }
+}
+
+impl FromBytes<CommandPayload> for CommandPayload {
+    fn from_bytes(bytes: &[u8]) -> Result<CommandPayload, ProtoConversionError> {
+        let proto: protos::command::CommandPayload =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get CommandPayload from byte".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for CommandPayload {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from CommandPayload".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::CommandPayload> for CommandPayload {}
+impl IntoNative<CommandPayload> for protos::command::CommandPayload {}
+
 /// A command to be executed
 #[derive(Debug, Clone)]
 pub enum Command {
@@ -42,6 +106,106 @@ pub enum Command {
     ReturnInvalid(ReturnInvalid),
     ReturnInternalError(ReturnInternalError),
 }
+
+impl FromProto<protos::command::Command> for Command {
+    fn from_proto(command: protos::command::Command) -> Result<Self, ProtoConversionError> {
+        match command.get_command_type() {
+            protos::command::Command_CommandType::SET_STATE => Ok(Command::SetState(
+                SetState::from_proto(command.get_set_state().clone())?,
+            )),
+            protos::command::Command_CommandType::GET_STATE => Ok(Command::GetState(
+                GetState::from_proto(command.get_get_state().clone())?,
+            )),
+            protos::command::Command_CommandType::DELETE_STATE => Ok(Command::DeleteState(
+                DeleteState::from_proto(command.get_delete_state().clone())?,
+            )),
+            protos::command::Command_CommandType::ADD_EVENT => Ok(Command::AddEvent(
+                AddEvent::from_proto(command.get_add_event().clone())?,
+            )),
+            protos::command::Command_CommandType::ADD_RECEIPT_DATA => Ok(Command::AddReceiptData(
+                AddReceiptData::from_proto(command.get_add_receipt_data().clone())?,
+            )),
+            protos::command::Command_CommandType::SLEEP => Ok(Command::Sleep(Sleep::from_proto(
+                command.get_sleep().clone(),
+            )?)),
+            protos::command::Command_CommandType::RETURN_INVALID => Ok(Command::ReturnInvalid(
+                ReturnInvalid::from_proto(command.get_return_invalid().clone())?,
+            )),
+            protos::command::Command_CommandType::RETURN_INTERNAL_ERROR => {
+                Ok(Command::ReturnInternalError(
+                    ReturnInternalError::from_proto(command.get_return_internal_error().clone())?,
+                ))
+            }
+            _ => Err(ProtoConversionError::InvalidTypeError(
+                "Cannot convert Command_CommandType with type unset.".to_string(),
+            )),
+        }
+    }
+}
+
+impl FromNative<Command> for protos::command::Command {
+    fn from_native(command: Command) -> Result<Self, ProtoConversionError> {
+        let mut proto_command = protos::command::Command::new();
+
+        match command {
+            Command::SetState(payload) => {
+                proto_command.set_command_type(protos::command::Command_CommandType::SET_STATE);
+                proto_command.set_set_state(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::GetState(payload) => {
+                proto_command.set_command_type(protos::command::Command_CommandType::GET_STATE);
+                proto_command.set_get_state(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::DeleteState(payload) => {
+                proto_command.set_command_type(protos::command::Command_CommandType::DELETE_STATE);
+                proto_command.set_delete_state(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::AddEvent(payload) => {
+                proto_command.set_command_type(protos::command::Command_CommandType::ADD_EVENT);
+                proto_command.set_add_event(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::AddReceiptData(payload) => {
+                proto_command
+                    .set_command_type(protos::command::Command_CommandType::ADD_RECEIPT_DATA);
+                proto_command.set_add_receipt_data(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::Sleep(payload) => {
+                proto_command.set_command_type(protos::command::Command_CommandType::SLEEP);
+                proto_command.set_sleep(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::ReturnInvalid(payload) => {
+                proto_command
+                    .set_command_type(protos::command::Command_CommandType::RETURN_INVALID);
+                proto_command.set_return_invalid(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+            Command::ReturnInternalError(payload) => {
+                proto_command
+                    .set_command_type(protos::command::Command_CommandType::RETURN_INTERNAL_ERROR);
+                proto_command.set_return_internal_error(payload.clone().into_proto()?);
+                Ok(proto_command)
+            }
+        }
+    }
+}
+
+impl FromBytes<Command> for Command {
+    fn from_bytes(bytes: &[u8]) -> Result<Command, ProtoConversionError> {
+        let proto: protos::command::Command = protobuf::parse_from_bytes(bytes).map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get Command from bytes".to_string())
+        })?;
+        proto.into_native()
+    }
+}
+
+impl IntoProto<protos::command::Command> for Command {}
+impl IntoNative<Command> for protos::command::Command {}
 
 /// Native implementation for BytesEntry
 #[derive(Debug, Clone)]
@@ -64,6 +228,63 @@ impl BytesEntry {
     }
 }
 
+impl FromProto<protos::command::BytesEntry> for BytesEntry {
+    fn from_proto(bytes_entry: protos::command::BytesEntry) -> Result<Self, ProtoConversionError> {
+        Ok(BytesEntry {
+            key: bytes_entry.get_key().to_string(),
+            value: bytes_entry.get_value().to_vec(),
+        })
+    }
+}
+
+impl IntoBytes for Command {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get bytes from Command".to_string())
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl FromNative<BytesEntry> for protos::command::BytesEntry {
+    fn from_native(bytes_entry: BytesEntry) -> Result<Self, ProtoConversionError> {
+        let mut proto_bytes_entry = protos::command::BytesEntry::new();
+
+        proto_bytes_entry.set_key(bytes_entry.key().to_string());
+        proto_bytes_entry.set_value(bytes_entry.value().to_vec());
+
+        Ok(proto_bytes_entry)
+    }
+}
+
+impl FromBytes<BytesEntry> for BytesEntry {
+    fn from_bytes(bytes: &[u8]) -> Result<BytesEntry, ProtoConversionError> {
+        let proto: protos::command::BytesEntry =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get BytesEntry from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for BytesEntry {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from BytesEntry".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::BytesEntry> for BytesEntry {}
+impl IntoNative<BytesEntry> for protos::command::BytesEntry {}
+
 /// Native implementation for SetState
 #[derive(Debug, Clone)]
 pub struct SetState {
@@ -79,6 +300,62 @@ impl SetState {
         &self.state_writes
     }
 }
+
+impl FromProto<protos::command::SetState> for SetState {
+    fn from_proto(set_state: protos::command::SetState) -> Result<Self, ProtoConversionError> {
+        Ok(SetState {
+            state_writes: set_state
+                .get_state_writes()
+                .to_vec()
+                .into_iter()
+                .map(BytesEntry::from_proto)
+                .collect::<Result<Vec<BytesEntry>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<SetState> for protos::command::SetState {
+    fn from_native(set_state: SetState) -> Result<Self, ProtoConversionError> {
+        let mut proto_set_state = protos::command::SetState::new();
+
+        proto_set_state.set_state_writes(RepeatedField::from_vec(
+            set_state
+                .state_writes()
+                .to_vec()
+                .into_iter()
+                .map(BytesEntry::into_proto)
+                .collect::<Result<Vec<protos::command::BytesEntry>, ProtoConversionError>>()?,
+        ));
+
+        Ok(proto_set_state)
+    }
+}
+
+impl FromBytes<SetState> for SetState {
+    fn from_bytes(bytes: &[u8]) -> Result<SetState, ProtoConversionError> {
+        let proto: protos::command::SetState = protobuf::parse_from_bytes(bytes).map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get SetState from bytes".to_string(),
+            )
+        })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for SetState {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from SetState".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::SetState> for SetState {}
+impl IntoNative<SetState> for protos::command::SetState {}
 
 /// Native implementation for DeleteState
 #[derive(Debug, Clone)]
@@ -96,6 +373,53 @@ impl DeleteState {
     }
 }
 
+impl FromProto<protos::command::DeleteState> for DeleteState {
+    fn from_proto(
+        delete_state: protos::command::DeleteState,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(DeleteState {
+            state_keys: delete_state.get_state_keys().to_vec(),
+        })
+    }
+}
+
+impl FromNative<DeleteState> for protos::command::DeleteState {
+    fn from_native(delete_state: DeleteState) -> Result<Self, ProtoConversionError> {
+        let mut proto_delete_state = protos::command::DeleteState::new();
+        proto_delete_state
+            .set_state_keys(RepeatedField::from_vec(delete_state.state_keys().to_vec()));
+
+        Ok(proto_delete_state)
+    }
+}
+
+impl FromBytes<DeleteState> for DeleteState {
+    fn from_bytes(bytes: &[u8]) -> Result<DeleteState, ProtoConversionError> {
+        let proto: protos::command::DeleteState =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get DeleteState from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for DeleteState {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from DeleteState".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::DeleteState> for DeleteState {}
+impl IntoNative<DeleteState> for protos::command::DeleteState {}
+
 /// Native implementation for GetState
 #[derive(Debug, Clone)]
 pub struct GetState {
@@ -111,6 +435,49 @@ impl GetState {
         &self.state_keys
     }
 }
+
+impl FromProto<protos::command::GetState> for GetState {
+    fn from_proto(get_state: protos::command::GetState) -> Result<Self, ProtoConversionError> {
+        Ok(GetState {
+            state_keys: get_state.get_state_keys().to_vec(),
+        })
+    }
+}
+
+impl FromNative<GetState> for protos::command::GetState {
+    fn from_native(get_state: GetState) -> Result<Self, ProtoConversionError> {
+        let mut proto_get_state = protos::command::GetState::new();
+        proto_get_state.set_state_keys(RepeatedField::from_vec(get_state.state_keys().to_vec()));
+
+        Ok(proto_get_state)
+    }
+}
+
+impl FromBytes<GetState> for GetState {
+    fn from_bytes(bytes: &[u8]) -> Result<GetState, ProtoConversionError> {
+        let proto: protos::command::GetState = protobuf::parse_from_bytes(bytes).map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get GetState from bytes".to_string(),
+            )
+        })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for GetState {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from GetState".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::GetState> for GetState {}
+impl IntoNative<GetState> for protos::command::GetState {}
 
 /// Native implementation for AddEvent
 #[derive(Debug, Clone)]
@@ -142,6 +509,66 @@ impl AddEvent {
     }
 }
 
+impl FromProto<protos::command::AddEvent> for AddEvent {
+    fn from_proto(add_event: protos::command::AddEvent) -> Result<Self, ProtoConversionError> {
+        Ok(AddEvent {
+            event_type: add_event.get_event_type().to_string(),
+            attributes: add_event
+                .get_attributes()
+                .to_vec()
+                .into_iter()
+                .map(BytesEntry::from_proto)
+                .collect::<Result<Vec<BytesEntry>, ProtoConversionError>>()?,
+            data: add_event.get_data().to_vec(),
+        })
+    }
+}
+
+impl FromNative<AddEvent> for protos::command::AddEvent {
+    fn from_native(add_event: AddEvent) -> Result<Self, ProtoConversionError> {
+        let mut proto_add_event = protos::command::AddEvent::new();
+
+        proto_add_event.set_event_type(add_event.event_type().to_string());
+        proto_add_event.set_attributes(RepeatedField::from_vec(
+            add_event
+                .attributes()
+                .to_vec()
+                .into_iter()
+                .map(BytesEntry::into_proto)
+                .collect::<Result<Vec<protos::command::BytesEntry>, ProtoConversionError>>()?,
+        ));
+        proto_add_event.set_data(add_event.data().to_vec());
+
+        Ok(proto_add_event)
+    }
+}
+
+impl FromBytes<AddEvent> for AddEvent {
+    fn from_bytes(bytes: &[u8]) -> Result<AddEvent, ProtoConversionError> {
+        let proto: protos::command::AddEvent = protobuf::parse_from_bytes(bytes).map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get AddEvent from bytes".to_string(),
+            )
+        })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for AddEvent {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from AddEvent".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::AddEvent> for AddEvent {}
+impl IntoNative<AddEvent> for protos::command::AddEvent {}
+
 /// Native implementation for AddReceiptData
 #[derive(Debug, Clone)]
 pub struct AddReceiptData {
@@ -158,11 +585,79 @@ impl AddReceiptData {
     }
 }
 
+impl FromProto<protos::command::AddReceiptData> for AddReceiptData {
+    fn from_proto(
+        add_receipt_data: protos::command::AddReceiptData,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(AddReceiptData {
+            receipt_data: add_receipt_data.get_receipt_data().to_vec(),
+        })
+    }
+}
+
+impl FromNative<AddReceiptData> for protos::command::AddReceiptData {
+    fn from_native(add_receipt_data: AddReceiptData) -> Result<Self, ProtoConversionError> {
+        let mut proto_add_receipt_data = protos::command::AddReceiptData::new();
+        proto_add_receipt_data.set_receipt_data(add_receipt_data.receipt_data().to_vec());
+        Ok(proto_add_receipt_data)
+    }
+}
+
+impl FromBytes<AddReceiptData> for AddReceiptData {
+    fn from_bytes(bytes: &[u8]) -> Result<AddReceiptData, ProtoConversionError> {
+        let proto: protos::command::AddReceiptData =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get AddReceiptData from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for AddReceiptData {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from AddReceiptData".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::AddReceiptData> for AddReceiptData {}
+impl IntoNative<AddReceiptData> for protos::command::AddReceiptData {}
+
 #[derive(Debug, Clone)]
 pub enum SleepType {
     Wait,
     BusyWait,
 }
+
+impl FromProto<protos::command::Sleep_SleepType> for SleepType {
+    fn from_proto(
+        sleep_type: protos::command::Sleep_SleepType,
+    ) -> Result<Self, ProtoConversionError> {
+        match sleep_type {
+            protos::command::Sleep_SleepType::WAIT => Ok(SleepType::Wait),
+            protos::command::Sleep_SleepType::BUSY_WAIT => Ok(SleepType::BusyWait),
+        }
+    }
+}
+
+impl FromNative<SleepType> for protos::command::Sleep_SleepType {
+    fn from_native(sleep_type: SleepType) -> Result<Self, ProtoConversionError> {
+        match sleep_type {
+            SleepType::Wait => Ok(protos::command::Sleep_SleepType::WAIT),
+            SleepType::BusyWait => Ok(protos::command::Sleep_SleepType::BUSY_WAIT),
+        }
+    }
+}
+
+impl IntoProto<protos::command::Sleep_SleepType> for SleepType {}
+impl IntoNative<SleepType> for protos::command::Sleep_SleepType {}
 
 /// Native implementation for Sleep
 #[derive(Debug, Clone)]
@@ -188,6 +683,46 @@ impl Sleep {
     }
 }
 
+impl FromProto<protos::command::Sleep> for Sleep {
+    fn from_proto(sleep: protos::command::Sleep) -> Result<Self, ProtoConversionError> {
+        Ok(Sleep {
+            duration_millis: sleep.get_duration_millis(),
+            sleep_type: SleepType::from_proto(sleep.get_sleep_type())?,
+        })
+    }
+}
+
+impl FromNative<Sleep> for protos::command::Sleep {
+    fn from_native(sleep: Sleep) -> Result<Self, ProtoConversionError> {
+        let mut proto_sleep = protos::command::Sleep::new();
+        proto_sleep.set_duration_millis(sleep.duration_millis().clone());
+        proto_sleep.set_sleep_type(sleep.sleep_type().clone().into_proto()?);
+        Ok(proto_sleep)
+    }
+}
+
+impl FromBytes<Sleep> for Sleep {
+    fn from_bytes(bytes: &[u8]) -> Result<Sleep, ProtoConversionError> {
+        let proto: protos::command::Sleep = protobuf::parse_from_bytes(bytes).map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get bytes from Sleep".to_string())
+        })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for Sleep {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError("Unable to get bytes from Sleep".to_string())
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::Sleep> for Sleep {}
+impl IntoNative<Sleep> for protos::command::Sleep {}
+
 /// Native implementation for ReturnInvalid
 #[derive(Debug, Clone)]
 pub struct ReturnInvalid {
@@ -204,6 +739,51 @@ impl ReturnInvalid {
     }
 }
 
+impl FromProto<protos::command::ReturnInvalid> for ReturnInvalid {
+    fn from_proto(
+        return_invalid: protos::command::ReturnInvalid,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(ReturnInvalid {
+            error_message: return_invalid.get_error_message().to_string(),
+        })
+    }
+}
+
+impl FromNative<ReturnInvalid> for protos::command::ReturnInvalid {
+    fn from_native(return_invalid: ReturnInvalid) -> Result<Self, ProtoConversionError> {
+        let mut proto_return_invalid = protos::command::ReturnInvalid::new();
+        proto_return_invalid.set_error_message(return_invalid.error_message().to_string());
+        Ok(proto_return_invalid)
+    }
+}
+
+impl FromBytes<ReturnInvalid> for ReturnInvalid {
+    fn from_bytes(bytes: &[u8]) -> Result<ReturnInvalid, ProtoConversionError> {
+        let proto: protos::command::ReturnInvalid =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get ReturnInvalid from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for ReturnInvalid {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from ReturnInvalid".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::ReturnInvalid> for ReturnInvalid {}
+impl IntoNative<ReturnInvalid> for protos::command::ReturnInvalid {}
+
 /// Native implementation for ReturnInternalError
 #[derive(Debug, Clone)]
 pub struct ReturnInternalError {
@@ -219,3 +799,51 @@ impl ReturnInternalError {
         &self.error_message
     }
 }
+
+impl FromProto<protos::command::ReturnInternalError> for ReturnInternalError {
+    fn from_proto(
+        return_internal_error: protos::command::ReturnInternalError,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(ReturnInternalError {
+            error_message: return_internal_error.get_error_message().to_string(),
+        })
+    }
+}
+
+impl FromNative<ReturnInternalError> for protos::command::ReturnInternalError {
+    fn from_native(
+        return_internal_error: ReturnInternalError,
+    ) -> Result<Self, ProtoConversionError> {
+        let mut proto_return_internal_error = protos::command::ReturnInternalError::new();
+        proto_return_internal_error
+            .set_error_message(return_internal_error.error_message().to_string());
+        Ok(proto_return_internal_error)
+    }
+}
+
+impl FromBytes<ReturnInternalError> for ReturnInternalError {
+    fn from_bytes(bytes: &[u8]) -> Result<ReturnInternalError, ProtoConversionError> {
+        let proto: protos::command::ReturnInternalError = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get ReturnInvalid from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for ReturnInternalError {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from ReturnInternalError".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::command::ReturnInternalError> for ReturnInternalError {}
+impl IntoNative<ReturnInternalError> for protos::command::ReturnInternalError {}

--- a/libtransact/src/protocol/mod.rs
+++ b/libtransact/src/protocol/mod.rs
@@ -21,5 +21,6 @@
 //! scheduled and executed.  The resuls of execution are stored in transaction receipts.
 
 pub mod batch;
+pub mod command;
 pub mod receipt;
 pub mod transaction;


### PR DESCRIPTION
Implements the Command transaction family through the workload module. Adds Commands defined by the Command Family RFC that were not previously implemented. Also adds tests for these commands via the static execution adapter. 