### PR TITLE
Manage task readers in executor thread

### DIFF
--- a/libtransact/src/execution/executor/internal.rs
+++ b/libtransact/src/execution/executor/internal.rs
@@ -25,7 +25,7 @@
 //                                                                                                --------- ExecutionAdapter
 //
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread::JoinHandle;
@@ -35,6 +35,8 @@ use log::warn;
 use crate::execution::adapter::{ExecutionAdapter, ExecutionAdapterError};
 use crate::execution::{ExecutionRegistry, TransactionFamily};
 use crate::scheduler::{ExecutionTask, ExecutionTaskCompletionNotifier};
+
+use super::reader::ExecutionTaskReader;
 
 /// The `TransactionPair` and `ContextId` along with where to send
 /// results.
@@ -59,6 +61,11 @@ pub enum RegistrationChange {
 pub enum ExecutorCommand {
     RegistrationChange(RegistrationChange),
     Execution(Box<ExecutionEvent>),
+    CreateReader(
+        Box<dyn Iterator<Item = ExecutionTask> + Send>,
+        Box<dyn ExecutionTaskCompletionNotifier>,
+    ),
+    ReaderDone(usize),
     Shutdown,
 }
 
@@ -180,8 +187,8 @@ impl ExecutorThread {
                 }
             }
 
-            self.sender = Some(registry_sender);
-            match self.start_thread(receiver) {
+            self.sender = Some(registry_sender.clone());
+            match self.start_thread(registry_sender, receiver) {
                 Ok(join_handle) => {
                     self.internal_thread = Some(join_handle);
                 }
@@ -282,6 +289,7 @@ impl ExecutorThread {
 
     fn start_thread(
         &self,
+        sender: ExecutorCommandSender,
         receiver: ExecutorCommandReceiver,
     ) -> Result<JoinHandle<()>, std::io::Error> {
         std::thread::Builder::new()
@@ -293,6 +301,7 @@ impl ExecutorThread {
                 > = HashMap::new();
                 let mut parked: ParkedExecutionEventsMap = HashMap::new();
                 let mut unparked = vec![];
+                let mut readers: BTreeMap<usize, ExecutionTaskReader> = BTreeMap::new();
                 loop {
                     for execution_event in unparked.drain(0..) {
                         Self::try_send_execution_event(
@@ -344,6 +353,25 @@ impl ExecutorThread {
                                 });
                         }
 
+                        Ok(ExecutorCommand::CreateReader(task_iterator, notifier)) => {
+                            let index = readers.keys().max().cloned().unwrap_or(0);
+                            let mut reader = ExecutionTaskReader::new(index);
+
+                            if let Err(err) = reader.start(task_iterator, notifier, sender.clone())
+                            {
+                                error!("Unable to start task reader: {}", err);
+                                continue;
+                            }
+
+                            readers.insert(index, reader);
+                        }
+
+                        Ok(ExecutorCommand::ReaderDone(reader_id)) => {
+                            if let Some(reader) = readers.remove(&reader_id) {
+                                reader.stop();
+                            }
+                        }
+
                         Ok(ExecutorCommand::Shutdown) => {
                             break;
                         }
@@ -355,6 +383,9 @@ impl ExecutorThread {
                 }
 
                 Self::shutdown_fanout_threads(&fanout_threads);
+                for (_, reader) in readers.into_iter() {
+                    reader.stop();
+                }
             })
     }
 
@@ -565,7 +596,7 @@ mod tests {
                         });
                     }
                 },
-                ExecutorCommand::Shutdown => panic!("Should not have called shutdown during test"),
+                _ => panic!("Should not have sent command during test"),
             }
         }
 

--- a/libtransact/src/execution/executor/internal.rs
+++ b/libtransact/src/execution/executor/internal.rs
@@ -345,7 +345,6 @@ impl ExecutorThread {
                         }
 
                         Ok(ExecutorCommand::Shutdown) => {
-                            Self::shutdown_fanout_threads(&fanout_threads);
                             break;
                         }
                         Err(err) => {
@@ -354,6 +353,8 @@ impl ExecutorThread {
                         }
                     }
                 }
+
+                Self::shutdown_fanout_threads(&fanout_threads);
             })
     }
 

--- a/libtransact/src/execution/executor/reader.rs
+++ b/libtransact/src/execution/executor/reader.rs
@@ -53,6 +53,7 @@ impl ExecutionTaskReader {
         let stop = Arc::clone(&self.stop);
 
         if self.threads.is_none() {
+            let reader_id = self.id;
             let join_handle = thread::Builder::new()
                 .name(format!("ExecutionTaskReader-{}", self.id))
                 .spawn(move || {
@@ -69,6 +70,9 @@ impl ExecutionTaskReader {
                         }
                     }
                     debug!("Completed task iterator!");
+                    if let Err(err) = internal.send(ExecutorCommand::ReaderDone(reader_id)) {
+                        warn!("Unable to send done signal: {}", err)
+                    }
                 })?;
 
             self.threads = Some(join_handle);


### PR DESCRIPTION
This change manages the task readers in the main internal thread of the Executor.  It allows the executor to fully manage the life-cycle of the task reader threads.

Prior to this change the number of readers would grow over the lifetime of the executor, without being cleaned up.

Additionally, 

- Fix an issue with the task reader indexes
- shutdown all fan-out threads when the loop exits.