### PR TITLE
Add a CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+Contributions Guide
+===================
+
+We welcome contributions, eagerly. The contributions to Transact 
+follow a similar process to 
+[Sawtooth](https://sawtooth.hyperledger.org/docs/core/releases/latest/community/contributing.html).
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+  <img alt="Creative Commons License" 
+    style="border-width:0" 
+    src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
+</a>
+  <br />This work is licensed under a 
+    <a rel="license" 
+      href="http://creativecommons.org/licenses/by/4.0/">Creative 
+      Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Transact uses a similar process to Sawtooth for contributions.
Adding a CONTRIBUTING.md file will make it easier for new people
to contribute.

Signed-off-by: Christopher Ferris <chrisfer@us.ibm.com>