### PR TITLE
Return current state root on empty changes

### DIFF
--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -307,6 +307,10 @@ impl MerkleRadixTree {
         state_changes: &[StateChange],
         is_virtual: bool,
     ) -> Result<String, StateDatabaseError> {
+        if state_changes.is_empty() {
+            return Ok(self.root_hash.clone());
+        }
+
         let mut path_map = HashMap::new();
 
         let mut deletions = HashSet::new();


### PR DESCRIPTION
In the `MerkleRadixTree::update` method, if provided an empty set of changes, it should return the current state root.  This prevents it from returning an empty, invalid state id.
