### PR TITLE
Optionally Enable WAL mode in sqlite

### DIFF
--- a/libtransact/src/database/sqlite.rs
+++ b/libtransact/src/database/sqlite.rs
@@ -70,6 +70,7 @@ pub struct SqliteDatabaseBuilder {
     indexes: Vec<&'static str>,
     pool_size: Option<u32>,
     memory_map_size: i64,
+    write_ahead_log_mode: bool,
 }
 
 impl SqliteDatabaseBuilder {
@@ -80,6 +81,7 @@ impl SqliteDatabaseBuilder {
             indexes: vec![],
             pool_size: None,
             memory_map_size: DEFAULT_MMAP_SIZE,
+            write_ahead_log_mode: false,
         }
     }
 
@@ -122,6 +124,19 @@ impl SqliteDatabaseBuilder {
         self
     }
 
+    /// Enable "Write-Ahead Log" (WAL) journal mode.
+    ///
+    /// In SQLite, WAL journal mode provides considerable performance improvements in most
+    /// scenarios.  See [https://sqlite.org/wal.html](https://sqlite.org/wal.html) for more
+    /// details on this mode.
+    ///
+    /// While many of the disadvantages of this mode are unlikely to effect transact and its
+    /// use-cases, WAL mode cannot be used with a database file on a networked file system.
+    pub fn with_write_ahead_log_mode(mut self) -> Self {
+        self.write_ahead_log_mode = true;
+        self
+    }
+
     /// Constructs the database instance.
     ///
     /// # Errors
@@ -131,6 +146,7 @@ impl SqliteDatabaseBuilder {
     /// * No path provided
     /// * Unable to connect to the database.
     /// * Unable to configure the provided memory map size
+    /// * Unable to configure the WAL journal mode, if requested
     /// * Unable to create tables, as required.
     pub fn build(self) -> Result<SqliteDatabase, SqliteDatabaseError> {
         let path = self.path.ok_or_else(|| SqliteDatabaseError {
@@ -161,6 +177,14 @@ impl SqliteDatabaseBuilder {
                 context: "unable to configure memory map I/O".into(),
                 source: Some(Box::new(err)),
             })?;
+
+        if self.write_ahead_log_mode {
+            conn.pragma_update(None, "journal_mode", &String::from("WAL"))
+                .map_err(|err| SqliteDatabaseError {
+                    context: "unable to configure WAL journal mode".into(),
+                    source: Some(Box::new(err)),
+                })?;
+        }
 
         let prefix = self
             .prefix

--- a/libtransact/src/database/sqlite.rs
+++ b/libtransact/src/database/sqlite.rs
@@ -286,7 +286,7 @@ impl Database for SqliteDatabase {
         })?;
 
         conn.execute_batch("BEGIN DEFERRED").map_err(|err| {
-            DatabaseError::WriterError(format!("Unable to begin read transaction: {}", err))
+            DatabaseError::WriterError(format!("Unable to begin write transaction: {}", err))
         })?;
 
         Ok(Box::new(SqliteDatabaseWriter {

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1371,10 +1371,25 @@ mod sqlitedb {
     }
 
     #[test]
-    fn merkle_trie_update() {
+    fn merkle_trie_update_atomic_commit_rollback() {
         run_test(|db_path| {
             let db = Box::new(
                 SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_update(db);
+        })
+    }
+
+    #[test]
+    fn merkle_trie_update_with_wal_mode() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::builder()
+                    .with_path(db_path)
+                    .with_indexes(&INDEXES)
+                    .with_write_ahead_log_mode()
+                    .build()
+                    .expect("Unable to create Sqlite database"),
             );
             test_merkle_trie_update(db);
         })

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1033,7 +1033,7 @@ mod lmdb {
     }
 
     #[test]
-    fn merkle_trie_update() {
+    fn merkle_trie_update_multiple_entries() {
         run_test(|merkle_path| {
             let db = make_lmdb(&merkle_path);
             test_merkle_trie_update(db);


### PR DESCRIPTION
Add an optional setting to enable SQLite's ["Write-ahead Log" journal mode](https://sqlite.org/wal.html) (WAL). This mode adds a significant performance boost to the use of the sqlite database during the merkle trie

Without WAL enabled:
```
$ time cargo test --release --manifest-path libtransact/Cargo.toml --features sqlite-db -- state::merkle::sqlitedb::merkle_trie_update_atomic_commit_rollback
    Finished release [optimized] target(s) in 0.12s
     Running target/release/deps/transact-3a8dbec3b51972ee
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 86 filtered out
     Running target/release/deps/mod-5a9cca40d3484850
running 1 test
test state::merkle::sqlitedb::merkle_trie_update_atomic_commit_rollback ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out
   Doc-tests transact
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out
real    0m11.786s
user    0m2.664s
sys     0m4.657s
```
With WAL enabled:
```
$ time cargo test --release --manifest-path libtransact/Cargo.toml --features sqlite-db -- state::merkle::sqlitedb::merkle_trie_update_with_wal_mode
    Finished release [optimized] target(s) in 0.13s
     Running target/release/deps/transact-3a8dbec3b51972ee
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 86 filtered out
     Running target/release/deps/mod-5a9cca40d3484850
running 1 test
test state::merkle::sqlitedb::merkle_trie_update_with_wal_mode ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out
   Doc-tests transact
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out
real    0m3.994s
user    0m2.079s
sys     0m1.154s
```

For comparison, LMDB timing of the same test:
```
dongle08:transact pschwarz$ time cargo test --release --manifest-path libtransact/Cargo.toml --features sqlite-db -- state::merkle::lmdb::merkle_trie_update_multiple_entries
    Finished release [optimized] target(s) in 0.12s
     Running target/release/deps/transact-3a8dbec3b51972ee
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 86 filtered out
     Running target/release/deps/mod-5a9cca40d3484850
running 1 test
test state::merkle::lmdb::merkle_trie_update_multiple_entries ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out
   Doc-tests transact
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out
real    0m3.573s
user    0m1.645s
sys     0m1.888s
```