### PR TITLE
Implement Sqlite Database backend

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,10 @@ RUN apt-get update && \
     libssl-dev \
     pkg-config \
     protobuf-compiler \
-    libzmq3-dev
+    libzmq3-dev \
+    libsqlite3-dev \
+    sqlite3
+
 
 RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init && \
     chmod +x /usr/bin/rustup-init && \

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -13,7 +13,7 @@ description = """\
 repository = "http://github.com/hyperledger/transact"
 
 [package.metadata.docs.rs]
-features = ["sawtooth-compat", "redis-db"]
+features = ["experimental"]
 
 [dependencies]
 hex = "0.3"

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -50,6 +50,7 @@ experimental = [
     "contract-context-key-value",
     "key-value-state",
     "redis-db",
+    "sqlite-db"
 ]
 sawtooth-compat = ["sawtooth-sdk"]
 ursa-compat = ["ursa"]
@@ -62,4 +63,5 @@ contract-address-triple-key-hash = ["contract-address"]
 contract-context = ["contract", "contract-address"]
 contract-context-key-value = ["contract-context", "key-value-state"]
 key-value-state = []
+sqlite-db = []
 state-merkle = ["cbor-codec"]

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -28,7 +28,10 @@ openssl = "0.10"
 uuid = { version = "0.7", features = ["v4"] }
 sawtooth-sdk = { version = "0.3", optional = true }
 ursa = { version = "0.2.0", optional = true }
+r2d2 = { version = "0.8", optional = true }
+r2d2_sqlite = { version = "0.14", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
+rusqlite = { version = "0.21.0", optional = true }
 
 [dev-dependencies]
 rand_hc = "0.1"
@@ -63,5 +66,5 @@ contract-address-triple-key-hash = ["contract-address"]
 contract-context = ["contract", "contract-address"]
 contract-context-key-value = ["contract-context", "key-value-state"]
 key-value-state = []
-sqlite-db = []
+sqlite-db = ["rusqlite", "r2d2", "r2d2_sqlite"]
 state-merkle = ["cbor-codec"]

--- a/libtransact/src/database/mod.rs
+++ b/libtransact/src/database/mod.rs
@@ -56,7 +56,7 @@ impl Clone for Box<dyn Database> {
 /// A DatabaseReader provides read access to a database instance.
 pub trait DatabaseReader {
     /// Returns the bytes stored at the given key, if found.
-    fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;
 
     /// Returns the bytes stored at the given key on a specified index, if found.
     fn index_get(&self, index: &str, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError>;

--- a/libtransact/src/database/mod.rs
+++ b/libtransact/src/database/mod.rs
@@ -34,6 +34,8 @@ pub mod error;
 pub mod lmdb;
 #[cfg(feature = "redis-db")]
 pub mod redis;
+#[cfg(feature = "sqlite-db")]
+pub mod sqlite;
 
 pub use crate::database::error::DatabaseError;
 

--- a/libtransact/src/database/sqlite.rs
+++ b/libtransact/src/database/sqlite.rs
@@ -14,3 +14,777 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::{named_params, params};
+
+use super::{
+    Database, DatabaseCursor, DatabaseError, DatabaseReader, DatabaseReaderCursor, DatabaseWriter,
+};
+
+type SqliteConnection = r2d2::PooledConnection<SqliteConnectionManager>;
+
+#[derive(Clone)]
+pub struct SqliteDatabase {
+    pool: r2d2::Pool<SqliteConnectionManager>,
+}
+
+impl SqliteDatabase {
+    pub fn new(path: &str, indexes: &[&str]) -> Result<Self, DatabaseError> {
+        let manager = SqliteConnectionManager::file(path);
+        let pool = r2d2::Pool::new(manager).map_err(|err| {
+            DatabaseError::InitError(format!(
+                "unable to create sqlite connection pool to {}: {}",
+                path, err
+            ))
+        })?;
+
+        let conn = pool.get().map_err(|err| {
+            DatabaseError::InitError(format!("unable to connect to database: {}", err))
+        })?;
+
+        let create_table = "CREATE TABLE IF NOT EXISTS transact_primary (\
+                            key BLOB PRIMARY KEY, \
+                            value BLOB NOT NULL\
+                            )";
+        conn.execute(create_table, params![]).map_err(|err| {
+            DatabaseError::InitError(format!("unable to create primary table: {}", err))
+        })?;
+
+        for index in indexes {
+            let create_index_table = format!(
+                "CREATE TABLE IF NOT EXISTS transact_index_{} (\
+                 index_key BLOB PRIMARY KEY, \
+                 value BLOB NOT NULL\
+                 )",
+                index,
+            );
+
+            conn.execute(&create_index_table, params![])
+                .map_err(|err| {
+                    DatabaseError::InitError(format!(
+                        "unable to create index {} table: {}",
+                        index, err
+                    ))
+                })?;
+        }
+
+        Ok(Self { pool })
+    }
+}
+
+impl Database for SqliteDatabase {
+    fn get_reader<'a>(&'a self) -> Result<Box<dyn DatabaseReader + 'a>, DatabaseError> {
+        let conn = self.pool.get().map_err(|err| {
+            DatabaseError::ReaderError(format!("Unable to connect to database: {}", err))
+        })?;
+
+        Ok(Box::new(SqliteDatabaseReader {
+            conn: Rc::new(RefCell::new(conn)),
+        }))
+    }
+
+    fn get_writer<'a>(&'a self) -> Result<Box<dyn DatabaseWriter + 'a>, DatabaseError> {
+        let conn = self.pool.get().map_err(|err| {
+            DatabaseError::WriterError(format!("Unable to connect to database: {}", err))
+        })?;
+
+        conn.execute_batch("BEGIN DEFERRED").map_err(|err| {
+            DatabaseError::WriterError(format!("Unable to begin read transaction: {}", err))
+        })?;
+
+        Ok(Box::new(SqliteDatabaseWriter {
+            conn: Rc::new(RefCell::new(conn)),
+        }))
+    }
+
+    fn clone_box(&self) -> Box<dyn Database> {
+        Box::new(self.clone())
+    }
+}
+
+struct SqliteDatabaseReader {
+    conn: Rc<RefCell<SqliteConnection>>,
+}
+
+impl DatabaseReader for SqliteDatabaseReader {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_get(&mut conn, key)
+    }
+
+    fn index_get(&self, index: &str, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_index_get(&mut conn, index, key)
+    }
+
+    fn cursor(&self) -> Result<DatabaseCursor, DatabaseError> {
+        let total = {
+            let mut conn = self.conn.borrow_mut();
+            execute_count(&mut conn)?
+        };
+
+        Ok(Box::new(SqliteCursor::new(
+            self.conn.clone(),
+            "SELECT key, value from transact_primary LIMIT ? OFFSET ?",
+            total,
+        )?))
+    }
+
+    fn index_cursor(&self, index: &str) -> Result<DatabaseCursor, DatabaseError> {
+        let total = {
+            let mut conn = self.conn.borrow_mut();
+            execute_index_count(&mut conn, index)?
+        };
+
+        Ok(Box::new(SqliteCursor::new(
+            self.conn.clone(),
+            &format!(
+                "SELECT index_key, value from transact_index_{} LIMIT ? OFFSET ?",
+                index
+            ),
+            total,
+        )?))
+    }
+
+    fn count(&self) -> Result<usize, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_count(&mut conn).map(|count| count as usize)
+    }
+
+    fn index_count(&self, index: &str) -> Result<usize, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_index_count(&mut conn, index).map(|count| count as usize)
+    }
+}
+
+struct SqliteDatabaseWriter {
+    conn: Rc<RefCell<SqliteConnection>>,
+}
+
+impl Drop for SqliteDatabaseWriter {
+    fn drop(&mut self) {
+        if let Err(err) = self.conn.borrow_mut().execute_batch("ROLLBACK") {
+            warn!("Unable to rollback writer transaction: {}", err);
+        }
+    }
+}
+
+impl DatabaseWriter for SqliteDatabaseWriter {
+    fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        let conn = self.conn.borrow_mut();
+        let mut stmt = conn
+            .prepare_cached("INSERT INTO transact_primary (key, value) VALUES (?, ?)")
+            .map_err(|err| DatabaseError::WriterError(format!("unable to write value: {}", err)))?;
+
+        match stmt.execute(params![key, value]) {
+            Ok(_) => Ok(()),
+            Err(ref err) if err.to_string().contains("UNIQUE constraint") => {
+                Err(DatabaseError::DuplicateEntry)
+            }
+            Err(err) => Err(DatabaseError::WriterError(format!(
+                "unable to write value: {}",
+                err
+            ))),
+        }
+    }
+
+    fn overwrite(&mut self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        let conn = self.conn.borrow_mut();
+        let mut stmt = conn
+            .prepare_cached(
+                "INSERT OR REPLACE INTO transact_primary (key, value) VALUES (:key, :value)",
+            )
+            .map_err(|err| DatabaseError::WriterError(format!("unable to write value: {}", err)))?;
+
+        stmt.execute_named(named_params! {":key": key, ":value": value})
+            .map_err(|err| DatabaseError::WriterError(format!("unable to write value: {}", err)))?;
+
+        Ok(())
+    }
+
+    fn delete(&mut self, key: &[u8]) -> Result<(), DatabaseError> {
+        let conn = self.conn.borrow_mut();
+        let mut stmt = conn
+            .prepare_cached("DELETE FROM transact_primary WHERE key = ?")
+            .map_err(|err| {
+                DatabaseError::WriterError(format!("unable to delete value: {}", err))
+            })?;
+        stmt.execute(params![key]).map_err(|err| {
+            DatabaseError::WriterError(format!("unable to delete value: {}", err))
+        })?;
+
+        Ok(())
+    }
+
+    fn index_put(&mut self, index: &str, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        let sql = format!(
+            "INSERT OR REPLACE INTO transact_index_{} (index_key, value) VALUES (:key, :value)",
+            index
+        );
+        let conn = self.conn.borrow_mut();
+        let mut stmt = conn
+            .prepare_cached(&sql)
+            .map_err(|err| DatabaseError::WriterError(format!("unable to write value: {}", err)))?;
+
+        stmt.execute_named(named_params! {":key": key, ":value": value})
+            .map_err(|err| DatabaseError::WriterError(format!("unable to write value: {}", err)))?;
+
+        Ok(())
+    }
+    fn index_delete(&mut self, index: &str, key: &[u8]) -> Result<(), DatabaseError> {
+        let sql = format!("DELETE FROM transact_index_{} WHERE index_key = ?", index);
+        let conn = self.conn.borrow_mut();
+        let mut stmt = conn.prepare_cached(&sql).map_err(|err| {
+            DatabaseError::WriterError(format!("unable to delete value: {}", err))
+        })?;
+        stmt.execute(params![key]).map_err(|err| {
+            DatabaseError::WriterError(format!("unable to delete value: {}", err))
+        })?;
+
+        Ok(())
+    }
+    fn commit(self: Box<Self>) -> Result<(), DatabaseError> {
+        let conn = self.conn.borrow_mut();
+        conn.execute_batch("COMMIT").map_err(|err| {
+            DatabaseError::WriterError(format!("Unable to commit changes: {}", err))
+        })?;
+
+        Ok(())
+    }
+    fn as_reader(&self) -> &dyn DatabaseReader {
+        self
+    }
+}
+
+impl DatabaseReader for SqliteDatabaseWriter {
+    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_get(&mut conn, key)
+    }
+
+    fn index_get(&self, index: &str, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_index_get(&mut conn, index, key)
+    }
+
+    fn cursor(&self) -> Result<DatabaseCursor, DatabaseError> {
+        unimplemented!()
+    }
+
+    fn index_cursor(&self, _index: &str) -> Result<DatabaseCursor, DatabaseError> {
+        unimplemented!()
+    }
+
+    fn count(&self) -> Result<usize, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_count(&mut conn).map(|count| count as usize)
+    }
+
+    fn index_count(&self, index: &str) -> Result<usize, DatabaseError> {
+        let mut conn = self.conn.borrow_mut();
+        execute_index_count(&mut conn, index).map(|count| count as usize)
+    }
+}
+
+const PAGE_SIZE: i64 = 100;
+
+struct SqliteCursor {
+    conn: Rc<RefCell<SqliteConnection>>,
+    sql: String,
+    start: Option<i64>,
+    total: i64,
+    cache: VecDeque<(Vec<u8>, Vec<u8>)>,
+}
+
+impl SqliteCursor {
+    fn new(
+        conn: Rc<RefCell<SqliteConnection>>,
+        prepared_stmt_sql: &str,
+        total: i64,
+    ) -> Result<Self, DatabaseError> {
+        let mut new_instance = Self {
+            conn,
+            sql: prepared_stmt_sql.into(),
+            total,
+            start: Some(0),
+            cache: VecDeque::new(),
+        };
+
+        new_instance.fill_cache()?;
+
+        Ok(new_instance)
+    }
+
+    fn fill_cache(&mut self) -> Result<(), DatabaseError> {
+        if let Some(start) = self.start.as_ref() {
+            let conn = self.conn.borrow_mut();
+
+            let mut stmt = conn.prepare_cached(&self.sql).map_err(|err| {
+                DatabaseError::ReaderError(format!(
+                    "unable to prepare statement for cursor: {}",
+                    err
+                ))
+            })?;
+
+            let value_iter = stmt
+                .query_map(params![PAGE_SIZE, start], |row| {
+                    Ok((row.get(0)?, row.get(1)?))
+                })
+                .map_err(|err| {
+                    DatabaseError::ReaderError(format!(
+                        "unable to execute query for cursor: {}",
+                        err
+                    ))
+                })?;
+
+            let new_cache: Result<VecDeque<_>, _> = value_iter.collect();
+
+            self.cache = new_cache.map_err(|err| {
+                DatabaseError::ReaderError(format!("unable to read entries: {}", err))
+            })?;
+
+            let next_start = start + PAGE_SIZE;
+            self.start = if next_start >= self.total {
+                None
+            } else {
+                Some(next_start)
+            };
+        }
+        Ok(())
+    }
+}
+
+impl Iterator for SqliteCursor {
+    type Item = (Vec<u8>, Vec<u8>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cache.is_empty() {
+            if let Err(err) = self.fill_cache() {
+                error!("Unable to fill cursor cache; aborting: {}", err);
+            }
+        }
+
+        self.cache.pop_front()
+    }
+}
+
+impl DatabaseReaderCursor for SqliteCursor {
+    fn seek_first(&mut self) -> Option<Self::Item> {
+        self.start = Some(0);
+        if let Err(err) = self.fill_cache() {
+            error!("Unable to fill cursor cache; aborting: {}", err);
+            self.cache = VecDeque::new();
+        }
+
+        self.cache.pop_front()
+    }
+
+    fn seek_last(&mut self) -> Option<Self::Item> {
+        if self.total > 0 {
+            self.start = Some(self.total - 1);
+            if let Err(err) = self.fill_cache() {
+                error!("Unable to fill cursor cache; aborting: {}", err);
+                self.cache = VecDeque::new();
+            }
+
+            self.cache.pop_front()
+        } else {
+            None
+        }
+    }
+}
+
+fn execute_get(conn: &mut SqliteConnection, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+    let mut stmt = conn
+        .prepare_cached("SELECT value FROM transact_primary WHERE key = ?")
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))?;
+
+    let mut value_iter = stmt
+        .query_map(params![key], |row| row.get(0))
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))?;
+
+    value_iter
+        .next()
+        .transpose()
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))
+}
+
+fn execute_count(conn: &mut SqliteConnection) -> Result<i64, DatabaseError> {
+    let mut stmt = conn
+        .prepare_cached("SELECT COUNT(key) FROM transact_primary")
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))?;
+
+    stmt.query_row(params![], |row| row.get(0))
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))
+}
+
+fn execute_index_get(
+    conn: &mut SqliteConnection,
+    index: &str,
+    key: &[u8],
+) -> Result<Option<Vec<u8>>, DatabaseError> {
+    let query = format!(
+        "SELECT value FROM transact_index_{} WHERE index_key = ?",
+        index
+    );
+    let mut stmt = conn
+        .prepare_cached(&query)
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))?;
+
+    let mut value_iter = stmt
+        .query_map(params![key], |row| row.get(0))
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))?;
+
+    value_iter
+        .next()
+        .transpose()
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))
+}
+
+fn execute_index_count(conn: &mut SqliteConnection, index: &str) -> Result<i64, DatabaseError> {
+    let query = format!("SELECT COUNT(index_key) FROM transact_index_{}", index);
+    let mut stmt = conn
+        .prepare_cached(&query)
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))?;
+
+    stmt.query_row(params![], |row| row.get(0))
+        .map_err(|err| DatabaseError::ReaderError(format!("unable to read value: {}", err)))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::convert::TryInto;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Asserts that there are COUNT many objects in DB.
+    fn assert_database_count(count: usize, db: &dyn Database) {
+        let reader = db.get_reader().expect("unable to get a database reader");
+
+        assert_eq!(
+            reader.count().expect("could not count database records"),
+            count,
+        );
+    }
+
+    /// Asserts that there are are COUNT many objects in DB's INDEX.
+    fn assert_index_count(index: &str, count: usize, db: &dyn Database) {
+        let reader = db.get_reader().expect("unable to get a database reader");
+
+        assert_eq!(
+            reader
+                .index_count(index)
+                .expect("unable to count index records"),
+            count,
+        );
+    }
+
+    /// Asserts that KEY is associated with VAL in DB.
+    fn assert_key_value(key: u8, val: u8, db: &dyn Database) {
+        let reader = db.get_reader().expect("unable to get a database reader");
+
+        assert_eq!(
+            reader.get(&[key]).expect("unable to get value"),
+            Some(vec![val])
+        );
+    }
+
+    /// Asserts that KEY is associated with VAL in DB's INDEX.
+    fn assert_index_key_value(index: &str, key: u8, val: u8, db: &dyn Database) {
+        let reader = db.get_reader().expect("unable to get a database reader");
+
+        assert_eq!(
+            reader
+                .index_get(index, &[key])
+                .expect("unable to get value by index"),
+            Some(vec![val])
+        );
+    }
+
+    /// Asserts that KEY is not in DB.
+    fn assert_not_in_database(key: u8, db: &dyn Database) {
+        let reader = db.get_reader().expect("unable to get a database reader");
+
+        assert!(reader.get(&[key]).expect("unable to get value").is_none());
+    }
+
+    /// Asserts that KEY is not in DB's INDEX.
+    fn assert_not_in_index(index: &str, key: u8, db: &dyn Database) {
+        let reader = db.get_reader().expect("unable to get a database reader");
+
+        assert!(reader
+            .index_get(index, &[key])
+            .expect("unable to get value by index")
+            .is_none());
+    }
+
+    #[test]
+    fn test_basic_db_operations() {
+        run_test(|db_path| {
+            let database =
+                SqliteDatabase::new(&db_path, &["a", "b"]).expect("Could not instantiate database");
+
+            assert_database_count(0, &database);
+            assert_not_in_database(3, &database);
+            assert_not_in_database(5, &database);
+
+            // Add {3: 4}
+            let mut writer = database.get_writer().expect("unable to get db writer");
+            writer.put(&[3], &[4]).expect("unable to put value");
+
+            assert_database_count(0, &database);
+            assert_not_in_database(3, &database);
+
+            writer.commit().expect("unable to commit");
+
+            assert_database_count(1, &database);
+            assert_key_value(3, 4, &database);
+
+            // Add {5: 6}
+            let mut writer = database.get_writer().expect("unable to get db writer");
+            writer.put(&[5], &[6]).expect("unable to put value");
+            writer.commit().expect("unable to commit");
+
+            assert_database_count(2, &database);
+            assert_key_value(5, 6, &database);
+            assert_key_value(3, 4, &database);
+
+            // Delete {3: 4}
+            let mut writer = database.get_writer().expect("unable to get db writer");
+            writer.delete(&[3]).expect("unable to delete value");
+
+            assert_database_count(2, &database);
+
+            writer.commit().expect("unable to commit");
+
+            assert_database_count(1, &database);
+            assert_key_value(5, 6, &database);
+            assert_not_in_database(3, &database);
+
+            // Add {55: 5} in "a"
+            assert_index_count("a", 0, &database);
+            assert_index_count("b", 0, &database);
+            assert_not_in_index("a", 5, &database);
+            assert_not_in_index("b", 5, &database);
+
+            let mut writer = database.get_writer().expect("unable to get db writer");
+            writer
+                .index_put("a", &[55], &[5])
+                .expect("unable to put in index value");
+
+            assert_index_count("a", 0, &database);
+            assert_index_count("b", 0, &database);
+            assert_not_in_index("a", 5, &database);
+            assert_not_in_index("b", 5, &database);
+
+            writer.commit().expect("unable to commit");
+
+            assert_index_count("a", 1, &database);
+            assert_index_count("b", 0, &database);
+            assert_index_key_value("a", 55, 5, &database);
+            assert_not_in_index("b", 5, &database);
+            assert_database_count(1, &database);
+            assert_key_value(5, 6, &database);
+            assert_not_in_database(3, &database);
+
+            // Delete {55: 5} in "a"
+            let mut writer = database.get_writer().expect("unable to get db writer");
+            writer
+                .index_delete("a", &[55])
+                .expect("unable to delete value by index");
+
+            assert_index_count("a", 1, &database);
+            assert_index_count("b", 0, &database);
+            assert_index_key_value("a", 55, 5, &database);
+            assert_not_in_index("b", 5, &database);
+
+            writer.commit().expect("unable to commit");
+
+            assert_index_count("a", 0, &database);
+            assert_index_count("b", 0, &database);
+            assert_not_in_index("a", 5, &database);
+            assert_not_in_index("b", 5, &database);
+            assert_database_count(1, &database);
+            assert_key_value(5, 6, &database);
+            assert_not_in_database(3, &database);
+        })
+    }
+
+    /// Tests the cursor operations from the reader and writer's perspective.
+    #[test]
+    fn test_cursor_operations() {
+        run_test(|db_path| {
+            let db =
+                SqliteDatabase::new(&db_path, &["a", "b"]).expect("Could not instantiate database");
+
+            {
+                let reader = db.get_reader().expect("unable to get a database reader");
+                let cursor = reader.cursor().expect("unable to open cursor");
+
+                assert!(cursor.collect::<Vec<_>>().is_empty());
+            }
+
+            let mut writer = db.get_writer().expect("unable to get db writer");
+            writer.put(&[1], b"hello").expect("unable to put value");
+            writer.put(&[2], b"bonjour").expect("unable to put value");
+            writer.put(&[3], b"guten tag").expect("unable to put value");
+
+            writer.commit().expect("unable to commit");
+
+            {
+                let reader = db.get_reader().expect("unable to get a database reader");
+                let cursor = reader.cursor().expect("unable to open cursor");
+
+                assert_eq!(
+                    vec![
+                        (vec![1u8], b"hello".to_vec()),
+                        (vec![2u8], b"bonjour".to_vec()),
+                        (vec![3u8], b"guten tag".to_vec()),
+                    ],
+                    cursor.collect::<Vec<_>>()
+                );
+            }
+
+            {
+                let reader = db.get_reader().expect("unable to get a database reader");
+                let mut cursor = reader.cursor().expect("unable to open cursor");
+
+                assert_eq!(Some((vec![1u8], b"hello".to_vec())), cursor.next());
+                assert_eq!(Some((vec![2u8], b"bonjour".to_vec())), cursor.next());
+
+                assert_eq!(Some((vec![1u8], b"hello".to_vec())), cursor.seek_first());
+
+                assert_eq!(Some((vec![3u8], b"guten tag".to_vec())), cursor.seek_last());
+
+                assert_eq!(None, cursor.next());
+            }
+        })
+    }
+
+    /// Tests the index cursor operations from the reader and writer's perspective.
+    #[test]
+    fn test_index_cursor_operations() {
+        run_test(|db_path| {
+            let db =
+                SqliteDatabase::new(&db_path, &["a", "b"]).expect("Could not instantiate database");
+
+            {
+                let reader = db.get_reader().expect("unable to get a database reader");
+                let cursor = reader.index_cursor("a").expect("unable to open cursor");
+
+                assert!(cursor.collect::<Vec<_>>().is_empty());
+            }
+
+            let mut writer = db.get_writer().expect("unable to get db writer");
+            writer
+                .index_put("a", &[1], b"hello")
+                .expect("unable to put value");
+            writer
+                .index_put("a", &[2], b"bonjour")
+                .expect("unable to put value");
+            writer
+                .index_put("a", &[3], b"guten tag")
+                .expect("unable to put value");
+            writer
+                .index_put("b", &[44], b"goodbye")
+                .expect("unable to put value");
+
+            writer.commit().expect("unable to commit");
+
+            {
+                let reader = db.get_reader().expect("unable to get a database reader");
+                let cursor = reader.index_cursor("a").expect("unable to open cursor");
+
+                assert_eq!(
+                    vec![
+                        (vec![1u8], b"hello".to_vec()),
+                        (vec![2u8], b"bonjour".to_vec()),
+                        (vec![3u8], b"guten tag".to_vec()),
+                    ],
+                    cursor.collect::<Vec<_>>()
+                );
+            }
+
+            {
+                let reader = db.get_reader().expect("unable to get a database reader");
+                let mut cursor = reader.index_cursor("a").expect("unable to open cursor");
+
+                assert_eq!(Some((vec![1u8], b"hello".to_vec())), cursor.next());
+                assert_eq!(Some((vec![2u8], b"bonjour".to_vec())), cursor.next());
+
+                assert_eq!(Some((vec![1u8], b"hello".to_vec())), cursor.seek_first());
+
+                assert_eq!(Some((vec![3u8], b"guten tag".to_vec())), cursor.seek_last());
+
+                assert_eq!(None, cursor.next());
+            }
+        })
+    }
+
+    #[test]
+    fn test_large_cursor() {
+        run_test(|db_path| {
+            let db =
+                SqliteDatabase::new(&db_path, &["a", "b"]).expect("Could not instantiate database");
+            let mut writer = db.get_writer().expect("unable to get db writer");
+
+            for i in 0..PAGE_SIZE * 2 {
+                let i_bytes = i.to_be_bytes();
+                writer
+                    .put(&i_bytes, b"record")
+                    .expect("unable to write record");
+            }
+
+            writer.commit().expect("unable to commit records");
+
+            let reader = db.get_reader().expect("unable to get a database reader");
+            let cursor = reader.cursor().expect("unable to open cursor");
+
+            let record_ids: Vec<i64> = cursor
+                .map(|(key, _)| {
+                    let (int_bytes, _) = key.split_at(std::mem::size_of::<i64>());
+                    i64::from_be_bytes(
+                        int_bytes
+                            .try_into()
+                            .expect("should be the correct number of bytes"),
+                    )
+                })
+                .collect();
+
+            assert_eq!(
+                (0..PAGE_SIZE * 2).into_iter().collect::<Vec<i64>>(),
+                record_ids
+            );
+        })
+    }
+
+    static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(1);
+
+    fn run_test<T>(test: T) -> ()
+    where
+        T: FnOnce(&str) -> () + std::panic::UnwindSafe,
+    {
+        let dbpath = temp_db_path();
+
+        let testpath = dbpath.clone();
+        let result = std::panic::catch_unwind(move || test(&testpath));
+
+        std::fs::remove_file(dbpath).unwrap();
+
+        assert!(result.is_ok())
+    }
+
+    fn temp_db_path() -> String {
+        let mut temp_dir = std::env::temp_dir();
+
+        let thread_id = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::SeqCst);
+        temp_dir.push(format!("sqlite-test-{:?}.db", thread_id));
+        temp_dir.to_str().unwrap().to_string()
+    }
+}

--- a/libtransact/src/database/sqlite.rs
+++ b/libtransact/src/database/sqlite.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -747,7 +747,7 @@ fn tokenize_address(address: &str) -> Box<[&str]> {
 
 /// Fetch a node by its hash
 fn get_node_by_hash(db: &dyn Database, hash: &str) -> Result<Node, StateDatabaseError> {
-    match db.get_reader()?.get(hash.as_bytes()) {
+    match db.get_reader()?.get(hash.as_bytes())? {
         Some(bytes) => Node::from_bytes(&bytes),
         None => Err(StateDatabaseError::NotFound(hash.to_string())),
     }

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -529,7 +529,10 @@ fn test_merkle_trie_pruning_parent(db: Box<dyn Database>) {
             .get_deletions()
             .to_vec()
         {
-            assert!(reader.get(&deletion).is_none());
+            assert!(reader
+                .get(&deletion)
+                .expect("Could not query for deletion")
+                .is_none());
         }
 
         assert!(reader

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1338,3 +1338,163 @@ mod redisdb {
         Ok(())
     }
 }
+
+#[cfg(feature = "sqlite-db")]
+mod sqlitedb {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use transact::{
+        database::{btree::BTreeDatabase, sqlite::SqliteDatabase},
+        state::merkle::INDEXES,
+    };
+
+    use super::*;
+
+    #[test]
+    fn merkle_trie_root_advance() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_root_advance(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_delete() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_delete(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_update() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_update(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_update_same_address_space() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_update_same_address_space(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_update_same_address_space_with_no_children() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_update_same_address_space_with_no_children(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_pruning_parent() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_pruning_parent(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_pruning_successors() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_pruning_successors(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_pruning_duplicate_leaves() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_pruning_duplicate_leaves(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_pruning_successor_duplicate_leaves() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_pruning_successor_duplicate_leaves(db);
+        })
+    }
+
+    #[test]
+    fn leaf_iteration() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_leaf_iteration(db);
+        })
+    }
+
+    /// Verifies that a state tree backed by lmdb and btree give the same root hashes
+    #[test]
+    fn sqlite_btree_comparison() {
+        run_test(|db_path| {
+            let sqlite_db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
+
+            test_same_results(sqlite_db, btree_db);
+        })
+    }
+
+    #[test]
+    fn btree_sqlite_comparison() {
+        run_test(|db_path| {
+            let sqlite_db = Box::new(
+                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
+
+            test_same_results(btree_db, sqlite_db);
+        })
+    }
+
+    fn run_test<T>(test: T) -> ()
+    where
+        T: FnOnce(&str) -> () + std::panic::UnwindSafe,
+    {
+        let dbpath = temp_db_path();
+
+        let testpath = dbpath.clone();
+        let result = std::panic::catch_unwind(move || test(&testpath));
+
+        std::fs::remove_file(dbpath).unwrap();
+
+        assert!(result.is_ok())
+    }
+    static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(1);
+
+    fn temp_db_path() -> String {
+        let mut temp_dir = std::env::temp_dir();
+
+        let thread_id = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::SeqCst);
+        temp_dir.push(format!("sqlite-test-{:?}.db", thread_id));
+        temp_dir.to_str().unwrap().to_string()
+    }
+}


### PR DESCRIPTION
This PR adds an experimental Sqlite database implementation.  

Items to be implemented for moving this feature to stable:

[ ] Allow multiple databases to target a single sqlite database file, either through schemas or namespaced tables.
[ ] Determine best default fore Memory-mapped I/O size
[ ] Autovacuuming setting.

Note:

This PR also introduces a breaking API change to the `Database` trait to have the `Database::get` return a `Result`, instead of ignoring errors. 