### PR TITLE
Native/proto conversion implementations

### DIFF
--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -82,10 +82,11 @@ impl FromNative<BatchHeader> for protos::batch::BatchHeader {
 impl FromBytes<BatchHeader> for BatchHeader {
     fn from_bytes(bytes: &[u8]) -> Result<BatchHeader, ProtoConversionError> {
         let proto: protos::batch::BatchHeader =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
-                ProtoConversionError::SerializationError(
-                    "Unable to get BatchHeader from bytes".to_string(),
-                )
+            protobuf::parse_from_bytes(bytes).map_err(|err| {
+                ProtoConversionError::SerializationError(format!(
+                    "unable to get BatchHeader from bytes: {}",
+                    err
+                ))
             })?;
         proto.into_native()
     }
@@ -94,10 +95,11 @@ impl FromBytes<BatchHeader> for BatchHeader {
 impl IntoBytes for BatchHeader {
     fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
         let proto = self.into_proto()?;
-        let bytes = proto.write_to_bytes().map_err(|_| {
-            ProtoConversionError::SerializationError(
-                "Unable to get bytes from BatchHeader".to_string(),
-            )
+        let bytes = proto.write_to_bytes().map_err(|err| {
+            ProtoConversionError::SerializationError(format!(
+                "unable to get bytes from BatchHeader: {}",
+                err
+            ))
         })?;
         Ok(bytes)
     }
@@ -176,8 +178,11 @@ impl FromNative<Batch> for protos::batch::Batch {
 
 impl FromBytes<Batch> for Batch {
     fn from_bytes(bytes: &[u8]) -> Result<Batch, ProtoConversionError> {
-        let proto: protos::batch::Batch = protobuf::parse_from_bytes(bytes).map_err(|_| {
-            ProtoConversionError::SerializationError("Unable to get Batch from bytes".to_string())
+        let proto: protos::batch::Batch = protobuf::parse_from_bytes(bytes).map_err(|err| {
+            ProtoConversionError::SerializationError(format!(
+                "unable to get Batch from bytes: {}",
+                err
+            ))
         })?;
         proto.into_native()
     }
@@ -186,8 +191,11 @@ impl FromBytes<Batch> for Batch {
 impl IntoBytes for Batch {
     fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
         let proto = self.into_proto()?;
-        let bytes = proto.write_to_bytes().map_err(|_| {
-            ProtoConversionError::SerializationError("Unable to get bytes from Batch".to_string())
+        let bytes = proto.write_to_bytes().map_err(|err| {
+            ProtoConversionError::SerializationError(format!(
+                "unable to get bytes from Batch: {}",
+                err
+            ))
         })?;
         Ok(bytes)
     }

--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -216,6 +216,37 @@ impl BatchPair {
     }
 }
 
+impl FromProto<protos::batch::Batch> for BatchPair {
+    fn from_proto(batch: protos::batch::Batch) -> Result<Self, ProtoConversionError> {
+        Batch::from_proto(batch)?
+            .into_pair()
+            .map_err(|err| ProtoConversionError::DeserializationError(err.to_string()))
+    }
+}
+
+impl FromNative<BatchPair> for protos::batch::Batch {
+    fn from_native(batch_pair: BatchPair) -> Result<Self, ProtoConversionError> {
+        batch_pair.take().0.into_proto()
+    }
+}
+
+impl FromBytes<BatchPair> for BatchPair {
+    fn from_bytes(bytes: &[u8]) -> Result<BatchPair, ProtoConversionError> {
+        Batch::from_bytes(bytes)?
+            .into_pair()
+            .map_err(|err| ProtoConversionError::DeserializationError(err.to_string()))
+    }
+}
+
+impl IntoBytes for BatchPair {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        self.take().0.into_bytes()
+    }
+}
+
+impl IntoProto<protos::batch::Batch> for BatchPair {}
+impl IntoNative<BatchPair> for protos::batch::Batch {}
+
 #[derive(Debug)]
 pub enum BatchBuildError {
     MissingField(String),

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -160,10 +160,11 @@ impl FromNative<TransactionHeader> for protos::transaction::TransactionHeader {
 impl FromBytes<TransactionHeader> for TransactionHeader {
     fn from_bytes(bytes: &[u8]) -> Result<TransactionHeader, ProtoConversionError> {
         let proto: protos::transaction::TransactionHeader = protobuf::parse_from_bytes(bytes)
-            .map_err(|_| {
-                ProtoConversionError::SerializationError(
-                    "Unable to get TransactionHeader from bytes".to_string(),
-                )
+            .map_err(|err| {
+                ProtoConversionError::SerializationError(format!(
+                    "unable to get TransactionHeader from bytes: {}",
+                    err
+                ))
             })?;
         proto.into_native()
     }
@@ -172,10 +173,11 @@ impl FromBytes<TransactionHeader> for TransactionHeader {
 impl IntoBytes for TransactionHeader {
     fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
         let proto = self.into_proto()?;
-        let bytes = proto.write_to_bytes().map_err(|_| {
-            ProtoConversionError::SerializationError(
-                "Unable to get bytes from TransactionHeader".to_string(),
-            )
+        let bytes = proto.write_to_bytes().map_err(|err| {
+            ProtoConversionError::SerializationError(format!(
+                "unable to get bytes from TransactionHeader: {}",
+                err
+            ))
         })?;
         Ok(bytes)
     }
@@ -247,10 +249,11 @@ impl FromNative<Transaction> for protos::transaction::Transaction {
 impl FromBytes<Transaction> for Transaction {
     fn from_bytes(bytes: &[u8]) -> Result<Transaction, ProtoConversionError> {
         let proto: protos::transaction::Transaction =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
-                ProtoConversionError::SerializationError(
-                    "Unable to get Transaction from bytes".to_string(),
-                )
+            protobuf::parse_from_bytes(bytes).map_err(|err| {
+                ProtoConversionError::SerializationError(format!(
+                    "unable to get Transaction from bytes: {}",
+                    err
+                ))
             })?;
         proto.into_native()
     }
@@ -259,10 +262,11 @@ impl FromBytes<Transaction> for Transaction {
 impl IntoBytes for Transaction {
     fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
         let proto = self.into_proto()?;
-        let bytes = proto.write_to_bytes().map_err(|_| {
-            ProtoConversionError::SerializationError(
-                "Unable to get bytes from Transaction".to_string(),
-            )
+        let bytes = proto.write_to_bytes().map_err(|err| {
+            ProtoConversionError::SerializationError(format!(
+                "unable to get bytes from Transaction: {}",
+                err
+            ))
         })?;
         Ok(bytes)
     }

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -222,15 +222,54 @@ impl Transaction {
     }
 }
 
-impl From<protos::transaction::Transaction> for Transaction {
-    fn from(transaction: protos::transaction::Transaction) -> Self {
-        Transaction {
-            header: transaction.get_header().to_vec(),
-            header_signature: transaction.get_header_signature().to_string(),
-            payload: transaction.get_payload().to_vec(),
-        }
+impl FromProto<protos::transaction::Transaction> for Transaction {
+    fn from_proto(
+        transaction: protos::transaction::Transaction,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(Transaction {
+            header: transaction.header,
+            header_signature: transaction.header_signature,
+            payload: transaction.payload,
+        })
     }
 }
+
+impl FromNative<Transaction> for protos::transaction::Transaction {
+    fn from_native(transaction: Transaction) -> Result<Self, ProtoConversionError> {
+        let mut proto_transaction = protos::transaction::Transaction::new();
+        proto_transaction.set_header(transaction.header);
+        proto_transaction.set_header_signature(transaction.header_signature);
+        proto_transaction.set_payload(transaction.payload);
+        Ok(proto_transaction)
+    }
+}
+
+impl FromBytes<Transaction> for Transaction {
+    fn from_bytes(bytes: &[u8]) -> Result<Transaction, ProtoConversionError> {
+        let proto: protos::transaction::Transaction =
+            protobuf::parse_from_bytes(bytes).map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get Transaction from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for Transaction {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from Transaction".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::transaction::Transaction> for Transaction {}
+impl IntoNative<Transaction> for protos::transaction::Transaction {}
 
 #[derive(Debug)]
 pub struct TransactionPair {
@@ -757,7 +796,9 @@ mod tests {
             protobuf::parse_from_bytes(&transaction_bytes).unwrap();
 
         // Convert to a Transaction
-        let transaction: Transaction = transaction_proto.into();
+        let transaction: Transaction = transaction_proto
+            .into_native()
+            .expect("failed to convert to native");
 
         assert_eq!(BYTES1.to_vec(), transaction.header());
         assert_eq!(SIGNATURE1, transaction.header_signature());

--- a/libtransact/src/protos.rs
+++ b/libtransact/src/protos.rs
@@ -21,6 +21,7 @@ use std::error::Error as StdError;
 
 #[derive(Debug)]
 pub enum ProtoConversionError {
+    DeserializationError(String),
     SerializationError(String),
     InvalidTypeError(String),
 }
@@ -28,6 +29,7 @@ pub enum ProtoConversionError {
 impl StdError for ProtoConversionError {
     fn description(&self) -> &str {
         match *self {
+            ProtoConversionError::DeserializationError(ref msg) => msg,
             ProtoConversionError::SerializationError(ref msg) => msg,
             ProtoConversionError::InvalidTypeError(ref msg) => msg,
         }
@@ -35,6 +37,7 @@ impl StdError for ProtoConversionError {
 
     fn cause(&self) -> Option<&StdError> {
         match *self {
+            ProtoConversionError::DeserializationError(_) => None,
             ProtoConversionError::SerializationError(_) => None,
             ProtoConversionError::InvalidTypeError(_) => None,
         }
@@ -44,6 +47,9 @@ impl StdError for ProtoConversionError {
 impl std::fmt::Display for ProtoConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
+            ProtoConversionError::DeserializationError(ref s) => {
+                write!(f, "DeserializationError: {}", s)
+            }
             ProtoConversionError::SerializationError(ref s) => {
                 write!(f, "SerializationError: {}", s)
             }

--- a/libtransact/src/protos.rs
+++ b/libtransact/src/protos.rs
@@ -48,12 +48,16 @@ impl std::fmt::Display for ProtoConversionError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             ProtoConversionError::DeserializationError(ref s) => {
-                write!(f, "DeserializationError: {}", s)
+                write!(f, "unable to deserialize during protobuf conversion: {}", s)
             }
             ProtoConversionError::SerializationError(ref s) => {
-                write!(f, "SerializationError: {}", s)
+                write!(f, "unable to serialize during protobuf conversion: {}", s)
             }
-            ProtoConversionError::InvalidTypeError(ref s) => write!(f, "InvalidTypeError: {}", s),
+            ProtoConversionError::InvalidTypeError(ref s) => write!(
+                f,
+                "invalid type encountered during protobuf conversion: {}",
+                s
+            ),
         }
     }
 }

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -31,6 +31,8 @@ pub mod multi;
 pub mod parallel;
 pub mod serial;
 
+use std::error::Error;
+
 use crate::context::ContextId;
 use crate::protocol::batch::BatchPair;
 use crate::protocol::receipt::TransactionReceipt;
@@ -123,6 +125,8 @@ pub enum SchedulerError {
     /// was not expecting; the contained `String` is the transaction ID.
     UnexpectedNotification(String),
 }
+
+impl Error for SchedulerError {}
 
 impl std::fmt::Display for SchedulerError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {


### PR DESCRIPTION
Implements the various native/protobuf conversion traits for the Transaction, Batch, and BatchPair structs. This makes it easier to deal with batches when using the library by cutting out conversion steps (e.g. can go from bytes -> BatchPair with a single method call).