### PR TITLE
Add native .scar representation and loading

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -48,6 +48,7 @@ experimental = [
     "contract-address-double-key-hash",
     "contract-address-key-hash",
     "contract-address-triple-key-hash",
+    "contract-archive",
     "contract-context",
     "contract-context-key-value",
     "key-value-state",
@@ -60,6 +61,7 @@ contract-address = ["contract"]
 contract-address-key-hash = ["contract-address"]
 contract-address-double-key-hash = ["contract-address"]
 contract-address-triple-key-hash = ["contract-address"]
+contract-archive = ["contract"]
 contract-context = ["contract", "contract-address"]
 contract-context-key-value = ["contract-context", "key-value-state"]
 key-value-state = []

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -13,7 +13,9 @@ description = """\
 repository = "http://github.com/hyperledger/transact"
 
 [dependencies]
+bzip2 = { version = "0.3", optional = true }
 cbor-codec = { version = "0.7", optional = true }
+glob = { version = "0.3", optional = true }
 hex = "0.3"
 libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
@@ -26,13 +28,20 @@ rand = "0.6"
 redis = { version = "0.13.0", default-features = false, optional = true }
 rusqlite = { version = "0.21.0", optional = true }
 sawtooth-sdk = { version = "0.3", optional = true }
+semver = { version = "0.9", optional = true }
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
+serde_yaml = { version = "0.8", optional = true }
 sha2 = "0.8"
+tar = { version = "0.4", optional = true }
 ursa = { version = "0.2.0", optional = true }
 uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
 rand_hc = "0.1"
 sawtooth-xo = "0.3"
+serial_test = "0.3"
+tempdir = "0.3"
 
 [build-dependencies]
 protoc-rust = "2"
@@ -61,7 +70,7 @@ contract-address = ["contract"]
 contract-address-key-hash = ["contract-address"]
 contract-address-double-key-hash = ["contract-address"]
 contract-address-triple-key-hash = ["contract-address"]
-contract-archive = ["contract"]
+contract-archive = ["bzip2", "contract", "glob", "semver", "serde", "serde_derive", "serde_yaml", "tar"]
 contract-context = ["contract", "contract-address"]
 contract-context-key-value = ["contract-context", "key-value-state"]
 key-value-state = []

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -12,26 +12,23 @@ description = """\
 """
 repository = "http://github.com/hyperledger/transact"
 
-[package.metadata.docs.rs]
-features = ["experimental"]
-
 [dependencies]
+cbor-codec = { version = "0.7", optional = true }
 hex = "0.3"
-protobuf = "2"
-rand = "0.6"
-sha2 = "0.8"
+libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
 log = { version = "0.4", features = ["std"] }
-cbor-codec = { version = "0.7", optional = true }
-libc = ">=0.2.35"
 openssl = "0.10"
-uuid = { version = "0.7", features = ["v4"] }
-sawtooth-sdk = { version = "0.3", optional = true }
-ursa = { version = "0.2.0", optional = true }
+protobuf = "2"
 r2d2 = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.14", optional = true }
+rand = "0.6"
 redis = { version = "0.13.0", default-features = false, optional = true }
 rusqlite = { version = "0.21.0", optional = true }
+sawtooth-sdk = { version = "0.3", optional = true }
+sha2 = "0.8"
+ursa = { version = "0.2.0", optional = true }
+uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
 rand_hc = "0.1"
@@ -42,7 +39,9 @@ protoc-rust = "2"
 
 [features]
 default = ["state-merkle"]
+
 nightly = []
+
 experimental = [
     "contract",
     "contract-address",
@@ -55,9 +54,7 @@ experimental = [
     "redis-db",
     "sqlite-db"
 ]
-sawtooth-compat = ["sawtooth-sdk"]
-ursa-compat = ["ursa"]
-redis-db = ["redis"]
+
 contract = []
 contract-address = ["contract"]
 contract-address-key-hash = ["contract-address"]
@@ -66,5 +63,16 @@ contract-address-triple-key-hash = ["contract-address"]
 contract-context = ["contract", "contract-address"]
 contract-context-key-value = ["contract-context", "key-value-state"]
 key-value-state = []
+redis-db = ["redis"]
+sawtooth-compat = ["sawtooth-sdk"]
 sqlite-db = ["rusqlite", "r2d2", "r2d2_sqlite"]
 state-merkle = ["cbor-codec"]
+ursa-compat = ["ursa"]
+
+[package.metadata.docs.rs]
+features = [
+  "default",
+  "nightly",
+  "experimental",
+  "sawtooth-compat",
+]

--- a/libtransact/src/contract/archive/error.rs
+++ b/libtransact/src/contract/archive/error.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use glob::PatternError;
+use semver::ReqParseError;
+
+#[derive(Debug)]
+pub struct Error {
+    context: String,
+    source: Option<Box<dyn std::error::Error>>,
+}
+
+impl Error {
+    pub fn new(context: &str) -> Self {
+        Self {
+            context: context.into(),
+            source: None,
+        }
+    }
+
+    pub fn new_with_source(context: &str, err: Box<dyn std::error::Error>) -> Self {
+        Self {
+            context: context.into(),
+            source: Some(err),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(ref err) = self.source {
+            write!(f, "{}: {}", self.context, err)
+        } else {
+            f.write_str(&self.context)
+        }
+    }
+}
+
+impl From<PatternError> for Error {
+    fn from(err: PatternError) -> Self {
+        Self::new_with_source("invalid file pattern", err.into())
+    }
+}
+
+impl From<ReqParseError> for Error {
+    fn from(err: ReqParseError) -> Self {
+        Self::new_with_source("invalid version", err.into())
+    }
+}

--- a/libtransact/src/contract/archive/mod.rs
+++ b/libtransact/src/contract/archive/mod.rs
@@ -14,3 +14,586 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
+
+//! Enables loading smart contract archives from .scar files.
+//!
+//! A .scar file is a tar bzip2 archive that contains two required files:
+//! - A `.wasm` file that contains a WASM smart contract
+//! - A `manifest.yaml` file that contains, at a minimum:
+//!   - The contract `name`
+//!   - The contract `version`
+//!   - The contract's `input` addresses
+//!   - The contract's `output` addresses
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use transact::contract::archive::{default_scar_path, SmartContractArchive};
+//!
+//! let default_paths = default_scar_path();
+//! let archive = SmartContractArchive::from_scar_file("xo", "0.1", &default_paths[0])
+//!     .expect("failed to load .scar file");
+//! ```
+
+mod error;
+
+use std::env::{split_paths, var_os};
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use bzip2::read::BzDecoder;
+use glob::glob;
+use semver::{Version, VersionReq};
+use tar::Archive;
+
+pub use error::Error;
+
+const DEFAULT_SCAR_PATH: &str = "/usr/share/scar";
+const SCAR_PATH_ENV_VAR: &str = "SCAR_PATH";
+
+/// Load default location(s) for .scar files.
+pub fn default_scar_path() -> Vec<PathBuf> {
+    match var_os(SCAR_PATH_ENV_VAR) {
+        Some(paths) => split_paths(&paths).collect(),
+        None => vec![PathBuf::from(DEFAULT_SCAR_PATH)],
+    }
+}
+
+/// The definition of a smart contract, including the contract's associated metadata and the bytes
+/// of the smart contract itself.
+pub struct SmartContractArchive {
+    /// The raw bytes of the WASM smart contract.
+    pub contract: Vec<u8>,
+    /// The metadata associated with this smart contract.
+    pub metadata: SmartContractMetadata,
+}
+
+impl SmartContractArchive {
+    /// Attempt to load a `SmartContractArchive` from a .scar file in the given `path`.
+    ///
+    /// The .scar file to load will be named `<name>_<version>.scar`, where `<name>` is the name
+    /// specified for this method and `<version>` is a valid semver string.
+    ///
+    /// The `version` argument for this method must be a valid semver requirement string. The
+    /// latest contract (based on semver requirement rules) that matches the given name and meets
+    /// the version requirements will be loaded.
+    ///
+    /// For more info on semver: https://semver.org/
+    ///
+    /// # Example
+    ///
+    /// If there are two files `/usr/share/scar/xo_1.2.3.scar` and `/usr/share/scar/xo_1.2.4`, you
+    /// can load v1.2.4 with:
+    ///
+    /// ```no_run
+    /// use transact::contract::archive::SmartContractArchive;
+    ///
+    /// let archive = SmartContractArchive::from_scar_file("xo", "1.2", "/usr/share/scar")
+    ///     .expect("failed to load .scar file");
+    /// assert_eq!(&archive.metadata.version, "1.2.4");
+    /// ```
+    ///
+    /// To load v1.2.3 explicitly, specify the exact version:
+    ///
+    /// ```no_run
+    /// use transact::contract::archive::SmartContractArchive;
+    ///
+    /// let archive = SmartContractArchive::from_scar_file("xo", "1.2.3", "/usr/share/scar")
+    ///     .expect("failed to load .scar file");
+    /// assert_eq!(&archive.metadata.version, "1.2.3");
+    /// ```
+    pub fn from_scar_file<P: AsRef<Path>>(
+        name: &str,
+        version: &str,
+        path: P,
+    ) -> Result<SmartContractArchive, Error> {
+        let file_path = find_scar(name, version, path)?;
+
+        let scar_file = File::open(&file_path).map_err(|err| {
+            Error::new_with_source(
+                &format!("failed to open file {}", file_path.display()),
+                err.into(),
+            )
+        })?;
+        let mut archive = Archive::new(BzDecoder::new(scar_file));
+        let archive_entries = archive.entries().map_err(|err| {
+            Error::new_with_source(
+                &format!("failed to read scar file {}", file_path.display()),
+                err.into(),
+            )
+        })?;
+
+        let mut metadata = None;
+        let mut contract = None;
+
+        for entry in archive_entries {
+            let mut entry = entry.map_err(|err| {
+                Error::new_with_source(
+                    &format!(
+                        "invalid .scar file: failed to read archive entry from {}",
+                        file_path.display()
+                    ),
+                    err.into(),
+                )
+            })?;
+            let path = entry
+                .path()
+                .map_err(|err| {
+                    Error::new_with_source(
+                        &format!(
+                            "invalid .scar file: failed to get path of archive entry from {}",
+                            file_path.display()
+                        ),
+                        err.into(),
+                    )
+                })?
+                .into_owned();
+            if path_is_manifest(&path) {
+                metadata = Some(serde_yaml::from_reader(entry).map_err(|err| {
+                    Error::new_with_source(
+                        &format!(
+                            "invalid .scar file: manifest.yaml invalid in {}",
+                            file_path.display()
+                        ),
+                        err.into(),
+                    )
+                })?);
+            } else if path_is_wasm(&path) {
+                let mut contract_bytes = vec![];
+                entry.read_to_end(&mut contract_bytes).map_err(|err| {
+                    Error::new_with_source(
+                        &format!(
+                            "invalid .scar file: failed to read smart contract in {}",
+                            file_path.display()
+                        ),
+                        err.into(),
+                    )
+                })?;
+                contract = Some(contract_bytes);
+            }
+        }
+
+        let contract = contract.ok_or_else(|| {
+            Error::new(&format!(
+                "invalid scar file: smart contract not found in {}",
+                file_path.display()
+            ))
+        })?;
+        let metadata = metadata.ok_or_else(|| {
+            Error::new(&format!(
+                "invalid scar file: manifest.yaml not found in {}",
+                file_path.display()
+            ))
+        })?;
+
+        Ok(SmartContractArchive { contract, metadata })
+    }
+}
+
+/// The metadata of a smart contract archive.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SmartContractMetadata {
+    /// The name of the smart contract.
+    pub name: String,
+    /// The version of the smart contract.
+    pub version: String,
+    /// The list of input addresses used by this smart contract.
+    pub inputs: Vec<String>,
+    /// The list of output addresses used by this smart contract.
+    pub outputs: Vec<String>,
+}
+
+fn find_scar<P: AsRef<Path>>(name: &str, version: &str, path: P) -> Result<PathBuf, Error> {
+    let file_name_pattern = format!("{}_*.scar", name);
+    let file_path_pattern = path.as_ref().join(&file_name_pattern);
+    let pattern_string = file_path_pattern
+        .to_str()
+        .ok_or_else(|| Error::new("name is not valid UTF-8"))?;
+
+    let version_req = VersionReq::parse(version)?;
+
+    // Start with all .scar files that match the name
+    glob(pattern_string)?
+        // Filter out any files that can't be read
+        .filter_map(|path_res| path_res.ok())
+        // Filter out any files that don't meet the version requirements
+        .filter_map(|path| {
+            let file_stem = path.file_stem()?.to_str()?;
+            let version_str = (*file_stem.splitn(2, '_').collect::<Vec<_>>().get(1)?).to_string();
+            let version = Version::parse(&version_str).ok()?;
+            if version_req.matches(&version) {
+                Some((path, version))
+            } else {
+                None
+            }
+        })
+        // Get the file with the highest matching version
+        .max_by(|(_, x_version), (_, y_version)| x_version.cmp(y_version))
+        .map(|(path, _)| path)
+        .ok_or_else(|| {
+            Error::new(&format!(
+                "could not find contract '{}' that meets version requirement '{}' in path '{}'",
+                name,
+                version_req,
+                path.as_ref().display(),
+            ))
+        })
+}
+
+fn path_is_manifest(path: &std::path::Path) -> bool {
+    path.file_name()
+        .map(|file_name| file_name == "manifest.yaml")
+        .unwrap_or(false)
+}
+
+fn path_is_wasm(path: &std::path::Path) -> bool {
+    match path.extension() {
+        Some(extension) => extension == "wasm",
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+    use std::path::Path;
+
+    use bzip2::write::BzEncoder;
+    use bzip2::Compression;
+    use serde::Serialize;
+    use serial_test::serial;
+    use tar::Builder;
+    use tempdir::TempDir;
+
+    const MOCK_CONTRACT_BYTES: &[u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    // The tests that modify and read environment variable(s) must be run serially to prevent
+    // interference with each other. Each of these tests is annotated with `#[serial(scar_path)]`
+    // to enforce this.
+
+    /// Verify that the `default_scar_path()` method returns DEFAULT_SCAR_PATH when
+    /// SCAR_PATH_ENV_VAR is unset.
+    #[test]
+    #[serial(scar_path)]
+    fn default_scar_path_env_unset() {
+        std::env::remove_var(SCAR_PATH_ENV_VAR);
+        assert_eq!(default_scar_path(), vec![PathBuf::from(DEFAULT_SCAR_PATH)]);
+    }
+
+    /// Verify that the `default_scar_path()` method returns all paths in SCAR_PATH_ENV_VAR when it
+    /// is set.
+    #[test]
+    #[serial(scar_path)]
+    fn default_scar_path_env_set() {
+        let paths = vec!["/test/dir", "/other/dir", ".", "~/"];
+        let joined_paths = std::env::join_paths(&paths).expect("failed to join paths");
+        std::env::set_var(SCAR_PATH_ENV_VAR, joined_paths);
+
+        assert_eq!(
+            default_scar_path(),
+            paths
+                .iter()
+                .map(|path| PathBuf::from(path))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// Verify that an error is returned when no contract with the given name exists.
+    #[test]
+    fn find_scar_no_matching_name() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.0");
+
+        assert!(find_scar("nonexistent", "0.1.0", &dir).is_err());
+    }
+
+    /// Verify that an error is returned when no matching contract is found in the given path.
+    #[test]
+    fn find_scar_not_in_path() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.0");
+
+        assert!(find_scar("mock", "0.1.0", "/some/other/dir").is_err());
+    }
+
+    /// Verify that an error is returned when no contract is found with a sufficient patch version
+    /// and no pre-release tag.
+    #[test]
+    fn find_scar_insufficient_release() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.0-dev");
+
+        assert!(find_scar("mock", "0.1.0", &dir).is_err());
+    }
+
+    /// Verify that an error is returned when no contract is found with a sufficient patch version.
+    #[test]
+    fn find_scar_insufficient_patch() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.0");
+
+        assert!(find_scar("mock", "0.1.1", &dir).is_err());
+    }
+
+    /// Verify that an error is returned when no contract is found with a sufficient minor version.
+    #[test]
+    fn find_scar_insufficient_minor() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.0");
+
+        assert!(find_scar("mock", "0.2.0", &dir).is_err());
+    }
+
+    /// Verify that an error is returned when no contract is found with a sufficient major version.
+    #[test]
+    fn find_scar_insufficient_major() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.0");
+
+        assert!(find_scar("mock", "1.0.0", &dir).is_err());
+    }
+
+    /// Verify that a .scar file is correctly found when any version (`*`) is requested.
+    #[test]
+    fn find_scar_any_version() {
+        let dir = new_temp_dir();
+        let scar_path = write_mock_scar(&dir, "mock", "0.1.0");
+
+        assert_eq!(
+            find_scar("mock", "*", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that a .scar file is correctly found when the exact version is requested.
+    #[test]
+    fn find_scar_exact_version() {
+        let dir = new_temp_dir();
+        let scar_path = write_mock_scar(&dir, "mock", "0.1.2-dev");
+
+        assert_eq!(
+            find_scar("mock", "0.1.2-dev", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that a .scar file is correctly found when it meets the minimum minor version.
+    #[test]
+    fn find_scar_minimum_minor() {
+        let dir = new_temp_dir();
+        let scar_path = write_mock_scar(&dir, "mock", "0.1.2");
+
+        assert_eq!(
+            find_scar("mock", "0.1", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that a .scar file is correctly found when it meets the minimum major version.
+    #[test]
+    fn find_scar_minimum_major() {
+        let dir = new_temp_dir();
+        let scar_path = write_mock_scar(&dir, "mock", "1.2.3");
+
+        assert_eq!(
+            find_scar("mock", "1", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that the .scar file with no pre-release tag is returned rather than the same patch
+    /// version with a pre-release tag.
+    #[test]
+    fn find_scar_highest_matching_patch() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.2-dev");
+        let scar_path = write_mock_scar(&dir, "mock", "0.1.2");
+
+        assert_eq!(
+            find_scar("mock", "0.1.2", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that the .scar file with the highest patch version is returned for the specified
+    /// minor version.
+    #[test]
+    fn find_scar_highest_matching_minor() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "0.1.1");
+        let scar_path = write_mock_scar(&dir, "mock", "0.1.2");
+
+        assert_eq!(
+            find_scar("mock", "0.1", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that the .scar file with the highest minor version is returned for the specified
+    /// major version.
+    #[test]
+    fn find_scar_highest_matching_major() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "1.1.0");
+        let scar_path = write_mock_scar(&dir, "mock", "1.2.0");
+
+        assert_eq!(
+            find_scar("mock", "1", &dir).expect("failed to find .scar"),
+            scar_path
+        );
+    }
+
+    /// Verify that a valid .scar file is successfully loaded.
+    #[test]
+    fn load_scar_file_successful() {
+        let dir = new_temp_dir();
+        write_mock_scar(&dir, "mock", "1.0.0");
+
+        let scar = SmartContractArchive::from_scar_file("mock", "1.0.0", &dir)
+            .expect("failed to load .scar");
+
+        assert_eq!(scar.contract, MOCK_CONTRACT_BYTES);
+        assert_eq!(scar.metadata.name, mock_smart_contract_metadata().name);
+        assert_eq!(
+            scar.metadata.version,
+            mock_smart_contract_metadata().version
+        );
+        assert_eq!(scar.metadata.inputs, mock_smart_contract_metadata().inputs);
+        assert_eq!(
+            scar.metadata.outputs,
+            mock_smart_contract_metadata().outputs
+        );
+    }
+
+    /// Verify that an error is returned when attempting to load a .scar file that does not contain
+    /// a `manifest.yaml` file.
+    #[test]
+    fn load_scar_manifest_not_found() {
+        let dir = new_temp_dir();
+
+        let contract_file_path = write_contract(&dir);
+        write_scar_file::<&Path>(
+            dir.as_ref(),
+            "mock",
+            "1.0.0",
+            None,
+            Some(contract_file_path.as_path()),
+        );
+
+        assert!(SmartContractArchive::from_scar_file("mock", "1.0.0", &dir).is_err());
+    }
+
+    /// Verify that an error is returned when attempting to load a .scar file whose `manifest.yaml`
+    /// is invalidly formatted.
+    #[test]
+    fn load_scar_manifest_invalid() {
+        let dir = new_temp_dir();
+
+        let manifest_file_path = write_manifest(&dir, &[0x00]);
+        let contract_file_path = write_contract(&dir);
+        write_scar_file::<&Path>(
+            dir.as_ref(),
+            "mock",
+            "1.0.0",
+            Some(manifest_file_path.as_path()),
+            Some(contract_file_path.as_path()),
+        );
+
+        assert!(SmartContractArchive::from_scar_file("mock", "1.0.0", &dir).is_err());
+    }
+
+    /// Verify that an error is returned when attempting to load a .scar file that does not contain
+    /// a .wasm smart contract.
+    #[test]
+    fn load_scar_contract_not_found() {
+        let dir = new_temp_dir();
+
+        let manifest_file_path = write_manifest(&dir, &mock_smart_contract_metadata());
+        write_scar_file::<&Path>(
+            dir.as_ref(),
+            "mock",
+            "1.0.0",
+            Some(manifest_file_path.as_path()),
+            None,
+        );
+
+        assert!(SmartContractArchive::from_scar_file("mock", "1.0.0", &dir).is_err());
+    }
+
+    fn new_temp_dir() -> TempDir {
+        let thread_id = format!("{:?}", std::thread::current().id());
+        TempDir::new(&thread_id).expect("failed to create temp dir")
+    }
+
+    fn write_mock_scar<P: AsRef<Path>>(dir: P, name: &str, version: &str) -> PathBuf {
+        let manifest_file_path = write_manifest(&dir, &mock_smart_contract_metadata());
+        let contract_file_path = write_contract(&dir);
+        write_scar_file::<&Path>(
+            dir.as_ref(),
+            name,
+            version,
+            Some(manifest_file_path.as_path()),
+            Some(contract_file_path.as_path()),
+        )
+    }
+
+    fn write_manifest<P: AsRef<Path>, T: Serialize>(dir: P, manifest: &T) -> PathBuf {
+        let manifest_file_path = dir.as_ref().join("manifest.yaml");
+        let manifest_file =
+            File::create(manifest_file_path.as_path()).expect("failed to create manifest file");
+        serde_yaml::to_writer(manifest_file, manifest).expect("failed to write manifest file");
+        manifest_file_path
+    }
+
+    fn write_contract<P: AsRef<Path>>(dir: P) -> PathBuf {
+        let contract_file_path = dir.as_ref().join("mock.wasm");
+        let mut contract_file =
+            File::create(contract_file_path.as_path()).expect("failed to create contract file");
+        contract_file
+            .write_all(MOCK_CONTRACT_BYTES)
+            .expect("failed to write contract file");
+        contract_file_path
+    }
+
+    fn write_scar_file<P: AsRef<Path>>(
+        dir: P,
+        name: &str,
+        version: &str,
+        manifest_file_path: Option<P>,
+        contract_file_path: Option<P>,
+    ) -> PathBuf {
+        let scar_file_path = dir.as_ref().join(format!("{}_{}.scar", name, version));
+        let scar_file = File::create(&scar_file_path).expect("failed to create scar file");
+        let mut scar_file_builder = Builder::new(BzEncoder::new(scar_file, Compression::Default));
+
+        if let Some(manifest_file_path) = manifest_file_path {
+            scar_file_builder
+                .append_path_with_name(manifest_file_path, "manifest.yaml")
+                .expect("failed to add manifest to scar file");
+        }
+
+        if let Some(contract_file_path) = contract_file_path {
+            scar_file_builder
+                .append_path_with_name(contract_file_path, "mock.wasm")
+                .expect("failed to add contract to scar file");
+        }
+
+        scar_file_builder
+            .finish()
+            .expect("failed to write scar file");
+
+        scar_file_path
+    }
+
+    fn mock_smart_contract_metadata() -> SmartContractMetadata {
+        SmartContractMetadata {
+            name: "mock".into(),
+            version: "1.0".into(),
+            inputs: vec!["abcdef".into()],
+            outputs: vec!["012345".into()],
+        }
+    }
+}

--- a/libtransact/src/contract/archive/mod.rs
+++ b/libtransact/src/contract/archive/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Cargill Incorporated
+ * Copyright 2020 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,3 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
-
-#[cfg(feature = "contract-address")]
-pub mod address;
-#[cfg(feature = "contract-archive")]
-pub mod archive;
-#[cfg(feature = "contract-context")]
-pub mod context;

--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -134,3 +134,6 @@ pub mod workload;
 
 #[macro_use]
 extern crate log;
+#[cfg(feature = "contract-archive")]
+#[macro_use]
+extern crate serde_derive;


### PR DESCRIPTION
Introduces the `SmartContractArchive` struct, which is the native
representation of a .scar file. This struct can be loaded directly from
a .scar file on the filesystem.

Signed-off-by: Logan Seeley <seeley@bitwise.io>