### PR TITLE
Add SQLite setting for pragma "synchronous"

### DIFF
--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1396,6 +1396,22 @@ mod sqlitedb {
     }
 
     #[test]
+    fn merkle_trie_update_with_sync_full_wal_mode() {
+        run_test(|db_path| {
+            let db = Box::new(
+                SqliteDatabase::builder()
+                    .with_path(db_path)
+                    .with_indexes(&INDEXES)
+                    .with_write_ahead_log_mode()
+                    .with_synchronous(transact::database::sqlite::Synchronous::Full)
+                    .build()
+                    .expect("Unable to create Sqlite database"),
+            );
+            test_merkle_trie_update(db);
+        })
+    }
+
+    #[test]
     fn merkle_trie_update_same_address_space() {
         run_test(|db_path| {
             let db = Box::new(


### PR DESCRIPTION
Add a field to the SqliteDatabaseBuilder to modify the "synchronous"
setting via PRAGMA statement.  This setting provides different
guarantees of data safety for situations such as OS crash or power loss.

Defaults to the value specified by underlying build of sqlite (this
value may differ depending on build parameters).

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>