### PR TITLE
BACKPORT - Remove redundant hex conversion

### DIFF
--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -28,7 +28,6 @@ use crate::scheduler::InvalidTransactionResult;
 use crate::scheduler::SchedulerError;
 use crate::scheduler::TransactionExecutionResult;
 
-use hex;
 use std::collections::VecDeque;
 use std::error::Error;
 use std::sync::mpsc::{Receiver, SendError, Sender};
@@ -356,10 +355,8 @@ impl SchedulerCore {
                             self.current_txn = None;
                             self.previous_context = Some(context_id);
                             self.txn_results.push(TransactionExecutionResult::Valid(
-                                self.context_lifecycle.get_transaction_receipt(
-                                    &context_id,
-                                    &hex::encode(transaction_id),
-                                )?,
+                                self.context_lifecycle
+                                    .get_transaction_receipt(&context_id, &transaction_id)?,
                             ));
                         }
                         ExecutionTaskCompletionNotification::Invalid(_context_id, result) => {


### PR DESCRIPTION
Remove the redundant hex conversion of the header signature when producing a transaction receipt. The transaction header signature is already a hex string at this point.  The API for hex::encode, as of this commit, takes a generic `AsRef<[u8]>`, which String implements.

Backport of #34 