### PR TITLE
Fix a bug where None is never returned on SerialScheduler completion

### DIFF
--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -274,6 +274,20 @@ mod tests {
         scheduler.finalize().expect("Failed to finalize");
     }
 
+    /// Tests that a finalized serial scheduler can process two batches with a single transaction
+    /// and return None when finished
+    #[test]
+    pub fn test_serial_scheduler_flow_with_two_batches() {
+        let state_id = String::from("state0");
+        let context_lifecycle = Box::new(MockContextLifecycle::new());
+        let mut scheduler =
+            SerialScheduler::new(context_lifecycle, state_id).expect("Failed to create scheduler");
+        test_scheduler_flow_with_two_batches(&mut scheduler);
+
+        // Scheduler was finalized and all batches/transactions have "executed", so it has already
+        // shutdown
+    }
+
     /// Tests that the serial scheduler can process a batch with multiple transactions.
     #[test]
     pub fn test_serial_scheduler_flow_with_multiple_transactions() {


### PR DESCRIPTION
If the scheduler was finalized while there was still unscheduled
batches, None would not be returned. When try_schedule_next
was called, the scheduler would not be ready. Since the task
iterator was empty, next will never be true and try_schedule_next
would never be called again.

This commit checks to see if the all batches have been scheduled
and returns None if finalized before checking if the scheduler
is ready. This will allow the None to always be returned when
complete.

This commit also fixes a bug where if there are no unscheduled
batches the SerialScheduler would always shutdown, even
if not finalized.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>