### PR TITLE
Enable nightly CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,10 @@ pipeline {
         }
     }
 
+    triggers {
+        cron(env.BRANCH_NAME == 'master' ? 'H 2 * * *' : '')
+    }
+
     options {
         timestamps()
         buildDiscarder(logRotator(daysToKeepStr: '31'))


### PR DESCRIPTION
Running nightly builds helps to catch any breaking changes in dependencies
or upstream tooling.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>