### PR TITLE
Fix race condition in serial scheduler test

### DIFF
--- a/libtransact/src/scheduler/serial/mod.rs
+++ b/libtransact/src/scheduler/serial/mod.rs
@@ -417,12 +417,12 @@ mod tests {
             .name("Thread-test_serial_scheduler_ordering".into())
             .spawn(move || {
                 std::thread::sleep(std::time::Duration::from_secs(1));
+                // This send must occur before the next task is returned.
+                tx.send(()).expect("Failed to send");
                 first_task_notifier.notify(ExecutionTaskCompletionNotification::Valid(
                     mock_context_id(),
                     first_task_txn_id,
                 ));
-                // This send must occur before the next task is returned.
-                tx.send(()).expect("Failed to send");
             })
             .expect("Failed to spawn thread");
 


### PR DESCRIPTION
Fixes a race condition in the `test_serial_scheduler_ordering` test that
occasionally cause the test to fail. When the `tx.send` was after the
task notifier `notify` call, sometimes the message wasn't sent from the
spawned thread before the main test thread got to the `rx.try_recv`.
This caused the test to fail.

Signed-off-by: Logan Seeley <seeley@bitwise.io>