### PR TITLE
Implement KeyValueTransactionContext

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -46,6 +46,7 @@ experimental = [
     "contract-address-double-key-hash",
     "contract-address-key-hash",
     "contract-address-triple-key-hash",
+    "contract-context",
     "key-value-state",
     "redis-db",
 ]
@@ -57,4 +58,5 @@ contract-address = ["contract"]
 contract-address-key-hash = ["contract-address"]
 contract-address-double-key-hash = ["contract-address"]
 contract-address-triple-key-hash = ["contract-address"]
+contract-context = ["contract", "contract-address"]
 key-value-state = []

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -47,6 +47,7 @@ experimental = [
     "contract-address-key-hash",
     "contract-address-triple-key-hash",
     "contract-context",
+    "contract-context-key-value",
     "key-value-state",
     "redis-db",
 ]
@@ -59,4 +60,5 @@ contract-address-key-hash = ["contract-address"]
 contract-address-double-key-hash = ["contract-address"]
 contract-address-triple-key-hash = ["contract-address"]
 contract-context = ["contract", "contract-address"]
+contract-context-key-value = ["contract-context", "key-value-state"]
 key-value-state = []

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -46,6 +46,7 @@ experimental = [
     "contract-address-double-key-hash",
     "contract-address-key-hash",
     "contract-address-triple-key-hash",
+    "key-value-state",
     "redis-db",
 ]
 sawtooth-compat = ["sawtooth-sdk"]
@@ -56,3 +57,4 @@ contract-address = ["contract"]
 contract-address-key-hash = ["contract-address"]
 contract-address-double-key-hash = ["contract-address"]
 contract-address-triple-key-hash = ["contract-address"]
+key-value-state = []

--- a/libtransact/build.rs
+++ b/libtransact/build.rs
@@ -44,6 +44,8 @@ fn main() {
                 .unwrap(),
             proto_path.join("merkle.proto").to_str().unwrap(),
             proto_path.join("command.proto").to_str().unwrap(),
+            #[cfg(feature = "key-value-state")]
+            proto_path.join("key_value_state.proto").to_str().unwrap(),
         ],
         includes: &[proto_path.to_str().unwrap()],
         customize: Customize::default(),
@@ -53,6 +55,6 @@ fn main() {
     // Create mod.rs accordingly
     let mut mod_file = File::create(dest_path.join("mod.rs")).unwrap();
     mod_file
-        .write_all(b"pub mod batch;\npub mod events;\npub mod transaction;\npub mod transaction_receipt;\npub mod merkle;\npub mod command;\n")
+        .write_all(b"pub mod batch;\npub mod events;\n#[cfg(feature = \"key-value-state\")]\npub mod key_value_state;\npub mod transaction;\npub mod transaction_receipt;\npub mod merkle;\npub mod command;\n")
         .unwrap();
 }

--- a/libtransact/protos/key_value_state.proto
+++ b/libtransact/protos/key_value_state.proto
@@ -1,0 +1,48 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+message StateEntryValue {
+  enum ValueType {
+    TYPE_UNSET = 0;
+    INT64 = 1;
+    INT32 = 2;
+    UINT64 = 3;
+    UINT32 = 4;
+    STRING = 5;
+    BYTES = 6;
+  }
+  string key = 1;
+
+  ValueType value_type = 2;
+
+  int32 int32_value = 3;
+  int64 int64_value = 4;
+  uint32 uint32_value = 5;
+  uint64 uint64_value = 6;
+  string string_value = 7;
+  bytes bytes_value = 8;
+}
+
+
+message StateEntry {
+  string normalized_key = 1;
+  repeated StateEntryValue state_entry_values = 2;
+}
+
+message StateEntryList {
+  repeated StateEntry entries = 1;
+}

--- a/libtransact/src/contract/address/error.rs
+++ b/libtransact/src/contract/address/error.rs
@@ -23,13 +23,13 @@ impl std::fmt::Display for AddresserError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             AddresserError::KeyHashAddresserError(ref s) => {
-                write!(f, "KeyHashAddresserError: {}", s.to_string())
+                write!(f, "Unable to compute hash: {}", s.to_string())
             }
             AddresserError::DoubleKeyHashAddresserError(ref s) => {
-                write!(f, "DoubleKeyHashAddresserError: {}", s.to_string())
+                write!(f, "Unable to compute hash: {}", s.to_string())
             }
             AddresserError::TripleKeyHashAddresserError(ref s) => {
-                write!(f, "TripleKeyHashAddresserError: {}", s.to_string())
+                write!(f, "Unable to compute hash: {}", s.to_string())
             }
         }
     }

--- a/libtransact/src/contract/context/error.rs
+++ b/libtransact/src/contract/context/error.rs
@@ -15,6 +15,7 @@
 use std::error::Error as StdError;
 
 use crate::contract::address::AddresserError;
+use crate::handler::ContextError;
 use crate::protos::ProtoConversionError;
 
 #[derive(Debug)]
@@ -22,6 +23,7 @@ pub enum ContractContextError {
     AddresserError(AddresserError),
     ProtoConversionError(ProtoConversionError),
     ProtocolBuildError(Box<dyn StdError>),
+    TransactionContextError(ContextError),
 }
 
 impl StdError for ContractContextError {
@@ -30,6 +32,7 @@ impl StdError for ContractContextError {
             ContractContextError::AddresserError(_) => None,
             ContractContextError::ProtoConversionError(ref err) => Some(err),
             ContractContextError::ProtocolBuildError(ref err) => Some(&**err),
+            ContractContextError::TransactionContextError(ref err) => Some(err),
         }
     }
 }
@@ -48,6 +51,9 @@ impl std::fmt::Display for ContractContextError {
                 "Error occurred while building native protocol type: {}",
                 err
             ),
+            ContractContextError::TransactionContextError(ref err) => {
+                write!(f, "Error occurred in TransactionContext method: {}", err)
+            }
         }
     }
 }
@@ -61,5 +67,11 @@ impl From<ProtoConversionError> for ContractContextError {
 impl From<AddresserError> for ContractContextError {
     fn from(e: AddresserError) -> Self {
         ContractContextError::AddresserError(e)
+    }
+}
+
+impl From<ContextError> for ContractContextError {
+    fn from(e: ContextError) -> Self {
+        ContractContextError::TransactionContextError(e)
     }
 }

--- a/libtransact/src/contract/context/error.rs
+++ b/libtransact/src/contract/context/error.rs
@@ -1,0 +1,65 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error as StdError;
+
+use crate::contract::address::AddresserError;
+use crate::protos::ProtoConversionError;
+
+#[derive(Debug)]
+pub enum ContractContextError {
+    AddresserError(AddresserError),
+    ProtoConversionError(ProtoConversionError),
+    ProtocolBuildError(Box<dyn StdError>),
+}
+
+impl StdError for ContractContextError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match *self {
+            ContractContextError::AddresserError(_) => None,
+            ContractContextError::ProtoConversionError(ref err) => Some(err),
+            ContractContextError::ProtocolBuildError(ref err) => Some(&**err),
+        }
+    }
+}
+
+impl std::fmt::Display for ContractContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            ContractContextError::AddresserError(ref err) => {
+                write!(f, "Error occurred while computing an address: {}", err)
+            }
+            ContractContextError::ProtoConversionError(ref err) => {
+                write!(f, "Error occurred during protobuf conversion: {}", err)
+            }
+            ContractContextError::ProtocolBuildError(ref err) => write!(
+                f,
+                "Error occurred while building native protocol type: {}",
+                err
+            ),
+        }
+    }
+}
+
+impl From<ProtoConversionError> for ContractContextError {
+    fn from(e: ProtoConversionError) -> Self {
+        ContractContextError::ProtoConversionError(e)
+    }
+}
+
+impl From<AddresserError> for ContractContextError {
+    fn from(e: AddresserError) -> Self {
+        ContractContextError::AddresserError(e)
+    }
+}

--- a/libtransact/src/contract/context/key_value.rs
+++ b/libtransact/src/contract/context/key_value.rs
@@ -357,3 +357,952 @@ where
             .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))?)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::{Arc, Mutex};
+
+    use crate::contract::address::{
+        double_key_hash::DoubleKeyHashAddresser, key_hash::KeyHashAddresser,
+        triple_key_hash::TripleKeyHashAddresser,
+    };
+
+    use crate::handler::ContextError;
+
+    /// Simple state backed by a HashMap.
+    struct TestState {
+        state: HashMap<String, Vec<u8>>,
+    }
+
+    /// Simple state implementation with basic methods to get, set, and delete state values.
+    impl TestState {
+        pub fn new() -> Self {
+            TestState {
+                state: HashMap::new(),
+            }
+        }
+
+        fn get_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
+            let mut values = Vec::new();
+            addresses.iter().for_each(|key| {
+                if let Some(value) = self.state.get(key) {
+                    values.push((key.to_string(), value.to_vec()))
+                }
+            });
+            Ok(values)
+        }
+
+        fn set_entries(&mut self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
+            entries.iter().for_each(|(key, value)| {
+                match self.state.insert(key.to_string(), value.to_vec()) {
+                    _ => (),
+                }
+            });
+            Ok(())
+        }
+
+        fn delete_entries(&mut self, addresses: &[String]) -> Result<Vec<String>, ContextError> {
+            let mut deleted = Vec::new();
+            addresses.iter().for_each(|key| {
+                if let Some(_) = self.state.remove(key) {
+                    deleted.push(key.to_string());
+                }
+            });
+            Ok(deleted)
+        }
+
+        fn add_receipt_data(&self, _data: Vec<u8>) -> Result<(), ContextError> {
+            Ok(())
+        }
+
+        fn add_event(
+            &self,
+            _event_type: String,
+            _attributes: Vec<(String, String)>,
+            _data: Vec<u8>,
+        ) -> Result<(), ContextError> {
+            Ok(())
+        }
+    }
+
+    /// TestContext using the simple TestState backend to be used as the internal context to
+    /// construct a KeyValueTransactionContext for the tests.
+    struct TestContext {
+        internal_state: Arc<Mutex<TestState>>,
+    }
+
+    impl TestContext {
+        pub fn new() -> Self {
+            TestContext {
+                internal_state: Arc::new(Mutex::new(TestState::new())),
+            }
+        }
+    }
+
+    /// TransactionContext trait implementation for the TestContext.
+    impl TransactionContext for TestContext {
+        fn get_state_entries(
+            &self,
+            addresses: &[String],
+        ) -> Result<Vec<(String, Vec<u8>)>, ContextError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in get method")
+                .get_entries(addresses)
+        }
+
+        fn set_state_entries(&self, entries: Vec<(String, Vec<u8>)>) -> Result<(), ContextError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in set method")
+                .set_entries(entries)
+        }
+
+        fn delete_state_entries(&self, addresses: &[String]) -> Result<Vec<String>, ContextError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in delete method")
+                .delete_entries(addresses)
+        }
+
+        fn add_receipt_data(&self, data: Vec<u8>) -> Result<(), ContextError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in add_receipt_data method")
+                .add_receipt_data(data)
+        }
+
+        fn add_event(
+            &self,
+            event_type: String,
+            attributes: Vec<(String, String)>,
+            data: Vec<u8>,
+        ) -> Result<(), ContextError> {
+            self.internal_state
+                .lock()
+                .expect("Test lock was poisoned in add_event method")
+                .add_event(event_type, attributes, data)
+        }
+    }
+
+    /// Function to create a HashMap from `key` and `value` to create a StateEntryValue for a
+    /// StateEntry message.
+    fn create_entry_value_map(key: String, value: ValueType) -> HashMap<String, ValueType> {
+        let mut value_map = HashMap::new();
+        value_map.insert(key, value);
+        value_map
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a KeyHashAddresser,
+    /// will successfully perform the `set_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a KeyHashAddresser, so a key
+    ///    is represented by a single string
+    /// 2. Create a HashMap, a value to be set in state, with a string key and a ValueType value
+    ///
+    /// This test then verifies a successful return from the `set_state_entry` when providing a
+    /// single string for the `key` argument and the HashMap for the `values` argument
+    fn test_simple_set_state_entry() {
+        // Create a TestContext and KeyHashAddresser, then construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to be set in state
+        let value = ValueType::Int32(32);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Verify the `set_state_entry` method returns an `Ok(())` result
+        assert!(simple_state
+            .set_state_entry(&"a".to_string(), state_value)
+            .is_ok());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a KeyHashAddresser,
+    /// will successfully perform the `get_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a KeyHashAddresser, so a key
+    ///    is represented by a single string
+    /// 2. Create a HashMap, a value to be set in state, with a string key and a ValueType value
+    /// 3. Set the created HashMap in state at a key, 'a', using the `set_state_entry` method
+    ///
+    /// This test then verifies the `get_state_entry` returns a Some option and the value of the
+    /// returned option is equivalent to the HashMap created, including the key and ValueType
+    fn test_simple_get_state_entry() {
+        // Create a TestContext and KeyHashAddresser, then construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap, with a string key and ValueType value
+        let value = ValueType::Int32(32);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Set the HashMap, created above, at the key 'a'
+        simple_state
+            .set_state_entry(&"a".to_string(), state_value)
+            .expect("Unable to set state entry in get_state_entry test");
+
+        // Use the `get_state_entry` method to access the state entry at the 'a' key
+        let values = simple_state.get_state_entry(&"a".to_string()).unwrap();
+
+        // Verify the return value is equal to the HashMap used when the entry was originally set
+        assert!(values.is_some());
+        assert_eq!(
+            values.unwrap().get(&"key1".to_string()),
+            Some(&ValueType::Int32(32))
+        );
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a KeyHashAddresser,
+    /// will successfully perform the `delete_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a KeyHashAddresser, so a key
+    ///    is represented by a single string
+    /// 2. Create a HashMap, a value to be set in state, with a string key and a ValueType value
+    /// 3. Set the created HashMap in state at a key, 'a', using the `set_state_entry` method
+    ///
+    /// This test verifies the `delete_state_entry` successfully deletes the intended state entry
+    /// by checking that the initial call returns the correct key wrapped in a Some option
+    /// and a subsequent attempt to delete the entry at the same key returns a None option
+    fn test_simple_delete_state_entry() {
+        // Create a TestContext and KeyHashAddresser, then construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap, with a string key and ValueType value
+        let value = ValueType::Int32(32);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Set the HashMap, created above, at the key 'a'
+        simple_state
+            .set_state_entry(&"a".to_string(), state_value)
+            .expect("Unable to set state entry in delete_state_entry test");
+
+        // Call `get_state_entry` to ensure the value has been succesfully set
+        simple_state
+            .get_state_entry(&"a".to_string())
+            .expect("Unable to get state entry in delete_state_entry test");
+
+        // Call `delete_state_entry` and verify the return value is a Some option and the value of
+        // this option is the correct key, 'a'
+        let deleted = simple_state.delete_state_entry("a".to_string()).unwrap();
+        assert!(deleted.is_some());
+        assert_eq!(deleted, Some("a".to_string()));
+
+        // Call `delete_state_entry` with the same key, 'a', to verify the return value is a None
+        // option
+        let already_deleted = simple_state.delete_state_entry("a".to_string()).unwrap();
+        assert!(already_deleted.is_none());
+
+        // Verify access to the 'a' key using the `get_state_entry` method returns a None option
+        let deleted_value = simple_state.get_state_entry(&"a".to_string()).unwrap();
+        assert!(deleted_value.is_none());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a KeyHashAddresser,
+    /// will successfully perform the `set_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a KeyHashAddresser, so a key
+    ///    is represented by a single string
+    /// 2. Create two HashMaps, entries to be set in state, with values represented by a ValueType
+    ///
+    /// This test then verifies a successful return from the `set_state_entries` when provided a
+    /// HashMap of a natural key (the key the entry is meant to be set at) associated with a value,
+    /// represented by a HashMap (intended to be used in the state entry)
+    fn test_simple_set_state_entries() {
+        // Create a TestContext and KeyHashAddresser, then construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &"a".to_string();
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &"b".to_string();
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map);
+        entries.insert(second_key, second_value_map);
+
+        // Verify the `set_state_entries` method returns an `Ok(())` result
+        let set_result = simple_state.set_state_entries(entries);
+        assert!(set_result.is_ok());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a KeyHashAddresser,
+    /// will successfully perform the `get_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a KeyHashAddresser, so a key
+    ///    is represented by a single string
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    /// 3. Set these created HashMaps in state using the `set_state_entries` method
+    ///
+    /// This test then verifies the `get_state_entries` returns a HashMap containing the keys ('a'
+    /// and 'b') and each is associated with the unique HashMaps used to originally set the entries
+    fn test_simple_get_state_entries() {
+        // Create a TestContext and KeyHashAddresser, then construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &"a".to_string();
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &"b".to_string();
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+
+        // Use the `set_state_entries` method to place the `entries` HashMap in state
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set state entries in get_state_entries test");
+
+        // Use the `get_state_entries` method to access the state entries at the 'a' and 'b' key
+        let values = simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .unwrap();
+
+        // Verify each key has the same associated value as when the entries were originally set
+        assert_eq!(values.get("a").unwrap(), &first_value_map);
+        assert_eq!(values.get("b").unwrap(), &second_value_map);
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a KeyHashAddresser,
+    /// will successfully perform the `delete_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a KeyHashAddresser, so a key
+    ///    is represented by a single string
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    /// 3. Set these created HashMaps in state using the `set_state_entries` method
+    ///
+    /// This test verifies `delete_state_entries` successfully deletes the intended state entries
+    /// by checking that the initial call returns a list containing the correct keys and a
+    /// subsequent attempt to delete the entries at the same keys returns an empty list
+    fn test_simple_delete_state_entries() {
+        // Create a TestContext and KeyHashAddresser, then construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = KeyHashAddresser::new("prefix".to_string());
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &"a".to_string();
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &"b".to_string();
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+
+        // Call the `set_state_entries` method to place the `entries` HashMap in state
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set state entries in delete_state_entries test");
+
+        // Call the `get_state_entries` method to ensure the state entries have been set
+        simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to get state entries in delete_state_entries test");
+
+        // Call `delete_state_entries` and verify the return value is a list of the keys 'a' and 'b'
+        let deleted = simple_state
+            .delete_state_entries(["a".to_string(), "b".to_string()].to_vec())
+            .expect("Unable to delete state entries");
+        assert!(deleted.contains(&"a".to_string()));
+        assert!(deleted.contains(&"b".to_string()));
+
+        // Call `delete_state_entries` with the same keys and verify an empty list is returned
+        let already_deleted = simple_state
+            .delete_state_entries(["a".to_string(), "b".to_string()].to_vec())
+            .unwrap();
+        assert!(already_deleted.is_empty());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a DoubleKeyHashAddresser,
+    /// will successfully perform the `set_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a DoubleKeyHashAddresser, so
+    ///    a key is represented by a tuple of two strings
+    /// 2. Create a HashMap, a value to be set in state, with some key and a value represented by a
+    ///    ValueType
+    ///
+    /// This test then verifies a successful return from the `set_state_entry` when providing a
+    /// tuple of two strings for the `key` argument and the HashMap for the `values` argument
+    fn test_double_set_state_entry() {
+        // Create a TestContext and DoubleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to be set in state
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Verify the `set_state_entry` method returns an `Ok(())` result
+        assert!(simple_state
+            .set_state_entry(&("a".to_string(), "b".to_string()), state_value)
+            .is_ok());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a DoubleKeyHashAddresser,
+    /// will successfully perform the `get_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a DoubleKeyHashAddresser, so
+    ///    a key is represented by a tuple of two strings
+    /// 2. Create a HashMap, a value to be set in state, with a key and a ValueType as the value
+    /// 3. Set the created HashMap in state at a key, ('a', 'b'), using the `set_state_entry` method
+    ///
+    /// This test then verifies the `get_state_entry` returns a Some option and the value of the
+    /// returned option is equivalent to the HashMap created, including the key and ValueType
+    fn test_double_get_state_entry() {
+        // Create a TestContext and DoubleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap, with a string key and ValueType value
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Use `set_state_entry` to set the state entry at the ('a', 'b') key
+        simple_state
+            .set_state_entry(&("a".to_string(), "b".to_string()), state_value)
+            .expect("Unable to set state entry in get_state_entry test");
+
+        // Use the `get_state_entry` method to access the state entry at the ('a', 'b') key
+        let values = simple_state
+            .get_state_entry(&("a".to_string(), "b".to_string()))
+            .unwrap();
+
+        // Verify the return value is equal to the HashMap used when the entry was originally set
+        assert!(values.is_some());
+        assert_eq!(
+            values.unwrap().get(&"key1".to_string()),
+            Some(&ValueType::Int64(64))
+        );
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a DoubleKeyHashAddresser,
+    /// will successfully perform the `delete_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a DoubleKeyHashAddresser, so
+    ///    a key is represented by a tuple of two strings
+    /// 2. Create a HashMap, a value to be set in state, with a key and a ValueType as the value
+    /// 3. Set the created HashMap in state at a key, ('a', 'b'), using the `set_state_entry` method
+    ///
+    /// This test verifies the `delete_state_entry` successfully deletes the intended state entry
+    /// by checking that the initial call returns the normalized key wrapped in a Some option
+    fn test_double_delete_state_entry() {
+        // Create a TestContext and DoubleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap, with a string key and ValueType value
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Set the HashMap, created above, at the key ('a', 'b')
+        simple_state
+            .set_state_entry(&("a".to_string(), "b".to_string()), state_value)
+            .expect("Unable to set state entry in get_state_entry test");
+
+        // Call `get_state_entry` to ensure the value has been succesfully set
+        simple_state
+            .get_state_entry(&("a".to_string(), "b".to_string()))
+            .expect("Unable to get state entry in delete_state_entries test");
+
+        // Call `delete_state_entry` and verify the return value is a Some option and the value of
+        // this option is the correct normalized key, 'a_b'
+        let deleted = simple_state
+            .delete_state_entry(("a".to_string(), "b".to_string()))
+            .unwrap();
+        assert!(deleted.is_some());
+        assert_eq!(deleted, Some(format!("{}_{}", "a", "b")));
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a DoubleKeyHashAddresser,
+    /// will successfully perform the `set_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a DoubleKeyHashAddresser, so
+    ///    a key is represented by a tuple of two strings
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    ///
+    /// This test then verifies a successful return from the `set_state_entries` when provided a
+    /// HashMap of a natural key (the key the entry is meant to be set at) associated with a value,
+    /// represented by a HashMap (intended to be used in the state entry)
+    fn test_double_set_state_entries() {
+        // Create a TestContext and DoubleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &("a".to_string(), "b".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &("c".to_string(), "d".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map);
+        entries.insert(second_key, second_value_map);
+
+        // Verify the `set_state_entries` method returns an `Ok(())` result
+        assert!(simple_state.set_state_entries(entries).is_ok());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a DoubleKeyHashAddresser,
+    /// will successfully perform the `get_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a DoubleKeyHashAddresser, so
+    ///    a key is represented by a tuple of two strings
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    /// 3. Set these created HashMaps in state using the `set_state_entries` method
+    ///
+    /// This test verifies the `get_state_entries` returns a HashMap containing the keys, ('a', 'b')
+    /// and ('c', 'd'), and each is associated with the unique HashMaps used to originally set the entries
+    fn test_double_get_state_entries() {
+        // Create a TestContext and DoubleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &("a".to_string(), "b".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &("c".to_string(), "d".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+
+        // Use the `set_state_entries` method to place the `entries` HashMap in state
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set_state_entries in get_state_entries test");
+
+        // Use the `get_state_entries` method to access the state entries at the ('a', 'b') and
+        // ('c', 'd') keys
+        let values = simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to get state entries in get_state_entries test");
+
+        // Verify each normalized key has the same associated value as when the entries were
+        // originally set
+        assert_eq!(
+            values.get(&format!("{}_{}", "a", "b")).unwrap(),
+            &first_value_map
+        );
+        assert_eq!(
+            values.get(&format!("{}_{}", "c", "d")).unwrap(),
+            &second_value_map
+        );
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a DoubleKeyHashAddresser,
+    /// will successfully perform the `delete_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a DoubleKeyHashAddresser, so
+    ///    a key is represented by a tuple of two strings
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    /// 3. Set these created HashMaps in state using the `set_state_entries` method
+    ///
+    /// This test verifies `delete_state_entries` successfully deletes the intended state entries
+    /// by checking that the call returns a list containing the correct normalized keys
+    fn test_double_delete_state_entries() {
+        // Create a TestContext and DoubleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = DoubleKeyHashAddresser::new("prefix".to_string(), None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = ("a".to_string(), "b".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = ("c".to_string(), "d".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(&first_key, first_value_map.clone());
+        entries.insert(&second_key, second_value_map.clone());
+
+        // Call the `set_state_entries` method to place the `entries` HashMap in state
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set_state_entries in delete_state_entries test");
+
+        // Call the `get_state_entries` method to ensure the state entries have been set
+        simple_state
+            .get_state_entries([&first_key, &second_key].to_vec())
+            .expect("Unable to get_state_entries in the delete_state_entries test");
+
+        // Call `delete_state_entries` and verify the return value is a list containing the normalized
+        // keys 'a_b' and 'c_d'
+        let deleted = simple_state
+            .delete_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to delete state entries");
+        assert!(deleted.contains(&format!("{}_{}", "a", "b")));
+        assert!(deleted.contains(&format!("{}_{}", "c", "d")));
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a TripleKeyHashAddresser,
+    /// will successfully perform the `set_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a KeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a TripleKeyHashAddresser, so
+    ///    a key is represented by a tuple of three strings
+    /// 2. Create a HashMap, a value to be set in state, with some key and a value represented by a
+    ///    ValueType
+    ///
+    /// This test then verifies a successful return from the `set_state_entry` when providing a
+    /// tuple of three strings for the `key` argument and the HashMap for the `values` argument
+    fn test_triple_set_state_entry() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to be set in state
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Verify the `set_state_entry` method returns an `Ok(())` result
+        assert!(simple_state
+            .set_state_entry(
+                &("a".to_string(), "b".to_string(), "c".to_string()),
+                state_value
+            )
+            .is_ok());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a TripleKeyHashAddresser,
+    /// will successfully perform the `get_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a TripleKeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a TripleKeyHashAddresser, so
+    ///    a key is represented by a tuple of three strings
+    /// 2. Create a HashMap, a value to be set in state, with a key and a ValueType as the value
+    /// 3. Set the created HashMap in state at a key, ('a', 'b', 'c'), using `set_state_entry`
+    ///
+    /// This test then verifies the `get_state_entry` returns a Some option and the value of the
+    /// returned option is equivalent to the HashMap created, including the key and ValueType
+    fn test_triple_get_state_entry() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap, with a string key and ValueType value
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Use `set_state_entry` to set the state entry at the ('a', 'b', 'c') key
+        simple_state
+            .set_state_entry(
+                &("a".to_string(), "b".to_string(), "c".to_string()),
+                state_value,
+            )
+            .expect("Unable to set state entry in get_state_entry test");
+
+        // Use the `get_state_entry` method to access the state entry at the ('a', 'b', 'c') key
+        let values = simple_state
+            .get_state_entry(&("a".to_string(), "b".to_string(), "c".to_string()))
+            .unwrap();
+
+        // Verify the return value is equal to the HashMap used when the entry was originally set
+        assert!(values.is_some());
+        assert_eq!(
+            values.unwrap().get(&"key1".to_string()),
+            Some(&ValueType::Int64(64))
+        );
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a TripleKeyHashAddresser,
+    /// will successfully perform the `delete_state_entry` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a TripleKeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a TripleKeyHashAddresser, so
+    ///    a key is represented by a tuple of three strings
+    /// 2. Create a HashMap, a value to be set in state, with a key and a ValueType as the value
+    /// 3. Set the created HashMap in state at a key, ('a', 'b', 'c'), using `set_state_entry`
+    ///
+    /// This test verifies the `delete_state_entry` successfully deletes the intended state entry
+    /// by checking that the initial call returns the normalized key wrapped in a Some option
+    fn test_triple_delete_state_entry() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap, with a string key and ValueType value
+        let value = ValueType::Int64(64);
+        let mut state_value = HashMap::new();
+        state_value.insert("key1".to_string(), value);
+
+        // Set the HashMap, created above, at the key ('a', 'b', 'c')
+        simple_state
+            .set_state_entry(
+                &("a".to_string(), "b".to_string(), "c".to_string()),
+                state_value,
+            )
+            .expect("Unable to set state entry in get_state_entry test");
+
+        // Call `get_state_entry` to ensure the value has been succesfully set
+        simple_state
+            .get_state_entry(&("a".to_string(), "b".to_string(), "c".to_string()))
+            .expect("Unable to get state entry in delete_state_entries test");
+
+        // Call `delete_state_entry` and verify the return value is a Some option and the value of
+        // this option is the correct normalized key, 'a_b_c'
+        let deleted = simple_state
+            .delete_state_entry(("a".to_string(), "b".to_string(), "c".to_string()))
+            .unwrap();
+        assert!(deleted.is_some());
+        assert_eq!(deleted, Some(format!("{}_{}_{}", "a", "b", "c")));
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a TripleKeyHashAddresser,
+    /// will successfully perform the `set_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a TripleKeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a TripleKeyHashAddresser, so
+    ///    a key is represented by a tuple of three strings
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    ///
+    /// This test then verifies a successful return from the `set_state_entries` when provided a
+    /// HashMap of a natural key (the key the entry is meant to be set at) associated with a value,
+    /// represented by a HashMap (intended to be used in the state entry)
+    fn test_triple_set_state_entries() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &("a".to_string(), "b".to_string(), "c".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &("c".to_string(), "d".to_string(), "c".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map);
+        entries.insert(second_key, second_value_map);
+
+        // Verify the `set_state_entries` method returns an `Ok(())` result
+        assert!(simple_state.set_state_entries(entries).is_ok());
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a TripleKeyHashAddresser,
+    /// will successfully perform the `get_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a TripleKeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a TripleKeyHashAddresser, so
+    ///    a key is represented by a tuple of three strings
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    /// 3. Set these created HashMaps in state using the `set_state_entries` method
+    ///
+    /// This test verifies the `get_state_entries` returns a HashMap containing the keys, ('a', 'b', 'c')
+    /// and ('d', 'e', 'f'), and each is associated with the unique HashMaps used to originally set
+    /// the entries
+    fn test_triple_get_state_entries() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = &("a".to_string(), "b".to_string(), "c".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = &("d".to_string(), "e".to_string(), "f".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(first_key, first_value_map.clone());
+        entries.insert(second_key, second_value_map.clone());
+
+        // Use the `set_state_entries` method to place the `entries` HashMap in state
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set_state_entries in get_state_entries test");
+
+        // Use the `get_state_entries` method to access the state entries at the ('a', 'b', 'c') and
+        // ('d', 'e', 'f') keys
+        let values = simple_state
+            .get_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to get state entries in get_state_entries test");
+
+        // Verify each normalized key has the same associated value as when the entries were
+        // originally set
+        assert_eq!(
+            values.get(&format!("{}_{}_{}", "a", "b", "c")).unwrap(),
+            &first_value_map
+        );
+        assert_eq!(
+            values.get(&format!("{}_{}_{}", "d", "e", "f")).unwrap(),
+            &second_value_map
+        );
+    }
+
+    #[test]
+    /// This test verifies that a KeyValueTransactionContext, constructed with a TripleKeyHashAddresser,
+    /// will successfully perform the `delete_state_entries` method, after the following steps:
+    ///
+    /// 1. Create a TestContext and a TripleKeyHashAddresser to construct a KeyValueTransactionContext
+    ///    Note: This KeyValueTransactionContext is constructed using a TripleKeyHashAddresser, so
+    ///    a key is represented by a tuple of three strings
+    /// 2. Create two HashMaps, values to be set in state, with values represented by a ValueType
+    /// 3. Set these created HashMaps in state using the `set_state_entries` method
+    ///
+    /// This test verifies `delete_state_entries` successfully deletes the intended state entries
+    /// by checking that the call returns a list containing the correct normalized keys
+    fn test_triple_delete_state_entries() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Create a HashMap to contain the multiple entries to set in state
+        let mut entries = HashMap::new();
+
+        // Create two individual HashMaps, to be associated with unique keys
+        let first_key = ("a".to_string(), "b".to_string(), "c".to_string());
+        let first_value_map = create_entry_value_map("key1".to_string(), ValueType::Int32(32));
+        let second_key = ("d".to_string(), "e".to_string(), "f".to_string());
+        let second_value_map =
+            create_entry_value_map("key1".to_string(), ValueType::String("String".to_string()));
+
+        // Insert the two HashMaps at unique keys to the HashMap to be set in state
+        entries.insert(&first_key, first_value_map.clone());
+        entries.insert(&second_key, second_value_map.clone());
+
+        // Call the `set_state_entries` method to place the `entries` HashMap in state
+        simple_state
+            .set_state_entries(entries)
+            .expect("Unable to set_state_entries in delete_state_entries test");
+
+        // Call the `get_state_entries` method to ensure the state entries have been set
+        simple_state
+            .get_state_entries([&first_key, &second_key].to_vec())
+            .expect("Unable to get_state_entries in the delete_state_entries test");
+
+        // Call `delete_state_entries` and verify the return value is a list containing the normalized
+        // keys 'a_b_c' and 'd_e_f'
+        let deleted = simple_state
+            .delete_state_entries([first_key, second_key].to_vec())
+            .expect("Unable to delete state entries");
+        assert!(deleted.contains(&format!("{}_{}_{}", "a", "b", "c")));
+        assert!(deleted.contains(&format!("{}_{}_{}", "d", "e", "f")));
+    }
+
+    #[test]
+    /// This test verifies the `add_receipt_data` method returns an Ok(()), even though it is
+    /// currently not supported in Sawtooth Sabre. This test should return a simple Ok(())
+    fn test_add_receipt_data_ok() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Call the `add_receipt_data` method
+        let res = simple_state.add_receipt_data(vec![]);
+
+        // Verify this result is an Ok(())
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    /// This test verifies the `add_event` method returns an Ok(()), even though it is currently
+    /// not supported in Sawtooth Sabre. This test should return a simple Ok(())
+    fn test_add_event_ok() {
+        // Create a TestContext and TripleKeyHashAddresser to construct a KeyValueTransactionContext
+        let mut context = TestContext::new();
+        let addresser = TripleKeyHashAddresser::new("prefix".to_string(), None, None);
+        let simple_state = KeyValueTransactionContext::new(&mut context, addresser);
+
+        // Call the `add_event` method
+        let res = simple_state.add_event("event".to_string(), vec![], vec![]);
+
+        // Verify this result is an Ok(())
+        assert!(res.is_ok());
+    }
+}

--- a/libtransact/src/contract/context/key_value.rs
+++ b/libtransact/src/contract/context/key_value.rs
@@ -1,0 +1,359 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::marker::PhantomData;
+
+use crate::contract::address::Addresser;
+use crate::contract::context::error::ContractContextError;
+use crate::handler::TransactionContext;
+use crate::protocol::key_value_state::{
+    StateEntry, StateEntryBuilder, StateEntryList, StateEntryListBuilder, StateEntryValue,
+    StateEntryValueBuilder, ValueType,
+};
+use crate::protos::{FromBytes, IntoBytes};
+
+/// KeyValueTransactionContext used to implement a simplified state consisting of natural keys and
+/// a ValueType, an enum object used to represent a range of primitive data types. Uses an
+/// implementation of the Addresser trait to calculate radix addresses to be stored in the
+/// KeyValueTransactionContext's internal transaction context.
+pub struct KeyValueTransactionContext<'a, A, K>
+where
+    A: Addresser<K>,
+{
+    context: &'a mut dyn TransactionContext,
+    addresser: A,
+    // PhantomData<K> is necessary for the K generic to be used with the Addresser trait, as K is not
+    // used in any other elements of the KeyValueTransactionContext struct.
+    _key: PhantomData<K>,
+}
+
+impl<'a, A, K> KeyValueTransactionContext<'a, A, K>
+where
+    A: Addresser<K>,
+    K: Eq + Hash,
+{
+    /// Creates a new KeyValueTransactionContext
+    /// Implementations of the TransactionContext trait and Addresser trait must be provided.
+    pub fn new(
+        context: &'a mut dyn TransactionContext,
+        addresser: A,
+    ) -> KeyValueTransactionContext<'a, A, K> {
+        KeyValueTransactionContext {
+            context,
+            addresser,
+            _key: PhantomData,
+        }
+    }
+
+    /// Serializes the provided values and attempts to set this object at an address calculated
+    /// from the provided natural key.
+    ///
+    /// Returns an `Ok(())` if the entry is successfully stored.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The natural key that specifies where to set the state entry
+    /// * `values` - The HashMap to be stored in state at the provided natural key
+    pub fn set_state_entry(
+        &self,
+        key: &K,
+        values: HashMap<String, ValueType>,
+    ) -> Result<(), ContractContextError> {
+        let mut new_entries = HashMap::new();
+        new_entries.insert(key, values);
+        self.set_state_entries(new_entries)
+    }
+
+    /// Attempts to retrieve the data from state at the address calculated from the provided
+    /// natural key.
+    ///
+    /// Returns an optional HashMap which represents the value stored in state, returning `None`
+    /// if the state entry is not found.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The natural key to fetch
+    pub fn get_state_entry(
+        &self,
+        key: &K,
+    ) -> Result<Option<HashMap<String, ValueType>>, ContractContextError> {
+        Ok(self
+            .get_state_entries(vec![key])?
+            .into_iter()
+            .map(|(_, val)| val)
+            .next())
+    }
+
+    /// Attempts to unset the data in state at the address calculated from the provided natural key.
+    ///
+    /// Returns an optional normalized key of the successfully deleted state entry, returning
+    /// `None` if the state entry is not found.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The natural key to delete
+    pub fn delete_state_entry(&self, key: K) -> Result<Option<String>, ContractContextError> {
+        Ok(self.delete_state_entries(vec![key])?.into_iter().next())
+    }
+
+    /// Serializes each value in the provided map and attempts to set in state each of these objects
+    /// at the address calculated from its corresponding natural key.
+    ///
+    /// Returns an `Ok(())` if the provided entries were successfully stored.
+    ///
+    /// # Arguments
+    ///
+    /// * `entries` - HashMap with the map to be stored in state at the associated natural key
+    pub fn set_state_entries(
+        &self,
+        entries: HashMap<&K, HashMap<String, ValueType>>,
+    ) -> Result<(), ContractContextError> {
+        let keys = entries.keys().map(ToOwned::to_owned).collect::<Vec<&K>>();
+        let addresses = keys
+            .iter()
+            .map(|k| {
+                self.addresser
+                    .compute(&k)
+                    .map_err(ContractContextError::AddresserError)
+            })
+            .collect::<Result<Vec<String>, ContractContextError>>()?;
+        // Creating a map of the StateEntryList to the address it is stored at
+        let entry_list_map = self.get_state_entry_lists(&addresses)?;
+
+        // Iterating over the provided HashMap to see if there is an existing StateEntryList at the
+        // corresponding address. If there is one found, add the new StateEntry to the StateEntryList.
+        // If there is none found, creates a new StateEntryList entry for that address. Then,
+        // serializes the newly created StateEntryList to be set in the internal context.
+        let entries_list = entries
+            .iter()
+            .map(|(key, values)| {
+                let addr = self.addresser.compute(key)?;
+                let state_entry = self.create_state_entry(key, values.to_owned())?;
+                match entry_list_map.get(&addr) {
+                    Some(entry_list) => {
+                        let mut existing_entries = entry_list.entries().to_vec();
+                        existing_entries.push(state_entry);
+                        let entry_list = StateEntryListBuilder::new()
+                            .with_state_entries(existing_entries)
+                            .build()
+                            .map_err(|err| {
+                                ContractContextError::ProtocolBuildError(Box::new(err))
+                            })?;
+                        Ok((addr, entry_list.into_bytes()?))
+                    }
+                    None => {
+                        let entry_list = StateEntryListBuilder::new()
+                            .with_state_entries(vec![state_entry])
+                            .build()
+                            .map_err(|err| {
+                                ContractContextError::ProtocolBuildError(Box::new(err))
+                            })?;
+                        Ok((addr, entry_list.into_bytes()?))
+                    }
+                }
+            })
+            .collect::<Result<Vec<(String, Vec<u8>)>, ContractContextError>>()?;
+        self.context.set_state_entries(entries_list)?;
+
+        Ok(())
+    }
+
+    /// Attempts to retrieve the data from state at the addresses calculated from the provided list
+    /// of natural keys.
+    ///
+    /// Returns a HashMap that links a normalized key with a HashMap. The associated HashMap represents
+    /// the data retrieved from state. Only returns the data from addresses that have been set.
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - A list of natural keys to be fetched from state
+    pub fn get_state_entries(
+        &self,
+        keys: Vec<&K>,
+    ) -> Result<HashMap<String, HashMap<String, ValueType>>, ContractContextError> {
+        let addresses = keys
+            .iter()
+            .map(|k| {
+                self.addresser
+                    .compute(&k)
+                    .map_err(ContractContextError::AddresserError)
+            })
+            .collect::<Result<Vec<String>, ContractContextError>>()?;
+        let normalized_keys = keys
+            .iter()
+            .map(|k| self.addresser.normalize(&k))
+            .collect::<Vec<String>>();
+
+        let state_entries: Vec<StateEntry> = self.flatten_state_entries(&addresses)?;
+
+        // Now going to filter the StateEntry objects that actually have a matching normalized key
+        // and convert the normalized key and value to be added to the returned HashMap.
+        state_entries
+            .iter()
+            .filter(|entry| normalized_keys.contains(&entry.normalized_key().to_string()))
+            .map(|entry| {
+                let values = entry
+                    .state_entry_values()
+                    .iter()
+                    .map(|val| (val.key().to_string(), val.value().to_owned()))
+                    .collect::<HashMap<String, ValueType>>();
+                Ok((entry.normalized_key().to_string(), values))
+            })
+            .collect::<Result<HashMap<String, HashMap<String, ValueType>>, ContractContextError>>()
+    }
+
+    /// Attempts to unset the data in state at the addresses calculated from each natural key in the
+    /// provided list.
+    ///
+    /// Returns a list of normalized keys of successfully deleted state entries.
+    ///
+    /// # Arguments
+    ///
+    /// * `keys` - A list of natural keys to be deleted from state
+    pub fn delete_state_entries(&self, keys: Vec<K>) -> Result<Vec<String>, ContractContextError> {
+        let key_map: HashMap<String, String> = keys
+            .iter()
+            .map(|k| Ok((self.addresser.normalize(k), self.addresser.compute(k)?)))
+            .collect::<Result<HashMap<String, String>, ContractContextError>>()?;
+        let state_entry_lists: HashMap<String, StateEntryList> = self.get_state_entry_lists(
+            &key_map
+                .values()
+                .map(ToOwned::to_owned)
+                .collect::<Vec<String>>(),
+        )?;
+
+        let mut deleted_keys = Vec::new();
+        let mut new_entry_lists = Vec::new();
+        let mut delete_lists = Vec::new();
+        key_map.iter().for_each(|(nkey, addr)| {
+            // Fetching the StateEntryList at the corresponding address
+            if let Some(list) = state_entry_lists.get(addr) {
+                // The StateEntry objects will be filtered out of the StateEntryList if it has the
+                // normalized key. This normalized key is added to a list of successfully filtered
+                // entries to be returned.
+                if list.contains(nkey.to_string()) {
+                    let filtered = list
+                        .entries()
+                        .to_vec()
+                        .into_iter()
+                        .filter(|e| e.normalized_key() != nkey)
+                        .collect::<Vec<StateEntry>>();
+                    if filtered.is_empty() {
+                        delete_lists.push(addr.to_string());
+                    } else {
+                        new_entry_lists.push((addr.to_string(), filtered));
+                    }
+                    deleted_keys.push(nkey.to_string());
+                }
+            }
+        });
+        // Delete any StateEntryLists that have an empty list of entries
+        self.context.delete_state_entries(delete_lists.as_slice())?;
+        // Setting the newly filtered StateEntryLists into state using the internal context
+        self.context.set_state_entries(
+            new_entry_lists
+                .iter()
+                .map(|(addr, filtered_list)| {
+                    let new_entry_list = StateEntryListBuilder::new()
+                        .with_state_entries(filtered_list.to_vec())
+                        .build()
+                        .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))?;
+                    Ok((addr.to_string(), new_entry_list.into_bytes()?))
+                })
+                .collect::<Result<Vec<(String, Vec<u8>)>, ContractContextError>>()?,
+        )?;
+
+        Ok(deleted_keys)
+    }
+
+    /// Adds a blob to the execution result for this transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Transaction-family-specific data which can be interpreted by application clients.
+    pub fn add_receipt_data(&self, data: Vec<u8>) -> Result<(), ContractContextError> {
+        Ok(self.context.add_receipt_data(data)?)
+    }
+
+    /// add_event adds a new event to the execution result for this transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` -  A globally unique event identifier that is used to subscribe to events.
+    ///         It describes what, in general, has occured.
+    /// * `attributes` - Additional information about the event. Attributes can be used by
+    ///         subscribers to filter the type of events they receive.
+    /// * `data` - Transaction-family-specific data which can be interpreted by application clients.
+    pub fn add_event(
+        &self,
+        event_type: String,
+        attributes: Vec<(String, String)>,
+        data: Vec<u8>,
+    ) -> Result<(), ContractContextError> {
+        Ok(self.context.add_event(event_type, attributes, data)?)
+    }
+
+    /// Collects the StateEntryList objects from state and then uses flat_map to collect the
+    /// StateEntry objects held within each StateEntryList.
+    fn flatten_state_entries(
+        &self,
+        addresses: &[String],
+    ) -> Result<Vec<StateEntry>, ContractContextError> {
+        Ok(self
+            .get_state_entry_lists(addresses)?
+            .values()
+            .flat_map(|entry_list| entry_list.entries().to_vec())
+            .collect::<Vec<StateEntry>>())
+    }
+
+    /// Collects the StateEntryList objects from the bytes fetched from state, then deserializes
+    /// these into the native StateEntryList object.
+    fn get_state_entry_lists(
+        &self,
+        addresses: &[String],
+    ) -> Result<HashMap<String, StateEntryList>, ContractContextError> {
+        self.context
+            .get_state_entries(&addresses)?
+            .iter()
+            .map(|(addr, bytes_entry)| {
+                Ok((addr.to_string(), StateEntryList::from_bytes(bytes_entry)?))
+            })
+            .collect::<Result<HashMap<String, StateEntryList>, ContractContextError>>()
+    }
+
+    /// Creates a singular StateEntry object from the provided key and values.
+    fn create_state_entry(
+        &self,
+        key: &K,
+        values: HashMap<String, ValueType>,
+    ) -> Result<StateEntry, ContractContextError> {
+        let state_values: Vec<StateEntryValue> = values
+            .iter()
+            .map(|(key, value)| {
+                StateEntryValueBuilder::new()
+                    .with_key(key.to_string())
+                    .with_value(value.clone())
+                    .build()
+                    .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))
+            })
+            .collect::<Result<Vec<StateEntryValue>, ContractContextError>>()?;
+        Ok(StateEntryBuilder::new()
+            .with_normalized_key(self.addresser.normalize(key.to_owned()))
+            .with_state_entry_values(state_values)
+            .build()
+            .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))?)
+    }
+}

--- a/libtransact/src/contract/context/mod.rs
+++ b/libtransact/src/contract/context/mod.rs
@@ -15,7 +15,4 @@
  * -----------------------------------------------------------------------------
  */
 
-#[cfg(feature = "contract-address")]
-pub mod address;
-#[cfg(feature = "contract-context")]
-pub mod context;
+pub mod error;

--- a/libtransact/src/contract/context/mod.rs
+++ b/libtransact/src/contract/context/mod.rs
@@ -16,3 +16,5 @@
  */
 
 pub mod error;
+#[cfg(feature = "contract-context-key-value")]
+pub mod key_value;

--- a/libtransact/src/protocol/key_value_state.rs
+++ b/libtransact/src/protocol/key_value_state.rs
@@ -1,0 +1,475 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protobuf::Message;
+use protobuf::RepeatedField;
+
+use std::error::Error as StdError;
+
+use crate::protos;
+use crate::protos::{
+    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+
+/// Native implementation for ValueType
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValueType {
+    Int64(i64),
+    Int32(i32),
+    UInt64(u64),
+    UInt32(u32),
+    String(String),
+    Bytes(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateEntryValue {
+    key: String,
+    value: ValueType,
+}
+
+impl StateEntryValue {
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    pub fn value(&self) -> &ValueType {
+        &self.value
+    }
+}
+
+impl FromProto<protos::key_value_state::StateEntryValue> for StateEntryValue {
+    fn from_proto(
+        proto: protos::key_value_state::StateEntryValue,
+    ) -> Result<Self, ProtoConversionError> {
+        let value = match proto.get_value_type() {
+            protos::key_value_state::StateEntryValue_ValueType::INT64 => {
+                ValueType::Int64(proto.get_int64_value())
+            }
+            protos::key_value_state::StateEntryValue_ValueType::INT32 => {
+                ValueType::Int32(proto.get_int32_value())
+            }
+            protos::key_value_state::StateEntryValue_ValueType::UINT64 => {
+                ValueType::UInt64(proto.get_uint64_value())
+            }
+            protos::key_value_state::StateEntryValue_ValueType::UINT32 => {
+                ValueType::UInt32(proto.get_uint32_value())
+            }
+            protos::key_value_state::StateEntryValue_ValueType::STRING => {
+                ValueType::String(proto.get_string_value().to_string())
+            }
+            protos::key_value_state::StateEntryValue_ValueType::BYTES => {
+                ValueType::Bytes(proto.get_bytes_value().to_vec())
+            }
+            protos::key_value_state::StateEntryValue_ValueType::TYPE_UNSET => {
+                return Err(ProtoConversionError::InvalidTypeError(
+                    "Cannot convert StateEntryValue_ValueType with type unset.".to_string(),
+                ));
+            }
+        };
+
+        Ok(StateEntryValue {
+            key: proto.get_key().to_string(),
+            value,
+        })
+    }
+}
+
+impl FromNative<StateEntryValue> for protos::key_value_state::StateEntryValue {
+    fn from_native(native: StateEntryValue) -> Result<Self, ProtoConversionError> {
+        let mut proto = protos::key_value_state::StateEntryValue::new();
+        proto.set_key(native.key().to_string());
+        match native.value() {
+            ValueType::Int64(value) => {
+                proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::INT64);
+                proto.set_int64_value(value.clone());
+            }
+            ValueType::Int32(value) => {
+                proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::INT32);
+                proto.set_int32_value(value.clone());
+            }
+            ValueType::UInt64(value) => {
+                proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::UINT64);
+                proto.set_uint64_value(value.clone());
+            }
+            ValueType::UInt32(value) => {
+                proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::UINT32);
+                proto.set_uint32_value(value.clone());
+            }
+            ValueType::String(value) => {
+                proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::STRING);
+                proto.set_string_value(value.clone());
+            }
+            ValueType::Bytes(value) => {
+                proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::BYTES);
+                proto.set_bytes_value(value.clone());
+            }
+        }
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<StateEntryValue> for StateEntryValue {
+    fn from_bytes(bytes: &[u8]) -> Result<StateEntryValue, ProtoConversionError> {
+        let proto: protos::key_value_state::StateEntryValue = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get StateEntryValue from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for StateEntryValue {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto: protos::key_value_state::StateEntryValue = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from StateEntryValue".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::key_value_state::StateEntryValue> for StateEntryValue {}
+impl IntoNative<StateEntryValue> for protos::key_value_state::StateEntryValue {}
+
+#[derive(Debug)]
+pub enum StateEntryValueBuildError {
+    MissingField(String),
+}
+
+impl StdError for StateEntryValueBuildError {
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            StateEntryValueBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for StateEntryValueBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            StateEntryValueBuildError::MissingField(ref s) => {
+                write!(f, "'{}' field is required", s)
+            }
+        }
+    }
+}
+
+/// Builder used to create StateEntryValue
+#[derive(Default, Clone, Debug)]
+pub struct StateEntryValueBuilder {
+    key: Option<String>,
+    value: Option<ValueType>,
+}
+
+impl StateEntryValueBuilder {
+    pub fn new() -> Self {
+        StateEntryValueBuilder::default()
+    }
+
+    pub fn with_key(mut self, key: String) -> StateEntryValueBuilder {
+        self.key = Some(key);
+        self
+    }
+
+    pub fn with_value(mut self, value: ValueType) -> StateEntryValueBuilder {
+        self.value = Some(value);
+        self
+    }
+
+    pub fn build(self) -> Result<StateEntryValue, StateEntryValueBuildError> {
+        let key = self
+            .key
+            .ok_or_else(|| StateEntryValueBuildError::MissingField("key".to_string()))?;
+
+        let value = self
+            .value
+            .ok_or_else(|| StateEntryValueBuildError::MissingField("value".to_string()))?;
+
+        Ok(StateEntryValue { key, value })
+    }
+}
+
+/// Native implementation for StateEntry
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct StateEntry {
+    normalized_key: String,
+    state_entry_values: Vec<StateEntryValue>,
+}
+
+impl StateEntry {
+    pub fn normalized_key(&self) -> &str {
+        &self.normalized_key
+    }
+
+    pub fn state_entry_values(&self) -> &[StateEntryValue] {
+        &self.state_entry_values
+    }
+}
+
+impl FromProto<protos::key_value_state::StateEntry> for StateEntry {
+    fn from_proto(
+        proto: protos::key_value_state::StateEntry,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(StateEntry {
+            normalized_key: proto.get_normalized_key().to_string(),
+            state_entry_values: proto
+                .get_state_entry_values()
+                .to_vec()
+                .into_iter()
+                .map(StateEntryValue::from_proto)
+                .collect::<Result<Vec<StateEntryValue>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<StateEntry> for protos::key_value_state::StateEntry {
+    fn from_native(state_entry: StateEntry) -> Result<Self, ProtoConversionError> {
+        let mut proto = protos::key_value_state::StateEntry::new();
+        proto.set_normalized_key(state_entry.normalized_key().to_string());
+        proto.set_state_entry_values(RepeatedField::from_vec(
+            state_entry
+                .state_entry_values()
+                .to_vec()
+                .into_iter()
+                .map(StateEntryValue::into_proto)
+                .collect::<Result<
+                    Vec<protos::key_value_state::StateEntryValue>,
+                    ProtoConversionError,
+                >>()?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<StateEntry> for StateEntry {
+    fn from_bytes(bytes: &[u8]) -> Result<StateEntry, ProtoConversionError> {
+        let proto: protos::key_value_state::StateEntry = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get StateEntry from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for StateEntry {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from StateEntry".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::key_value_state::StateEntry> for StateEntry {}
+impl IntoNative<StateEntry> for protos::key_value_state::StateEntry {}
+
+#[derive(Debug)]
+pub enum StateEntryBuildError {
+    MissingField(String),
+}
+
+impl StdError for StateEntryBuildError {
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            StateEntryBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for StateEntryBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            StateEntryBuildError::MissingField(ref s) => write!(f, "'{}' field is required", s),
+        }
+    }
+}
+
+/// Builder used to create StateEntry
+#[derive(Default, Clone, Debug)]
+pub struct StateEntryBuilder {
+    normalized_key: Option<String>,
+    state_entry_values: Option<Vec<StateEntryValue>>,
+}
+
+impl StateEntryBuilder {
+    pub fn new() -> Self {
+        StateEntryBuilder::default()
+    }
+
+    pub fn with_normalized_key(mut self, normalized_key: String) -> StateEntryBuilder {
+        self.normalized_key = Some(normalized_key);
+        self
+    }
+
+    pub fn with_state_entry_values(
+        mut self,
+        state_entry_values: Vec<StateEntryValue>,
+    ) -> StateEntryBuilder {
+        self.state_entry_values = Some(state_entry_values);
+        self
+    }
+
+    pub fn build(self) -> Result<StateEntry, StateEntryBuildError> {
+        let normalized_key = self
+            .normalized_key
+            .ok_or_else(|| StateEntryBuildError::MissingField("normalized_key".to_string()))?;
+        let state_entry_values = self
+            .state_entry_values
+            .ok_or_else(|| StateEntryBuildError::MissingField("state_entry_values".to_string()))?;
+
+        Ok(StateEntry {
+            normalized_key,
+            state_entry_values,
+        })
+    }
+}
+
+/// Native implementation for StateEntryList
+#[derive(Default, Debug)]
+pub struct StateEntryList {
+    entries: Vec<StateEntry>,
+}
+
+impl StateEntryList {
+    pub fn entries(&self) -> &[StateEntry] {
+        &self.entries
+    }
+
+    pub fn contains(&self, normalized_key: String) -> bool {
+        let nkeys = self
+            .entries()
+            .to_vec()
+            .into_iter()
+            .map(|e| e.normalized_key().to_string())
+            .collect::<Vec<String>>();
+        nkeys.contains(&normalized_key)
+    }
+}
+
+impl FromProto<protos::key_value_state::StateEntryList> for StateEntryList {
+    fn from_proto(
+        proto: protos::key_value_state::StateEntryList,
+    ) -> Result<Self, ProtoConversionError> {
+        Ok(StateEntryList {
+            entries: proto
+                .get_entries()
+                .to_vec()
+                .into_iter()
+                .map(StateEntry::from_proto)
+                .collect::<Result<Vec<StateEntry>, ProtoConversionError>>()?,
+        })
+    }
+}
+
+impl FromNative<StateEntryList> for protos::key_value_state::StateEntryList {
+    fn from_native(state_entry_list: StateEntryList) -> Result<Self, ProtoConversionError> {
+        let mut proto = protos::key_value_state::StateEntryList::new();
+        proto.set_entries(RepeatedField::from_vec(
+            state_entry_list
+                .entries()
+                .to_vec()
+                .into_iter()
+                .map(StateEntry::into_proto)
+                .collect::<Result<Vec<protos::key_value_state::StateEntry>, ProtoConversionError>>(
+                )?,
+        ));
+
+        Ok(proto)
+    }
+}
+
+impl FromBytes<StateEntryList> for StateEntryList {
+    fn from_bytes(bytes: &[u8]) -> Result<StateEntryList, ProtoConversionError> {
+        let proto: protos::key_value_state::StateEntryList = protobuf::parse_from_bytes(bytes)
+            .map_err(|_| {
+                ProtoConversionError::SerializationError(
+                    "Unable to get StateEntryList from bytes".to_string(),
+                )
+            })?;
+        proto.into_native()
+    }
+}
+
+impl IntoBytes for StateEntryList {
+    fn into_bytes(self) -> Result<Vec<u8>, ProtoConversionError> {
+        let proto = self.into_proto()?;
+        let bytes = proto.write_to_bytes().map_err(|_| {
+            ProtoConversionError::SerializationError(
+                "Unable to get bytes from StateEntryList".to_string(),
+            )
+        })?;
+        Ok(bytes)
+    }
+}
+
+impl IntoProto<protos::key_value_state::StateEntryList> for StateEntryList {}
+impl IntoNative<StateEntryList> for protos::key_value_state::StateEntryList {}
+
+#[derive(Debug)]
+pub enum StateEntryListBuildError {
+    MissingField(String),
+}
+
+impl StdError for StateEntryListBuildError {
+    fn cause(&self) -> Option<&dyn StdError> {
+        match *self {
+            StateEntryListBuildError::MissingField(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for StateEntryListBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            StateEntryListBuildError::MissingField(ref s) => write!(f, "'{}' field is required", s),
+        }
+    }
+}
+
+/// Builder used to create StateEntryList
+#[derive(Default, Clone)]
+pub struct StateEntryListBuilder {
+    entries: Option<Vec<StateEntry>>,
+}
+
+impl StateEntryListBuilder {
+    pub fn new() -> Self {
+        StateEntryListBuilder::default()
+    }
+
+    pub fn with_state_entries(mut self, entries: Vec<StateEntry>) -> StateEntryListBuilder {
+        self.entries = Some(entries);
+        self
+    }
+
+    pub fn build(self) -> Result<StateEntryList, StateEntryListBuildError> {
+        let entries = self
+            .entries
+            .ok_or_else(|| StateEntryListBuildError::MissingField("entries".to_string()))?;
+
+        Ok(StateEntryList { entries })
+    }
+}

--- a/libtransact/src/protocol/mod.rs
+++ b/libtransact/src/protocol/mod.rs
@@ -22,5 +22,7 @@
 
 pub mod batch;
 pub mod command;
+#[cfg(feature = "key-value-state")]
+pub mod key_value_state;
 pub mod receipt;
 pub mod transaction;


### PR DESCRIPTION
Adds the `context` module, which has the implementation for the KeyValueTransactionContext, to `contract/` behind the `contract-context` feature.

To test, run `./bin/run_tests` because the tests are dependent on all the implementations of the Addresser trait, so the tests will fail if those features are also not enabled. 