### PR TITLE
Improve serial scheduler execution task iterator

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -54,6 +54,7 @@ tar = { version = "0.4", optional = true }
 uuid = { version = "0.7", features = ["v4"] }
 
 [dev-dependencies]
+rusty-fork = "0.3"
 sawtooth-xo = "0.5"
 serial_test = "0.3"
 tempdir = "0.3"

--- a/libtransact/src/scheduler/serial/core.rs
+++ b/libtransact/src/scheduler/serial/core.rs
@@ -38,6 +38,7 @@ use super::shared::Shared;
 
 /// An enum of messages which can be sent to the SchedulerCore via a
 /// `Sender<CoreMessage>`.
+#[derive(Debug)]
 pub enum CoreMessage {
     /// An indicator to the scheduler that a batch has been added.
     BatchAdded,
@@ -194,11 +195,8 @@ impl SchedulerCore {
             // be sent
             shared.result_callback()(None);
 
-            // If another execution task was requested, send `None` to indicate that there
-            // are no more tasks to execute
-            if self.next_ready {
-                self.execution_tx.send(None)?;
-            }
+            // Send a `None` execution task to indicate that there are no more tasks to execute
+            self.execution_tx.send(None)?;
 
             Ok(true)
         } else {

--- a/libtransact/src/scheduler/serial/execution.rs
+++ b/libtransact/src/scheduler/serial/execution.rs
@@ -29,11 +29,16 @@ use super::core::CoreMessage;
 pub struct SerialExecutionTaskIterator {
     tx: Sender<CoreMessage>,
     rx: Receiver<Option<ExecutionTask>>,
+    is_complete: bool,
 }
 
 impl SerialExecutionTaskIterator {
     pub fn new(tx: Sender<CoreMessage>, rx: Receiver<Option<ExecutionTask>>) -> Self {
-        SerialExecutionTaskIterator { tx, rx }
+        SerialExecutionTaskIterator {
+            tx,
+            rx,
+            is_complete: false,
+        }
     }
 }
 
@@ -42,23 +47,41 @@ impl Iterator for SerialExecutionTaskIterator {
 
     /// Return the next execution task which is available to be executed.
     fn next(&mut self) -> Option<ExecutionTask> {
+        if self.is_complete {
+            debug!(
+                "Execution task iterator already returned `None`; `next` should not be called again"
+            );
+            return None;
+        }
+
         // Send a message to the scheduler requesting the next task be sent.
         match self.tx.send(CoreMessage::Next) {
-            Ok(_) => {
-                match self.rx.recv() {
-                    Ok(task) => task,
-                    Err(_) => {
-                        // This is expected if the other side shuts down before this
-                        // end.
-                        None
-                    }
+            Ok(_) => match self.rx.recv() {
+                Ok(task) => {
+                    self.is_complete = task.is_none();
+                    task
                 }
-            }
-            Err(err) => {
-                error!(
-                    "failed to send request for next in execution task iterator: {}",
-                    err
-                );
+                Err(_) => {
+                    error!(
+                        "Failed to receive next execution task; scheduler shutdown unexpectedly"
+                    );
+                    self.is_complete = true;
+                    None
+                }
+            },
+            Err(_) => {
+                trace!("Scheduler core message receiver dropped; checking if it shutdown properly");
+                match self.rx.recv() {
+                    Ok(Some(_)) => error!(
+                        "Scheduler sent unexpected execution task before shutting down unexpectedly"
+                    ),
+                    // If `None` was sent, the scheduler had no more tasks so a shutdown is expected
+                    Ok(None) => {}
+                    _ => error!(
+                        "Failed to request next execution task; scheduler shutdown unexpectedly"
+                    ),
+                }
+                self.is_complete = true;
                 None
             }
         }
@@ -85,5 +108,287 @@ impl ExecutionTaskCompletionNotifier for SerialExecutionTaskCompletionNotifier {
 
     fn clone_box(&self) -> Box<dyn ExecutionTaskCompletionNotifier> {
         Box::new(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::{
+        mpsc::{channel, TryRecvError},
+        Arc, Mutex,
+    };
+
+    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
+    use log::{set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
+    use rusty_fork::rusty_fork_test;
+
+    use crate::context::ContextId;
+    use crate::protocol::transaction::{HashMethod, TransactionBuilder};
+
+    // This macro runs each of the tests in a separate process, which is necessary because the
+    // logger is per-process. If we ran the tests normally (which is accomplished with threads), the
+    // loggers would interfere with each other.
+    rusty_fork_test! {
+        /// Verifies that the task iterator works properly under normal conditions
+        ///
+        /// 1. Initialize the logger
+        /// 2. Initialize the channels used by the iterator
+        /// 3. Create the iterator and attempt to get two tasks in a new thread
+        /// 4. Simulate receiving the requests, send one task, and send a `None` to signal no more tasks
+        /// 5. Join the thread and verify the tasks were returned by the iterator
+        /// 6. Verify that no errors were logged
+        #[test]
+        fn task_iterator_successful() {
+            let logger = init_logger();
+
+            let (core_tx, core_rx) = channel();
+            let (task_tx, task_rx) = channel();
+
+            let join_handle = std::thread::spawn(move || {
+                let mut iter = SerialExecutionTaskIterator::new(core_tx, task_rx);
+                (iter.next(), iter.next())
+            });
+
+            recv_next(&core_rx);
+            task_tx
+                .send(Some(mock_execution_task()))
+                .expect("Failed to send execution task");
+            recv_next(&core_rx);
+            task_tx.send(None).expect("Failed to send `None`");
+
+            let (task1, task2) = join_handle.join().expect("Iterator thread panicked");
+            assert!(task1.is_some());
+            assert!(task2.is_none());
+
+            assert!(!logger.has_err());
+        }
+
+        /// Verifies that the task iterator makes a debug log and returns `None` if `next` is called
+        /// after a `None` result has already been returned.
+        ///
+        /// 1. Initialize the logger
+        /// 2. Initialize the channels used by the iterator
+        /// 3. Create the iterator and attempt to get three tasks in a new thread
+        /// 4. Simulate receiving two of the requests, send one task, and send a `None` to signal no
+        ///    more tasks
+        /// 5. Verify that a third request was not sent, because the iterator should have detected
+        ///    that `next` was called after a `None` result was received
+        /// 6. Join the thread and verify the correct tasks were returned by the iterator
+        /// 7. Verify that a debug log was made
+        #[test]
+        fn task_iterator_multiple_nones() {
+            let logger = init_logger();
+
+            let (core_tx, core_rx) = channel();
+            let (task_tx, task_rx) = channel();
+
+            let join_handle = std::thread::spawn(move || {
+                let mut iter = SerialExecutionTaskIterator::new(core_tx, task_rx);
+                (iter.next(), iter.next(), iter.next())
+            });
+
+            recv_next(&core_rx);
+            task_tx
+                .send(Some(mock_execution_task()))
+                .expect("Failed to send execution task");
+            recv_next(&core_rx);
+            task_tx.send(None).expect("Failed to send `None`");
+
+            match core_rx.try_recv() {
+                Err(TryRecvError::Empty) => {}
+                res => panic!("Expected `Err(TryRecvError::Empty)`, got {:?} instead", res),
+            }
+
+            let (task1, task2, task3) = join_handle.join().expect("Iterator thread panicked");
+            assert!(task1.is_some());
+            assert!(task2.is_none());
+            assert!(task3.is_none());
+
+            assert!(logger.has_debug());
+        }
+
+        /// Verifies that the task iterator returns `None` without logging an error if the next task
+        /// request fails to send but the scheduler sent a `None` result on shutdown.
+        ///
+        /// 1. Initialize the logger
+        /// 2. Initialize the channels used by the iterator but drop the core receiver immediately
+        /// 3. Create the iterator and attempt to get a task in a new thread
+        /// 4. Send a `None` to the task receiver to simulate proper scheduler thread shutdown
+        /// 5. Join the thread and verify the `None` was returned by the iterator
+        /// 7. Verify that no error was logged
+        #[test]
+        fn task_iterator_send_failed_but_shutdown_properly() {
+            let logger = init_logger();
+
+            let (core_tx, _) = channel();
+            let (task_tx, task_rx) = channel();
+
+            let join_handle = std::thread::spawn(move || {
+                SerialExecutionTaskIterator::new(core_tx, task_rx).next()
+            });
+
+            task_tx.send(None).expect("Failed to send `None`");
+
+            let task = join_handle.join().expect("Iterator thread panicked");
+            assert!(task.is_none());
+
+            assert!(!logger.has_err());
+        }
+
+        /// Verifies that the task iterator returns `None` and logs an error if the next task
+        /// request fails but an execution task is still received.
+        ///
+        /// 1. Initialize the logger
+        /// 2. Initialize the channels used by the iterator but drop the core receiver immediately
+        /// 3. Create the iterator and attempt to get a task in a new thread
+        /// 4. Send a task to the receiver to simulate an unexpected task
+        /// 5. Join the thread and verify `None` was returned by the iterator
+        /// 7. Verify that an error was logged
+        #[test]
+        fn task_iterator_send_failed_with_unexpected_task() {
+            let logger = init_logger();
+
+            let (core_tx, _) = channel();
+            let (task_tx, task_rx) = channel();
+
+            let join_handle = std::thread::spawn(move || {
+                SerialExecutionTaskIterator::new(core_tx, task_rx).next()
+            });
+
+            task_tx.send(Some(mock_execution_task())).expect("Failed to send task");
+
+            let task = join_handle.join().expect("Iterator thread panicked");
+            assert!(task.is_none());
+
+            assert!(logger.has_err());
+        }
+
+        /// Verifies that the task iterator returns `None` and logs an error if the next task
+        /// request fails and `None` task was never received.
+        ///
+        /// 1. Initialize the logger
+        /// 2. Initialize the channels used by the iterator but drop the core receiver and the task
+        ///    sender immediately
+        /// 3. Create the iterator and attempt to get a task in a new thread
+        /// 4. Join the thread and verify `None` was returned by the iterator
+        /// 5. Verify that an error was logged
+        #[test]
+        fn task_iterator_send_failed_no_notification() {
+            let logger = init_logger();
+
+            let (core_tx, _) = channel();
+            let (_, task_rx) = channel();
+
+            let join_handle = std::thread::spawn(move || {
+                SerialExecutionTaskIterator::new(core_tx, task_rx).next()
+            });
+
+            let task = join_handle.join().expect("Iterator thread panicked");
+            assert!(task.is_none());
+
+            assert!(logger.has_err());
+        }
+
+        /// Verifies that the task iterator returns `None` and logs an error if the next task
+        /// request succeeds but receiving the response fails.
+        ///
+        /// 1. Initialize the logger
+        /// 2. Initialize the channels used by the iterator but drop the task sender immediately
+        /// 3. Create the iterator and attempt to get a task in a new thread
+        /// 4. Join the thread and verify `None` was returned by the iterator
+        /// 5. Verify that an error was logged
+        #[test]
+        fn task_iterator_send_successful_but_receive_failed() {
+            let logger = init_logger();
+
+            let (core_tx, core_rx) = channel();
+            let (_, task_rx) = channel();
+
+            let join_handle = std::thread::spawn(move || {
+                SerialExecutionTaskIterator::new(core_tx, task_rx).next()
+            });
+
+            let task = join_handle.join().expect("Iterator thread panicked");
+            assert!(task.is_none());
+
+            assert!(logger.has_err());
+        }
+    }
+
+    fn recv_next(core_rx: &Receiver<CoreMessage>) {
+        match core_rx.recv() {
+            Ok(CoreMessage::Next) => {}
+            res => panic!("Expected `Ok(CoreMessage::Next)`, got {:?} instead", res),
+        }
+    }
+
+    fn mock_execution_task() -> ExecutionTask {
+        ExecutionTask {
+            pair: TransactionBuilder::new()
+                .with_family_name("test".into())
+                .with_family_version("0.1".into())
+                .with_inputs(vec![])
+                .with_outputs(vec![])
+                .with_payload_hash_method(HashMethod::SHA512)
+                .with_payload(vec![])
+                .build_pair(&*new_signer())
+                .expect("Failed to build txn pair"),
+            context_id: ContextId::default(),
+        }
+    }
+
+    fn new_signer() -> Box<dyn Signer> {
+        let context = Secp256k1Context::new();
+        let key = context.new_random_private_key();
+        context.new_signer(key)
+    }
+
+    fn init_logger() -> MockLogger {
+        let logger = MockLogger::default();
+        set_boxed_logger(Box::new(logger.clone())).expect("Failed to set logger");
+        set_max_level(LevelFilter::Debug);
+        logger
+    }
+
+    #[derive(Clone, Default)]
+    struct MockLogger {
+        log_levels: Arc<Mutex<Vec<Level>>>,
+    }
+
+    impl MockLogger {
+        /// Determines whether or not an error message was logged
+        pub fn has_err(&self) -> bool {
+            self.log_levels
+                .lock()
+                .expect("Failed to get log_levels lock")
+                .iter()
+                .any(|level| level == &Level::Error)
+        }
+
+        /// Determines whether or not a debug message was logged
+        pub fn has_debug(&self) -> bool {
+            self.log_levels
+                .lock()
+                .expect("Failed to get log_levels lock")
+                .iter()
+                .any(|level| level == &Level::Debug)
+        }
+    }
+
+    impl Log for MockLogger {
+        fn enabled(&self, _metadata: &Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &Record) {
+            self.log_levels
+                .lock()
+                .expect("Failed to get log_levels lock")
+                .push(record.level());
+        }
+
+        fn flush(&self) {}
     }
 }


### PR DESCRIPTION
Updates the serial scheduler's execution task iterator to always expect
a `None` result from the internal scheduler thread when the thread
shuts down. If the iterator's send or receive fail and a `None` result
is not received, the thread shutdown incorrectly, so an error is logged
by the iterator. This requires a minor change to the thread's shutdown
procedure: it now sends the `None` result even if the iterator is not
waiting for a new task.

Also logs an error and returns a `None` without requesting a new task if
the iterator has already returned `None`, since no more tasks will be
produced by the scheduler.

Signed-off-by: Logan Seeley <seeley@bitwise.io>