### PR TITLE
Add receipt/result conversions to state changes 

### DIFF
--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -21,14 +21,14 @@
 //! execution, in order for the batch to be considered valid.  Only valid batches produce state
 //! changes.
 
-use hex;
-use protobuf::Message;
 use std::error::Error as StdError;
 use std::fmt;
 
-use crate::protos;
+use hex;
+use protobuf::Message;
+
 use crate::protos::{
-    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+    self, FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
 };
 use crate::signing;
 

--- a/libtransact/src/protocol/command.rs
+++ b/libtransact/src/protocol/command.rs
@@ -18,9 +18,8 @@
 use protobuf::Message;
 use protobuf::RepeatedField;
 
-use crate::protos;
 use crate::protos::{
-    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+    self, FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
 };
 
 #[derive(Debug)]

--- a/libtransact/src/protocol/key_value_state.rs
+++ b/libtransact/src/protocol/key_value_state.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::error::Error as StdError;
+
 use protobuf::Message;
 use protobuf::RepeatedField;
 
-use std::error::Error as StdError;
-
-use crate::protos;
 use crate::protos::{
-    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+    self, FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
 };
 
 /// Native implementation for ValueType

--- a/libtransact/src/protocol/receipt.rs
+++ b/libtransact/src/protocol/receipt.rs
@@ -14,17 +14,19 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
+
 //! The `receipts` module contains structs that supply information on the processing
 //! of `Transaction`s
-use protobuf::Message;
 
-use crate::protos;
-use crate::protos::{
-    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
-};
-use crate::state;
 use std::error::Error as StdError;
 use std::fmt;
+
+use protobuf::Message;
+
+use crate::protos::{
+    self, FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+};
+use crate::state;
 
 /// A change to be applied to state, in terms of keys and values.
 ///

--- a/libtransact/src/protocol/receipt.rs
+++ b/libtransact/src/protocol/receipt.rs
@@ -50,10 +50,9 @@ impl StateChange {
     }
 }
 
-impl Into<state::StateChange> for StateChange {
-    /// Converts this modules StateChange into state::StateChange enum
-    fn into(self) -> state::StateChange {
-        match self {
+impl From<StateChange> for state::StateChange {
+    fn from(state_change: StateChange) -> Self {
+        match state_change {
             StateChange::Set { key, value } => state::StateChange::Set { key, value },
             StateChange::Delete { key } => state::StateChange::Delete { key },
         }

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -20,18 +20,17 @@
 //! A transaction is a signed, opaque payload that acts as a fundamental operation inducing a state
 //! change via a smart contract engine.  They are executed as part of a batch.
 
-use hex;
-use protobuf::Message;
-use sha2::{Digest, Sha512};
 use std::error::Error as StdError;
 use std::fmt;
 
+use hex;
+use protobuf::Message;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
+use sha2::{Digest, Sha512};
 
-use crate::protos;
 use crate::protos::{
-    FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
+    self, FromBytes, FromNative, FromProto, IntoBytes, IntoNative, IntoProto, ProtoConversionError,
 };
 use crate::signing;
 


### PR DESCRIPTION
Adds `TryFrom` implementations for both `TransactionResult` and
`TransactionReceipt` to convert them to vectors of state changes.

Signed-off-by: Logan Seeley <seeley@bitwise.io>