### PR TITLE
Separate task submission from Executor

### DIFF
--- a/examples/simple_xo/src/main.rs
+++ b/examples/simple_xo/src/main.rs
@@ -14,9 +14,12 @@
 // limitations under the License.
 
 use sawtooth_xo::handler::XoTransactionHandler;
-use transact::context::manager::sync::ContextManager;
-use transact::database::{btree::BTreeDatabase, Database};
-use transact::execution::{adapter::static_adapter::StaticExecutionAdapter, executor::Executor};
+use transact::context::{manager::sync::ContextManager, ContextLifecycle};
+use transact::database::btree::BTreeDatabase;
+use transact::execution::{
+    adapter::static_adapter::StaticExecutionAdapter,
+    executor::{ExecutionTaskSubmitter, Executor},
+};
 use transact::protocol::receipt::{Event, TransactionResult};
 use transact::protocol::{
     batch::{BatchBuilder, BatchPair},
@@ -33,16 +36,31 @@ use transact::state::Write;
 use sha2::{Digest, Sha512};
 use std::io;
 use std::str;
-use std::sync::{Arc, Mutex};
 
 fn main() {
     let db = Box::new(BTreeDatabase::new(&merkle::INDEXES));
     let merkle_db = MerkleRadixTree::new(db.clone(), None).unwrap();
     let merkle_state = MerkleState::new(db.clone());
-    let orig_root = merkle_db.get_merkle_root();
 
+    // create context manager using the db
+    let context_manager = ContextManager::new(Box::new(MerkleState::new(db)));
+
+    // create an executor using the context manager.
+    let mut executor = create_executor(&context_manager);
+    executor.start().expect("Unable to start executor");
+    let task_executor = executor
+        .execution_task_submitter()
+        .expect("Unable to get task executor after starting executor");
+
+    let orig_root = merkle_db.get_merkle_root();
     let signer = HashSigner::new(vec![00u8, 1, 2]);
-    let current_result = play_game(&orig_root, db.clone(), &signer, "my_game,create,");
+    let current_result = play_game(
+        &task_executor,
+        Box::new(context_manager.clone()),
+        &orig_root,
+        &signer,
+        "my_game,create,",
+    );
     let (game_address, value) = get_state_change(current_result);
 
     let state_change = ChangeSet::Set {
@@ -56,8 +74,9 @@ fn main() {
     loop {
         let next_tx = get_next_tx();
         let current_result = play_game(
+            &task_executor,
+            Box::new(context_manager.clone()),
             &state_root,
-            db.clone(),
             &signer,
             &format!("my_game,take,{}", next_tx),
         );
@@ -136,20 +155,16 @@ fn get_state_change(result: BatchExecutionResult) -> (String, Vec<u8>) {
 
 // the db should be a clone of the merkle tree
 fn play_game(
+    task_executor: &ExecutionTaskSubmitter,
+    context_lifecycle: Box<dyn ContextLifecycle>,
     state_root: &str,
-    db: Box<dyn Database>,
     signer: &dyn Signer,
     tx: &str,
 ) -> BatchExecutionResult {
     println!("Current state_root: {}", state_root);
     println!();
 
-    // create context manager using the db
-    let context_manager = ContextManager::new(Box::new(MerkleState::new(db)));
-    let executor = create_executor(&context_manager);
-    start_executor(&executor);
-
-    let mut scheduler = SerialScheduler::new(Box::new(context_manager), state_root.to_string())
+    let mut scheduler = SerialScheduler::new(context_lifecycle, state_root.to_string())
         .expect("Failed to create scheduler");
 
     // Create async channel to submit transactions and receive results
@@ -171,7 +186,7 @@ fn play_game(
         .expect("Failed to add batch");
     scheduler.finalize().expect("Failed to finalize scheduler");
 
-    run_schedule(&executor, &mut scheduler);
+    run_schedule(task_executor, &mut scheduler);
 
     result_receiver
         .recv()
@@ -179,8 +194,8 @@ fn play_game(
         .expect("Should not have received None from the executor")
 }
 
-fn create_executor(context_manager: &ContextManager) -> Arc<Mutex<Option<Executor>>> {
-    Arc::new(Mutex::new(Some(Executor::new(vec![Box::new(
+fn create_executor(context_manager: &ContextManager) -> Executor {
+    Executor::new(vec![Box::new(
         StaticExecutionAdapter::new_adapter(
             vec![Box::new(SawtoothToTransactHandlerAdapter::new(
                 XoTransactionHandler::new(),
@@ -188,17 +203,7 @@ fn create_executor(context_manager: &ContextManager) -> Arc<Mutex<Option<Executo
             context_manager.clone(),
         )
         .expect("Unable to create static execution adapter"),
-    )]))))
-}
-
-fn start_executor(executor: &Arc<Mutex<Option<Executor>>>) {
-    executor
-        .lock()
-        .expect("Should not have poisoned the lock")
-        .as_mut()
-        .expect("Should not be None")
-        .start()
-        .expect("Start should not have failed");
+    )])
 }
 
 fn create_batch(signer: &dyn Signer, game_name: &str, payload: &str) -> BatchPair {
@@ -223,16 +228,12 @@ fn create_batch(signer: &dyn Signer, game_name: &str, payload: &str) -> BatchPai
         .expect("Unable to build batch a pair")
 }
 
-fn run_schedule(executor: &Arc<Mutex<Option<Executor>>>, scheduler: &mut dyn Scheduler) {
+fn run_schedule(executor: &ExecutionTaskSubmitter, scheduler: &mut dyn Scheduler) {
     let task_iterator = scheduler
         .take_task_iterator()
         .expect("Failed to take task iterator");
     executor
-        .lock()
-        .expect("Should not have poisoned the lock")
-        .as_ref()
-        .expect("Should not be None")
-        .execute(
+        .submit(
             task_iterator,
             scheduler.new_notifier().expect("Failed to get notifier"),
         )

--- a/libtransact/src/execution/executor/error.rs
+++ b/libtransact/src/execution/executor/error.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Bitwise IO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+#[derive(Debug)]
+pub enum ExecutorError {
+    // The Executor has not been started, and so calling `execute` will return an error.
+    NotStarted,
+    // The Executor has had start called more than once.
+    AlreadyStarted(String),
+
+    ResourcesUnavailable(String),
+}
+
+impl std::error::Error for ExecutorError {}
+
+impl std::fmt::Display for ExecutorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ExecutorError::NotStarted => f.write_str("Executor not started"),
+            ExecutorError::AlreadyStarted(ref msg) => {
+                write!(f, "Executor already started: {}", msg)
+            }
+            ExecutorError::ResourcesUnavailable(ref msg) => {
+                write!(f, "Resource Unavailable: {}", msg)
+            }
+        }
+    }
+}

--- a/libtransact/src/execution/executor/mod.rs
+++ b/libtransact/src/execution/executor/mod.rs
@@ -15,6 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
+mod error;
 mod internal;
 mod reader;
 
@@ -28,6 +29,8 @@ use crate::scheduler::ExecutionTaskCompletionNotifier;
 use log::debug;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+
+pub use self::error::ExecutorError;
 
 pub struct Executor {
     readers: Arc<Mutex<HashMap<usize, ExecutionTaskReader>>>,
@@ -105,32 +108,6 @@ impl SubSchedulerHandler for Executor {
     ) -> Result<(), String> {
         self.execute(task_iterator, notifier)
             .map_err(|err| format!("{}", err))
-    }
-}
-
-#[derive(Debug)]
-pub enum ExecutorError {
-    // The Executor has not been started, and so calling `execute` will return an error.
-    NotStarted,
-    // The Executor has had start called more than once.
-    AlreadyStarted(String),
-
-    ResourcesUnavailable(String),
-}
-
-impl std::error::Error for ExecutorError {}
-
-impl std::fmt::Display for ExecutorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            ExecutorError::NotStarted => f.write_str("Executor not started"),
-            ExecutorError::AlreadyStarted(ref msg) => {
-                write!(f, "Executor already started: {}", msg)
-            }
-            ExecutorError::ResourcesUnavailable(ref msg) => {
-                write!(f, "Resource Unavailable: {}", msg)
-            }
-        }
     }
 }
 

--- a/libtransact/src/execution/executor/mod.rs
+++ b/libtransact/src/execution/executor/mod.rs
@@ -28,9 +28,10 @@ use crate::scheduler::ExecutionTask;
 use crate::scheduler::ExecutionTaskCompletionNotifier;
 use log::debug;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc::Sender, Arc, Mutex};
 
 pub use self::error::ExecutorError;
+use self::internal::ExecutorCommand;
 
 pub struct Executor {
     readers: Arc<Mutex<HashMap<usize, ExecutionTaskReader>>>,
@@ -43,32 +44,21 @@ impl Executor {
         task_iterator: Box<dyn Iterator<Item = ExecutionTask> + Send>,
         notifier: Box<dyn ExecutionTaskCompletionNotifier>,
     ) -> Result<(), ExecutorError> {
+        self.execution_task_submitter()?
+            .submit(task_iterator, notifier)
+    }
+
+    /// Returns a new ExecutionTaskSubmitter.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `ExecutorError` if the Executor has not been started.
+    pub fn execution_task_submitter(&self) -> Result<ExecutionTaskSubmitter, ExecutorError> {
         if let Some(sender) = self.executor_thread.sender() {
-            let index = self
-                .readers
-                .lock()
-                .expect("The iterator adapters map lock is poisoned")
-                .keys()
-                .max()
-                .cloned()
-                .unwrap_or(0);
-
-            let mut reader = ExecutionTaskReader::new(index);
-
-            reader
-                .start(task_iterator, notifier, sender)
-                .map_err(|err| ExecutorError::ResourcesUnavailable(err.to_string()))?;
-
-            debug!("Execute called, creating execution adapter {}", index);
-
-            let mut readers = self
-                .readers
-                .lock()
-                .expect("The iterator adapter map lock is poisoned");
-
-            readers.insert(index, reader);
-
-            Ok(())
+            Ok(ExecutionTaskSubmitter {
+                readers: Arc::clone(&self.readers),
+                sender,
+            })
         } else {
             Err(ExecutorError::NotStarted)
         }
@@ -100,13 +90,62 @@ impl Executor {
     }
 }
 
-impl SubSchedulerHandler for Executor {
+/// The interface for submitting execution tasks to the Executor.
+#[derive(Clone)]
+pub struct ExecutionTaskSubmitter {
+    sender: Sender<ExecutorCommand>,
+    readers: Arc<Mutex<HashMap<usize, ExecutionTaskReader>>>,
+}
+
+impl ExecutionTaskSubmitter {
+    /// Submits an Iterator of Execution tasks and a completion notifier to the Executor for
+    /// processing.  The iterator provided will be consumed until either it is exhausted or the
+    /// Executor is shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `ExecutorError` if the tasks cannot be successfully sent to the Executor, due to
+    /// the `Executor` being disconnected from this `ExecutionTaskSubmitter`.
+    pub fn submit(
+        &self,
+        task_iterator: Box<dyn Iterator<Item = ExecutionTask> + Send>,
+        notifier: Box<dyn ExecutionTaskCompletionNotifier>,
+    ) -> Result<(), ExecutorError> {
+        let index = self
+            .readers
+            .lock()
+            .expect("The iterator adapters map lock is poisoned")
+            .keys()
+            .max()
+            .cloned()
+            .unwrap_or(0);
+
+        let mut reader = ExecutionTaskReader::new(index);
+
+        reader
+            .start(task_iterator, notifier, self.sender.clone())
+            .map_err(|err| ExecutorError::ResourcesUnavailable(err.to_string()))?;
+
+        debug!("Execute called, creating execution adapter {}", index);
+
+        let mut readers = self
+            .readers
+            .lock()
+            .expect("The iterator adapter map lock is poisoned");
+
+        readers.insert(index, reader);
+
+        Ok(())
+    }
+}
+
+impl SubSchedulerHandler for ExecutionTaskSubmitter {
     fn pass_scheduler(
         &mut self,
         task_iterator: Box<dyn Iterator<Item = ExecutionTask> + Send>,
         notifier: Box<dyn ExecutionTaskCompletionNotifier>,
     ) -> Result<(), String> {
-        self.execute(task_iterator, notifier)
+        self.submit(task_iterator, notifier)
             .map_err(|err| format!("{}", err))
     }
 }
@@ -155,6 +194,9 @@ mod tests {
         ]);
 
         executor.start().expect("Executor did not correctly start");
+        let task_submitter = executor
+            .execution_task_submitter()
+            .expect("Unable to create a task executor.");
 
         let iterator1 = MockTaskExecutionIterator::new();
         let notifier1 = MockExecutionTaskCompletionNotifier::new();
@@ -162,12 +204,12 @@ mod tests {
         let iterator2 = MockTaskExecutionIterator::new();
         let notifier2 = MockExecutionTaskCompletionNotifier::new();
 
-        executor
-            .execute(Box::new(iterator1), Box::new(notifier1.clone()))
+        task_submitter
+            .submit(Box::new(iterator1), Box::new(notifier1.clone()))
             .expect("Start has been called so the executor can execute");
 
-        executor
-            .execute(Box::new(iterator2), Box::new(notifier2.clone()))
+        task_submitter
+            .submit(Box::new(iterator2), Box::new(notifier2.clone()))
             .expect("Start has been called so the executor can execute");
 
         adapter1.register("test1", "1.0");


### PR DESCRIPTION
Prior to this change, the `Executor` could not be shared among threads, requiring the `Executor` to be used by a single thread or guarded by an `Arc<Mutex<_>>`.

This PR separates the task submission from the API of the `Executor`.  This allows for separate threads to submit tasks iterators for processing.  

The `Executor `continues to own the `JoinHandle` for its background thread.

In addition to the above change, this PR:

- Move the error to its own module
- remove the unnecessary use of `AtomicBool` for shutting down various threads.