### PR TITLE
Add ContextLifecycle::clone_box and `Clone` impl

### DIFF
--- a/libtransact/src/context/manager/mod.rs
+++ b/libtransact/src/context/manager/mod.rs
@@ -26,6 +26,7 @@ use crate::context::{Context, ContextId, ContextLifecycle};
 use crate::protocol::receipt::{Event, StateChange, TransactionReceipt, TransactionReceiptBuilder};
 use crate::state::Read;
 
+#[derive(Clone)]
 pub struct ContextManager {
     contexts: HashMap<ContextId, Context>,
     database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>,
@@ -59,6 +60,10 @@ impl ContextLifecycle for ContextManager {
             .with_transaction_id(transaction_id.to_string())
             .build()?;
         Ok(new_transaction_receipt)
+    }
+
+    fn clone_box(&self) -> Box<dyn ContextLifecycle> {
+        Box::new(self.clone())
     }
 }
 

--- a/libtransact/src/context/manager/sync.rs
+++ b/libtransact/src/context/manager/sync.rs
@@ -139,4 +139,8 @@ impl ContextLifecycle for ContextManager {
             .expect("Lock in get_transaction_receipt was poisoned")
             .get_transaction_receipt(context_id, transaction_id)
     }
+
+    fn clone_box(&self) -> Box<dyn ContextLifecycle> {
+        Box::new(self.clone())
+    }
 }

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -45,6 +45,16 @@ pub trait ContextLifecycle: Send {
         context_id: &ContextId,
         transaction_id: &str,
     ) -> Result<TransactionReceipt, ContextManagerError>;
+
+    /// Clone implementation for `ContextLifecycle`. The implementation of the `Clone` trait for
+    /// `Box<dyn ContextLifecycle>` calls this method.
+    fn clone_box(&self) -> Box<dyn ContextLifecycle>;
+}
+
+impl Clone for Box<dyn ContextLifecycle> {
+    fn clone(&self) -> Box<dyn ContextLifecycle> {
+        self.clone_box()
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -344,6 +344,10 @@ mod tests {
         }
 
         fn drop_context(&mut self, _context_id: ContextId) {}
+
+        fn clone_box(&self) -> Box<dyn ContextLifecycle> {
+            Box::new(self.clone())
+        }
     }
 
     /// Attempt to add a batch to the scheduler; attempt to add the batch again and verify that a


### PR DESCRIPTION
Adds the `ContextLifecycle::clone_box` trait method and provides an
implementation of the `Clone` trait for `Box<dyn ContextLifecycle>`.
This allows multiple schedulers to be created by cloning a single
context lifecycle.

Signed-off-by: Logan Seeley <seeley@bitwise.io>