### PR TITLE
Add state-merkle-redis-db-tests feature

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -14,4 +14,5 @@ docker-compose -f docker/compose/docker-compose.yaml run --rm transact \
    /bin/bash -c \
    "cargo test && \
     cargo test --manifest-path /project/transact/libtransact/Cargo.toml --features sawtooth-compat && \
-    cargo test --manifest-path /project/transact/libtransact/Cargo.toml --features experimental"
+    cargo test --manifest-path /project/transact/libtransact/Cargo.toml --features experimental && \
+    cargo test --manifest-path /project/transact/libtransact/Cargo.toml --features experimental,state-merkle-redis-db-tests"

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -110,6 +110,9 @@ redis-db = ["redis"]
 sawtooth-compat = ["sawtooth-sdk"]
 sqlite-db = ["rusqlite", "r2d2", "r2d2_sqlite"]
 state-merkle = ["cbor-codec"]
+# This feature must be enabled to run the merkle tests using a redis db.  It is
+# not enabled by default, due to its requirement of an external redis instance.
+state-merkle-redis-db-tests = ["redis-db", "state-merkle"]
 workload = []
 
 [package.metadata.docs.rs]

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1186,7 +1186,7 @@ mod lmdb {
     }
 }
 
-#[cfg(feature = "redis-db")]
+#[cfg(feature = "state-merkle-redis-db-tests")]
 mod redisdb {
     use std::iter;
     use std::panic;


### PR DESCRIPTION
This change removes the merkle state tests, backed by Redis from the experimental feature list and puts it behind its own feature flag, leaving only tests that do not rely on external services.  The tests still remain, but must be enabled explicitly.

The `run_tests` script has been updated appropriately, such that the redis-db tests are still run in CI.
