### PR TITLE
Fix serial scheduler task iterator tests

### DIFF
--- a/libtransact/src/scheduler/serial/execution.rs
+++ b/libtransact/src/scheduler/serial/execution.rs
@@ -303,7 +303,7 @@ mod tests {
         fn task_iterator_send_successful_but_receive_failed() {
             let logger = init_logger();
 
-            let (core_tx, core_rx) = channel();
+            let (core_tx, _core_rx) = channel();
             let (_, task_rx) = channel();
 
             let join_handle = std::thread::spawn(move || {

--- a/libtransact/src/scheduler/serial/execution.rs
+++ b/libtransact/src/scheduler/serial/execution.rs
@@ -115,10 +115,7 @@ impl ExecutionTaskCompletionNotifier for SerialExecutionTaskCompletionNotifier {
 mod tests {
     use super::*;
 
-    use std::sync::{
-        mpsc::{channel, TryRecvError},
-        Arc, Mutex,
-    };
+    use std::sync::{mpsc::channel, Arc, Mutex};
 
     use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
     use log::{set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
@@ -196,10 +193,7 @@ mod tests {
             recv_next(&core_rx);
             task_tx.send(None).expect("Failed to send `None`");
 
-            match core_rx.try_recv() {
-                Err(TryRecvError::Empty) => {}
-                res => panic!("Expected `Err(TryRecvError::Empty)`, got {:?} instead", res),
-            }
+            core_rx.try_recv().expect_err("Got an unexpected task request");
 
             let (task1, task2, task3) = join_handle.join().expect("Iterator thread panicked");
             assert!(task1.is_some());


### PR DESCRIPTION
Updates the `task_iterator_multiple_nones` test to expect any error
instead of a specific error type when verifying that a new task request
was not sent; either `TryReceiveError` variant may be returned depending
on the timing of the test, and both are fine.

Also fixes some lint.

Signed-off-by: Logan Seeley <seeley@bitwise.io>