### PR TITLE
Update Sawtooth SDK version 0.3 -> 0.4

### DIFF
--- a/examples/simple_xo/Cargo.toml
+++ b/examples/simple_xo/Cargo.toml
@@ -20,8 +20,8 @@ authors = ["IBM Corp.", "Cargill Incorporated"]
 edition = "2018"
 
 [dependencies]
-transact = { version = "0.1.6", features = ["sawtooth-compat"] }
-sawtooth-xo = "0.3"
+transact = { path = "../../libtransact", features = ["sawtooth-compat"] }
+sawtooth-xo = "0.4"
 hex = "0.3"
 sha2 = "0.8"
 

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -54,7 +54,7 @@ ursa = { version = "0.2.0", optional = true }
 uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
-sawtooth-xo = "0.3"
+sawtooth-xo = "0.4"
 serial_test = "0.3"
 tempdir = "0.3"
 

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -43,7 +43,7 @@ rand = "0.6"
 rand_hc = { version = "0.1", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
 rusqlite = { version = "0.22", optional = true }
-sawtooth-sdk = { version = "0.3", optional = true }
+sawtooth-sdk = { version = "0.4", optional = true }
 semver = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -406,7 +406,7 @@ mod xo_compat_test {
         }
     }
 
-    fn create_batch(signer: &Signer, game_name: &str, payload: &str) -> BatchPair {
+    fn create_batch(signer: &dyn Signer, game_name: &str, payload: &str) -> BatchPair {
         let game_address = calculate_game_address(game_name);
         let txn_pair = TransactionBuilder::new()
             .with_batcher_public_key(signer.public_key().to_vec())


### PR DESCRIPTION
Also updates the XO example to pull in transact using a relative path rather than w/ a version number and updates the XO example for Sawtooth SDK 0.4.

Also updates one of the sawtooth unit tests to use `HashSigner` instead of just `Signer`.