### PR TITLE
Scheduler interface updates

### DIFF
--- a/libtransact/src/protocol/key_value_state.rs
+++ b/libtransact/src/protocol/key_value_state.rs
@@ -88,31 +88,31 @@ impl FromProto<protos::key_value_state::StateEntryValue> for StateEntryValue {
 impl FromNative<StateEntryValue> for protos::key_value_state::StateEntryValue {
     fn from_native(native: StateEntryValue) -> Result<Self, ProtoConversionError> {
         let mut proto = protos::key_value_state::StateEntryValue::new();
-        proto.set_key(native.key().to_string());
-        match native.value() {
+        proto.set_key(native.key);
+        match native.value {
             ValueType::Int64(value) => {
                 proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::INT64);
-                proto.set_int64_value(value.clone());
+                proto.set_int64_value(value);
             }
             ValueType::Int32(value) => {
                 proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::INT32);
-                proto.set_int32_value(value.clone());
+                proto.set_int32_value(value);
             }
             ValueType::UInt64(value) => {
                 proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::UINT64);
-                proto.set_uint64_value(value.clone());
+                proto.set_uint64_value(value);
             }
             ValueType::UInt32(value) => {
                 proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::UINT32);
-                proto.set_uint32_value(value.clone());
+                proto.set_uint32_value(value);
             }
             ValueType::String(value) => {
                 proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::STRING);
-                proto.set_string_value(value.clone());
+                proto.set_string_value(value);
             }
             ValueType::Bytes(value) => {
                 proto.set_value_type(protos::key_value_state::StateEntryValue_ValueType::BYTES);
-                proto.set_bytes_value(value.clone());
+                proto.set_bytes_value(value);
             }
         }
 

--- a/libtransact/src/sawtooth.rs
+++ b/libtransact/src/sawtooth.rs
@@ -284,8 +284,6 @@ mod xo_compat_test {
                 .expect("Unable to receive result from executor")
                 .expect("Should not have received None from the executor");
 
-            scheduler.shutdown();
-
             assert_state_changes(
                 vec![StateChange::Set {
                     key: calculate_game_address("my_game"),
@@ -357,8 +355,6 @@ mod xo_compat_test {
                 .recv()
                 .expect("Unable to receive result from executor")
                 .expect("Should not have received None from the executor");
-
-            scheduler.shutdown();
 
             assert_state_changes(
                 vec![StateChange::Set {

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -151,7 +151,7 @@ impl std::fmt::Display for SchedulerError {
 }
 
 /// Schedules batches and transactions and returns execution results.
-pub trait Scheduler {
+pub trait Scheduler: Send {
     /// Sets a callback to receive results from processing batches. The order
     /// the results are received is not guarenteed to be the same order as the
     /// batches were added with `add_batch`. If callback is called with None,

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -445,7 +445,12 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         scheduler
             .set_result_callback(Box::new(move |result| {
-                tx.send(result).expect("Failed to send result");
+                // The scheduler should be finalized/cancelled by the test that calls this method;
+                // when that happens, the scheduler will send a `None` result, but the receiver will
+                // already have been dropped.
+                if result.is_some() {
+                    tx.send(result).expect("Failed to send result");
+                }
             }))
             .expect("Failed to set result callback");
 
@@ -488,7 +493,12 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         scheduler
             .set_result_callback(Box::new(move |result| {
-                tx.send(result).expect("Failed to send result");
+                // The scheduler should be finalized/cancelled by the test that calls this method;
+                // when that happens, the scheduler will send a `None` result, but the receiver will
+                // already have been dropped.
+                if result.is_some() {
+                    tx.send(result).expect("Failed to send result");
+                }
             }))
             .expect("Failed to set result callback");
 
@@ -569,7 +579,12 @@ mod tests {
         let (tx, rx) = mpsc::channel();
         scheduler
             .set_result_callback(Box::new(move |result| {
-                tx.send(result).expect("Failed to send result");
+                // The scheduler should be finalized/cancelled by the test that calls this method;
+                // when that happens, the scheduler will send a `None` result, but the receiver will
+                // already have been dropped.
+                if result.is_some() {
+                    tx.send(result).expect("Failed to send result");
+                }
             }))
             .expect("Failed to set result callback");
 

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -194,6 +194,12 @@ pub trait Scheduler: Send {
     fn new_notifier(&mut self) -> Result<Box<dyn ExecutionTaskCompletionNotifier>, SchedulerError>;
 }
 
+/// Creates new schedulers
+pub trait SchedulerFactory {
+    /// Returns a new scheduler with the given state ID
+    fn create_scheduler(&mut self, state_id: String) -> Result<Box<dyn Scheduler>, SchedulerError>;
+}
+
 /// Allows sending a notification to the scheduler that execution of a task
 /// has completed.
 pub trait ExecutionTaskCompletionNotifier: Send {

--- a/libtransact/src/scheduler/multi/core.rs
+++ b/libtransact/src/scheduler/multi/core.rs
@@ -79,19 +79,20 @@ impl MultiSchedulerCore {
                             // If a sub-scheduler returns a None result, it has completed all of
                             // its batches
                             self.done_schedulers.insert(scheduler_index);
-                            // If all sub-schedulers are done, make sure all pending results have
-                            // been returned, then return None result to indicate MultiScheduler is
-                            // done.
+                            // If all sub-schedulers are done, return `None` result to indicate that
+                            // the MultiScheduler is also done.
                             if self.done_schedulers.len() == num_schedulers {
+                                // All pending results should have been returned if they executed
+                                // or drained if the scheduler was cancelled; if not, a subscheduler
+                                // must have failed to return an execution result.
                                 if !shared.pending_results().is_empty() {
                                     shared.error_callback()(SchedulerError::Internal(format!(
                                         "all sub-schedulers are done, but some results not \
                                          returned: {:?}",
                                         shared.pending_results(),
                                     )));
-                                } else {
-                                    shared.result_callback()(None);
                                 }
+                                shared.result_callback()(None);
                                 break;
                             }
                             continue;

--- a/libtransact/src/scheduler/multi/core.rs
+++ b/libtransact/src/scheduler/multi/core.rs
@@ -33,8 +33,6 @@ pub enum MultiSchedulerCoreMessage {
     BatchResult(usize, Option<BatchExecutionResult>),
     /// The sub-scheduler at the given index in the sub-schedulers list encountered an error
     SubSchedulerError(usize, SchedulerError),
-    /// An indicator to the `SchedulerCore` thread that it should exit its loop.
-    Shutdown,
 }
 
 pub struct MultiSchedulerCore {
@@ -167,9 +165,6 @@ impl MultiSchedulerCore {
                         "scheduler {} encountered error: {}",
                         scheduler_index, err,
                     )));
-                }
-                Ok(MultiSchedulerCoreMessage::Shutdown) => {
-                    break;
                 }
                 Err(err) => {
                     // This is expected if the other side shuts down

--- a/libtransact/src/scheduler/multi/mod.rs
+++ b/libtransact/src/scheduler/multi/mod.rs
@@ -73,7 +73,7 @@ pub struct MultiScheduler {
 impl MultiScheduler {
     /// Returns a newly created `MultiScheduler` that runs the specified sub-schedulers.
     pub fn new(
-        mut schedulers: Vec<Box<dyn Scheduler + Send>>,
+        mut schedulers: Vec<Box<dyn Scheduler>>,
         sub_scheduler_handler: &mut dyn SubSchedulerHandler,
     ) -> Result<MultiScheduler, SchedulerError> {
         let (core_tx, core_rx) = mpsc::channel();
@@ -389,7 +389,7 @@ mod tests {
     ) -> MultiScheduler {
         let sub_schedulers = sub_schedulers
             .iter()
-            .map(|sub_scheduler| sub_scheduler.clone() as Box<dyn Scheduler + Send>)
+            .map(|sub_scheduler| sub_scheduler.clone() as Box<dyn Scheduler>)
             .collect();
         MultiScheduler::new(sub_schedulers, &mut MockSubSchedulerHandler::new())
             .expect("Failed to create scheduler")
@@ -488,11 +488,9 @@ mod tests {
 
         // The first sub-scheduler doens't have a result for the batch
         let sub_schedulers = vec![
-            Box::new(MockSubScheduler::new(vec![valid_receipt.clone()]))
-                as Box<dyn Scheduler + Send>,
-            Box::new(MockSubScheduler::new(vec![valid_receipt.clone()]))
-                as Box<dyn Scheduler + Send>,
-            Box::new(MockSubScheduler::new(vec![])) as Box<dyn Scheduler + Send>,
+            Box::new(MockSubScheduler::new(vec![valid_receipt.clone()])) as Box<dyn Scheduler>,
+            Box::new(MockSubScheduler::new(vec![valid_receipt.clone()])) as Box<dyn Scheduler>,
+            Box::new(MockSubScheduler::new(vec![])) as Box<dyn Scheduler>,
         ];
         let mut sub_scheduler_handler = MockSubSchedulerHandler::new();
         let mut multi_scheduler = MultiScheduler::new(sub_schedulers, &mut sub_scheduler_handler)
@@ -551,17 +549,17 @@ mod tests {
                 valid_receipt_batch_0.clone(),
                 invalid_receipt_batch_1.clone(),
                 invalid_receipt_batch_2.clone(),
-            ])) as Box<dyn Scheduler + Send>,
+            ])) as Box<dyn Scheduler>,
             Box::new(MockSubScheduler::new(vec![
                 valid_receipt_batch_0.clone(),
                 invalid_receipt_batch_1.clone(),
                 valid_receipt_batch_2.clone(),
-            ])) as Box<dyn Scheduler + Send>,
+            ])) as Box<dyn Scheduler>,
             Box::new(MockSubScheduler::new(vec![
                 valid_receipt_batch_0.clone(),
                 invalid_receipt_batch_1.clone(),
                 valid_receipt_batch_2.clone(),
-            ])) as Box<dyn Scheduler + Send>,
+            ])) as Box<dyn Scheduler>,
         ];
 
         let mut sub_scheduler_handler = MockSubSchedulerHandler::new();

--- a/libtransact/src/scheduler/multi/shared.rs
+++ b/libtransact/src/scheduler/multi/shared.rs
@@ -35,11 +35,11 @@ pub struct MultiSchedulerShared {
     /// Tracks which sub-schedulers have returned results for the given batch pair.
     pending_results: HashMap<BatchPair, HashMap<usize, BatchExecutionResult>>,
     /// The sub-schedulers of this MultiScheduler.
-    schedulers: Vec<Box<dyn Scheduler + Send>>,
+    schedulers: Vec<Box<dyn Scheduler>>,
 }
 
 impl MultiSchedulerShared {
-    pub fn new(schedulers: Vec<Box<dyn Scheduler + Send>>) -> Self {
+    pub fn new(schedulers: Vec<Box<dyn Scheduler>>) -> Self {
         MultiSchedulerShared {
             finalized: false,
             result_callback: Box::new(default_result_callback),
@@ -122,11 +122,11 @@ impl MultiSchedulerShared {
         &mut self.pending_results
     }
 
-    pub fn schedulers(&self) -> &Vec<Box<dyn Scheduler + Send>> {
+    pub fn schedulers(&self) -> &Vec<Box<dyn Scheduler>> {
         &self.schedulers
     }
 
-    pub fn schedulers_mut(&mut self) -> &mut Vec<Box<dyn Scheduler + Send>> {
+    pub fn schedulers_mut(&mut self) -> &mut Vec<Box<dyn Scheduler>> {
         &mut self.schedulers
     }
 }


### PR DESCRIPTION
Includes the following updates to the scheduler interface:
- Requires implementations of `Scheduler` to be `Send`
- Adds the `SchedulerFactory` trait and implementations for creating generic schedulers
- Updates the `Scheduler::cancel` method to abort/return any in-progress batches and to send a notification if the scheduler is finished
- Updates schedulers to shut themselves down when they are finished