### PR TITLE
Add SmartContract trait

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -48,6 +48,7 @@ experimental = [
     "contract-address-triple-key-hash",
     "contract-context",
     "contract-context-key-value",
+    "contract-handler",
     "key-value-state",
     "redis-db",
 ]

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -60,5 +60,15 @@ contract-address-key-hash = ["contract-address"]
 contract-address-double-key-hash = ["contract-address"]
 contract-address-triple-key-hash = ["contract-address"]
 contract-context = ["contract", "contract-address"]
-contract-context-key-value = ["contract-context", "key-value-state"]
+contract-context-key-value = [
+    "contract-address-double-key-hash",
+    "contract-address-key-hash",
+    "contract-address-triple-key-hash",
+    "contract-context",
+    "key-value-state"
+]
+contract-handler = [
+    "contract-context-key-value",
+    "contract-address"
+]
 key-value-state = []

--- a/libtransact/src/contract/handler.rs
+++ b/libtransact/src/contract/handler.rs
@@ -1,0 +1,39 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::contract::SmartContract;
+use crate::handler::{ApplyError, TransactionContext, TransactionHandler};
+use crate::protocol::transaction::TransactionPair;
+
+impl<T> TransactionHandler for T
+where
+    T: SmartContract + Send,
+{
+    fn family_name(&self) -> &str {
+        self.get_family_name()
+    }
+
+    fn family_versions(&self) -> &[String] {
+        self.get_family_versions()
+    }
+
+    fn apply(
+        &self,
+        transaction: &TransactionPair,
+        context: &mut dyn TransactionContext,
+    ) -> Result<(), ApplyError> {
+        let contract_context = self.make_context(self.get_addresser(), context);
+        self.apply(transaction, contract_context)
+    }
+}

--- a/libtransact/src/contract/mod.rs
+++ b/libtransact/src/contract/mod.rs
@@ -19,3 +19,35 @@
 pub mod address;
 #[cfg(feature = "contract-context")]
 pub mod context;
+#[cfg(feature = "contract-handler")]
+pub mod handler;
+
+use std::hash::Hash;
+
+use crate::contract::address::Addresser;
+use crate::handler::{ApplyError, TransactionContext};
+use crate::protocol::transaction::TransactionPair;
+
+pub trait SmartContract: Send {
+    type Key: Eq + Hash;
+    type Addr: Addresser<Self::Key>;
+    type Context;
+
+    fn get_family_name(&self) -> &str;
+
+    fn get_family_versions(&self) -> &[String];
+
+    fn get_addresser(&self) -> Self::Addr;
+
+    fn make_context<'a>(
+        &self,
+        addresser: Self::Addr,
+        context: &'a mut dyn TransactionContext,
+    ) -> &mut Self::Context;
+
+    fn apply(
+        &self,
+        transaction: &TransactionPair,
+        context: &mut Self::Context,
+    ) -> Result<(), ApplyError>;
+}


### PR DESCRIPTION
Adds a basic trait `SmartContract` that will implement the `TransactionHandler` trait. This is necessary so that the `KeyValueTransactionContext` can be used within the `apply` method. This feature is added behind the `contract-handler` trait. 

Also makes a few minor adjustments (adding the three Addresser implementations to the `contract-context-key-value` feature in order to compile the tests in the `context::key_value` module which use all three impls)