### PR TITLE
Set lmdb default size for 32bit platforms

### DIFF
--- a/libtransact/src/database/lmdb.rs
+++ b/libtransact/src/database/lmdb.rs
@@ -29,6 +29,12 @@ use lmdb_zero as lmdb;
 
 use crate::database::error::DatabaseError;
 
+// 32-bit architectures
+#[cfg(any(target_arch = "x86", target_arch = "arm"))]
+const DEFAULT_SIZE: usize = 1 << 30; // 1024 ** 3
+
+// Remaining architectures are assumed to be 64-bit
+#[cfg(not(any(target_arch = "x86", target_arch = "arm")))]
 const DEFAULT_SIZE: usize = 1 << 40; // 1024 ** 4
 
 #[derive(Clone)]


### PR DESCRIPTION
The existing DEFAULT_SIZE for the lmdb database's memory map is too large for 32bit platforms.  This commit adds a 32bit-usize-friendly DEFAULT_SIZE value for those platforms.
