### PR TITLE
Fix Hex conversion in Sawtooth Compat

### DIFF
--- a/libtransact/src/execution/adapter/test_adapter.rs
+++ b/libtransact/src/execution/adapter/test_adapter.rs
@@ -228,7 +228,7 @@ mod tests {
     }
 
     fn make_transaction() -> TransactionPair {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         TransactionBuilder::new()
             .with_batcher_public_key(vec![])

--- a/libtransact/src/execution/executor/internal.rs
+++ b/libtransact/src/execution/executor/internal.rs
@@ -709,7 +709,7 @@ mod tests {
     }
 
     fn create_iterator() -> impl Iterator<Item = ExecutionTask> {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
         let context_id = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
         (0..NUMBER_OF_TRANSACTIONS)

--- a/libtransact/src/execution/executor/mod.rs
+++ b/libtransact/src/execution/executor/mod.rs
@@ -241,7 +241,7 @@ mod tests {
 
     impl MockTaskExecutionIterator {
         fn new() -> Self {
-            let signer = HashSigner::new();
+            let signer = HashSigner::default();
             let context_id = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
             let family_name = |i| {

--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -451,7 +451,7 @@ mod tests {
 
     #[test]
     fn batch_builder_chain() {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         let pair = BatchBuilder::new()
             .with_transactions(vec![
@@ -475,7 +475,7 @@ mod tests {
 
     #[test]
     fn batch_builder_separate() {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         let mut builder = BatchBuilder::new();
         builder = builder.with_transactions(vec![
@@ -620,7 +620,7 @@ mod benchmarks {
 
     #[bench]
     fn bench_batch_builder(b: &mut Bencher) {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
         let batch = BatchBuilder::new()
             .with_transactions(vec![
                 Transaction::new(

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn transaction_builder_chain() {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         let pair = TransactionBuilder::new()
             .with_batcher_public_key(hex::decode(KEY1).unwrap())
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn transaction_builder_seperate() {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         let mut builder = TransactionBuilder::new();
         builder = builder.with_batcher_public_key(hex::decode(KEY1).unwrap());
@@ -838,7 +838,7 @@ mod benchmarks {
 
     #[bench]
     fn bench_transaction_builder(b: &mut Bencher) {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
         let transaction = TransactionBuilder::new()
             .with_batcher_public_key(hex::decode(KEY1).unwrap())
             .with_dependencies(vec![hex::decode(KEY2).unwrap(), hex::decode(KEY3).unwrap()])

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -267,7 +267,7 @@ mod xo_compat_test {
         let test_executor = executor.clone();
 
         let panic_check = panic::catch_unwind(move || {
-            let signer = HashSigner::new();
+            let signer = HashSigner::new(vec![00u8, 01, 02]);
 
             let batch_pair = create_batch(&signer, "my_game", "my_game,create,");
 
@@ -332,7 +332,7 @@ mod xo_compat_test {
         let test_executor = executor.clone();
 
         let panic_check = panic::catch_unwind(move || {
-            let signer = HashSigner::new();
+            let signer = HashSigner::new(vec![00u8, 01, 02]);
 
             let create_batch_pair = create_batch(&signer, "my_game", "my_game,create,");
             let take_batch_pair = create_batch(&signer, "my_game", "my_game,take,1");

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -203,23 +203,14 @@ fn as_sawtooth_header(header: &TransactionHeader) -> SawtoothTxnHeader {
 
     sawtooth_header.set_family_name(header.family_name().to_owned());
     sawtooth_header.set_family_version(header.family_version().to_owned());
-    sawtooth_header.set_signer_public_key(to_hex(&header.signer_public_key()));
-    sawtooth_header.set_batcher_public_key(to_hex(&header.batcher_public_key()));
-    sawtooth_header.set_dependencies(header.dependencies().iter().map(to_hex).collect());
-    sawtooth_header.set_inputs(header.inputs().iter().map(to_hex).collect());
-    sawtooth_header.set_outputs(header.outputs().iter().map(to_hex).collect());
-    sawtooth_header.set_nonce(to_hex(&header.nonce()));
+    sawtooth_header.set_signer_public_key(hex::encode(&header.signer_public_key()));
+    sawtooth_header.set_batcher_public_key(hex::encode(&header.batcher_public_key()));
+    sawtooth_header.set_dependencies(header.dependencies().iter().map(hex::encode).collect());
+    sawtooth_header.set_inputs(header.inputs().iter().map(hex::encode).collect());
+    sawtooth_header.set_outputs(header.outputs().iter().map(hex::encode).collect());
+    sawtooth_header.set_nonce(hex::encode(&header.nonce()));
 
     sawtooth_header
-}
-
-fn to_hex<T: AsRef<[u8]>>(bytes: &T) -> String {
-    let bytes = bytes.as_ref();
-    let mut buf = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        write!(&mut buf, "{:0x}", b).unwrap(); // this can't fail
-    }
-    buf
 }
 
 fn to_context_error(err: ContextError) -> SawtoothContextError {

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -244,7 +244,7 @@ mod tests {
                     .with_nonce(vec![i])
                     .with_payload(vec![])
                     .with_payload_hash_method(HashMethod::SHA512)
-                    .build(&HashSigner::new())
+                    .build(&HashSigner::default())
                     .expect("Failed to build transaction")
             })
             .collect()
@@ -253,7 +253,7 @@ mod tests {
     pub fn mock_batch(transactions: Vec<Transaction>) -> BatchPair {
         BatchBuilder::new()
             .with_transactions(transactions)
-            .build_pair(&HashSigner::new())
+            .build_pair(&HashSigner::default())
             .expect("Failed to build batch pair")
     }
 

--- a/libtransact/src/signing/hash.rs
+++ b/libtransact/src/signing/hash.rs
@@ -27,19 +27,19 @@ use crate::signing::Error;
 use crate::signing::Signer;
 
 pub struct HashSigner {
-    dummy_public_key: Vec<u8>,
+    public_key: Vec<u8>,
 }
 
 impl HashSigner {
-    pub fn new() -> Self {
-        HashSigner::default()
+    pub fn new(public_key: Vec<u8>) -> Self {
+        Self { public_key }
     }
 }
 
 impl Default for HashSigner {
     fn default() -> Self {
         HashSigner {
-            dummy_public_key: String::from("hash_signer").into_bytes(),
+            public_key: String::from("hash_signer").into_bytes(),
         }
     }
 }
@@ -52,6 +52,6 @@ impl Signer for HashSigner {
     }
 
     fn public_key(&self) -> &[u8] {
-        &self.dummy_public_key
+        &self.public_key
     }
 }

--- a/libtransact/src/workload/command.rs
+++ b/libtransact/src/workload/command.rs
@@ -120,7 +120,7 @@ impl TransactionHandler for CommandTransactionHandler {
 }
 
 pub fn make_command_transaction(commands: &[Command]) -> TransactionPair {
-    let signer = HashSigner::new();
+    let signer = HashSigner::default();
     let command_payload = protocol::command::CommandPayload::new(commands.to_vec());
     TransactionBuilder::new()
         .with_batcher_public_key(vec![0u8, 0u8, 0u8, 0u8])

--- a/libtransact/src/workload/xo.rs
+++ b/libtransact/src/workload/xo.rs
@@ -27,7 +27,7 @@ pub struct XoTransactionWorkload {
 impl XoTransactionWorkload {
     pub fn new() -> Self {
         let rng = Hc128Rng::from_entropy();
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         XoTransactionWorkload {
             rng,
@@ -37,7 +37,7 @@ impl XoTransactionWorkload {
 
     pub fn new_with_seed(seed: u64) -> XoTransactionWorkload {
         let rng = Hc128Rng::seed_from_u64(seed);
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         XoTransactionWorkload {
             rng,
@@ -76,7 +76,7 @@ pub struct XoBatchWorkload {
 
 impl XoBatchWorkload {
     pub fn new() -> XoBatchWorkload {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         XoBatchWorkload {
             transaction_workload: XoTransactionWorkload::new(),
@@ -85,7 +85,7 @@ impl XoBatchWorkload {
     }
 
     pub fn new_with_seed(seed: u64) -> XoBatchWorkload {
-        let signer = HashSigner::new();
+        let signer = HashSigner::default();
 
         XoBatchWorkload {
             transaction_workload: XoTransactionWorkload::new_with_seed(seed),


### PR DESCRIPTION
Hex was not properly being converted when a transaction pair was converted to a Sawtooth `TpProcessRequest`.

Additionally, 

- Modifies `HashSigner`to take a public key, which was necessary to verify the fix. 