### PR TITLE
Update r2d2_sqlite and rusqlite dependency versions

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -38,10 +38,10 @@ log = { version = "0.4", features = ["std"] }
 openssl = "0.10"
 protobuf = "2"
 r2d2 = { version = "0.8", optional = true }
-r2d2_sqlite = { version = "0.14", optional = true }
+r2d2_sqlite = { version = "0.15", optional = true }
 rand = "0.6"
 redis = { version = "0.13.0", default-features = false, optional = true }
-rusqlite = { version = "0.21.0", optional = true }
+rusqlite = { version = "0.22", optional = true }
 sawtooth-sdk = { version = "0.3", optional = true }
 semver = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
Tracks the current versions of these dependencies. The version of
r2d2_sqlite is the latest, and the version of rustqlite is the one
that works with that version of r2d2_sqlite (a mismatch is fatal).

This is not actually required currently, but probably still a good idea.