### PR TITLE
Fix deprecation warning on protobuf upgrade

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -37,7 +37,7 @@ libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
 log = { version = "0.4", features = ["std"] }
 openssl = "0.10"
-protobuf = "2"
+protobuf = "2.19"
 r2d2 = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.15", optional = true }
 rand = "0.6"

--- a/libtransact/src/protocol/batch.rs
+++ b/libtransact/src/protocol/batch.rs
@@ -103,7 +103,7 @@ impl FromNative<BatchHeader> for protos::batch::BatchHeader {
 impl FromBytes<BatchHeader> for BatchHeader {
     fn from_bytes(bytes: &[u8]) -> Result<BatchHeader, ProtoConversionError> {
         let proto: protos::batch::BatchHeader =
-            protobuf::parse_from_bytes(bytes).map_err(|err| {
+            Message::parse_from_bytes(bytes).map_err(|err| {
                 ProtoConversionError::SerializationError(format!(
                     "unable to get BatchHeader from bytes: {}",
                     err
@@ -218,7 +218,7 @@ impl FromNative<Batch> for protos::batch::Batch {
 
 impl FromBytes<Batch> for Batch {
     fn from_bytes(bytes: &[u8]) -> Result<Batch, ProtoConversionError> {
-        let proto: protos::batch::Batch = protobuf::parse_from_bytes(bytes).map_err(|err| {
+        let proto: protos::batch::Batch = Message::parse_from_bytes(bytes).map_err(|err| {
             ProtoConversionError::SerializationError(format!(
                 "unable to get Batch from bytes: {}",
                 err
@@ -268,7 +268,7 @@ impl FromNative<Vec<Batch>> for protos::batch::BatchList {
 
 impl FromBytes<Vec<Batch>> for Vec<Batch> {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        let proto: protos::batch::BatchList = protobuf::parse_from_bytes(bytes).map_err(|err| {
+        let proto: protos::batch::BatchList = Message::parse_from_bytes(bytes).map_err(|err| {
             ProtoConversionError::SerializationError(format!(
                 "unable to get BatchList from bytes: {}",
                 err
@@ -623,7 +623,7 @@ mod tests {
 
         // Deserialize the header bytes into our protobuf
         let header_proto: protos::batch::BatchHeader =
-            protobuf::parse_from_bytes(&header_bytes).unwrap();
+            Message::parse_from_bytes(&header_bytes).unwrap();
 
         // Convert to a BatchHeader
         let header: BatchHeader = header_proto.into_native().unwrap();

--- a/libtransact/src/protocol/command.rs
+++ b/libtransact/src/protocol/command.rs
@@ -69,7 +69,7 @@ impl FromNative<CommandPayload> for protos::command::CommandPayload {
 impl FromBytes<CommandPayload> for CommandPayload {
     fn from_bytes(bytes: &[u8]) -> Result<CommandPayload, ProtoConversionError> {
         let proto: protos::command::CommandPayload =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get CommandPayload from byte".to_string(),
                 )
@@ -196,7 +196,7 @@ impl FromNative<Command> for protos::command::Command {
 
 impl FromBytes<Command> for Command {
     fn from_bytes(bytes: &[u8]) -> Result<Command, ProtoConversionError> {
-        let proto: protos::command::Command = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::command::Command = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError("Unable to get Command from bytes".to_string())
         })?;
         proto.into_native()
@@ -260,7 +260,7 @@ impl FromNative<BytesEntry> for protos::command::BytesEntry {
 impl FromBytes<BytesEntry> for BytesEntry {
     fn from_bytes(bytes: &[u8]) -> Result<BytesEntry, ProtoConversionError> {
         let proto: protos::command::BytesEntry =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get BytesEntry from bytes".to_string(),
                 )
@@ -332,7 +332,7 @@ impl FromNative<SetState> for protos::command::SetState {
 
 impl FromBytes<SetState> for SetState {
     fn from_bytes(bytes: &[u8]) -> Result<SetState, ProtoConversionError> {
-        let proto: protos::command::SetState = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::command::SetState = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError(
                 "Unable to get SetState from bytes".to_string(),
             )
@@ -395,7 +395,7 @@ impl FromNative<DeleteState> for protos::command::DeleteState {
 impl FromBytes<DeleteState> for DeleteState {
     fn from_bytes(bytes: &[u8]) -> Result<DeleteState, ProtoConversionError> {
         let proto: protos::command::DeleteState =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get DeleteState from bytes".to_string(),
                 )
@@ -454,7 +454,7 @@ impl FromNative<GetState> for protos::command::GetState {
 
 impl FromBytes<GetState> for GetState {
     fn from_bytes(bytes: &[u8]) -> Result<GetState, ProtoConversionError> {
-        let proto: protos::command::GetState = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::command::GetState = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError(
                 "Unable to get GetState from bytes".to_string(),
             )
@@ -544,7 +544,7 @@ impl FromNative<AddEvent> for protos::command::AddEvent {
 
 impl FromBytes<AddEvent> for AddEvent {
     fn from_bytes(bytes: &[u8]) -> Result<AddEvent, ProtoConversionError> {
-        let proto: protos::command::AddEvent = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::command::AddEvent = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError(
                 "Unable to get AddEvent from bytes".to_string(),
             )
@@ -605,7 +605,7 @@ impl FromNative<AddReceiptData> for protos::command::AddReceiptData {
 impl FromBytes<AddReceiptData> for AddReceiptData {
     fn from_bytes(bytes: &[u8]) -> Result<AddReceiptData, ProtoConversionError> {
         let proto: protos::command::AddReceiptData =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get AddReceiptData from bytes".to_string(),
                 )
@@ -702,7 +702,7 @@ impl FromNative<Sleep> for protos::command::Sleep {
 
 impl FromBytes<Sleep> for Sleep {
     fn from_bytes(bytes: &[u8]) -> Result<Sleep, ProtoConversionError> {
-        let proto: protos::command::Sleep = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::command::Sleep = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError("Unable to get bytes from Sleep".to_string())
         })?;
         proto.into_native()
@@ -759,7 +759,7 @@ impl FromNative<ReturnInvalid> for protos::command::ReturnInvalid {
 impl FromBytes<ReturnInvalid> for ReturnInvalid {
     fn from_bytes(bytes: &[u8]) -> Result<ReturnInvalid, ProtoConversionError> {
         let proto: protos::command::ReturnInvalid =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ReturnInvalid from bytes".to_string(),
                 )
@@ -822,7 +822,7 @@ impl FromNative<ReturnInternalError> for protos::command::ReturnInternalError {
 
 impl FromBytes<ReturnInternalError> for ReturnInternalError {
     fn from_bytes(bytes: &[u8]) -> Result<ReturnInternalError, ProtoConversionError> {
-        let proto: protos::command::ReturnInternalError = protobuf::parse_from_bytes(bytes)
+        let proto: protos::command::ReturnInternalError = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get ReturnInvalid from bytes".to_string(),

--- a/libtransact/src/protocol/key_value_state.rs
+++ b/libtransact/src/protocol/key_value_state.rs
@@ -122,7 +122,7 @@ impl FromNative<StateEntryValue> for protos::key_value_state::StateEntryValue {
 
 impl FromBytes<StateEntryValue> for StateEntryValue {
     fn from_bytes(bytes: &[u8]) -> Result<StateEntryValue, ProtoConversionError> {
-        let proto: protos::key_value_state::StateEntryValue = protobuf::parse_from_bytes(bytes)
+        let proto: protos::key_value_state::StateEntryValue = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get StateEntryValue from bytes".to_string(),
@@ -260,8 +260,8 @@ impl FromNative<StateEntry> for protos::key_value_state::StateEntry {
 
 impl FromBytes<StateEntry> for StateEntry {
     fn from_bytes(bytes: &[u8]) -> Result<StateEntry, ProtoConversionError> {
-        let proto: protos::key_value_state::StateEntry = protobuf::parse_from_bytes(bytes)
-            .map_err(|_| {
+        let proto: protos::key_value_state::StateEntry =
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get StateEntry from bytes".to_string(),
                 )
@@ -399,7 +399,7 @@ impl FromNative<StateEntryList> for protos::key_value_state::StateEntryList {
 
 impl FromBytes<StateEntryList> for StateEntryList {
     fn from_bytes(bytes: &[u8]) -> Result<StateEntryList, ProtoConversionError> {
-        let proto: protos::key_value_state::StateEntryList = protobuf::parse_from_bytes(bytes)
+        let proto: protos::key_value_state::StateEntryList = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get StateEntryList from bytes".to_string(),

--- a/libtransact/src/protocol/receipt.rs
+++ b/libtransact/src/protocol/receipt.rs
@@ -227,7 +227,7 @@ impl FromNative<StateChange> for protos::transaction_receipt::StateChange {
 
 impl FromBytes<StateChange> for StateChange {
     fn from_bytes(bytes: &[u8]) -> Result<StateChange, ProtoConversionError> {
-        let proto: protos::transaction_receipt::StateChange = protobuf::parse_from_bytes(bytes)
+        let proto: protos::transaction_receipt::StateChange = Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get StateChange from bytes".to_string(),
@@ -363,7 +363,7 @@ impl FromNative<TransactionReceipt> for protos::transaction_receipt::Transaction
 impl FromBytes<TransactionReceipt> for TransactionReceipt {
     fn from_bytes(bytes: &[u8]) -> Result<TransactionReceipt, ProtoConversionError> {
         let proto: protos::transaction_receipt::TransactionReceipt =
-            protobuf::parse_from_bytes(bytes).map_err(|_| {
+            Message::parse_from_bytes(bytes).map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get TransactionReceipt from bytes".to_string(),
                 )
@@ -439,7 +439,7 @@ impl FromNative<Event> for protos::events::Event {
 
 impl FromBytes<Event> for Event {
     fn from_bytes(bytes: &[u8]) -> Result<Event, ProtoConversionError> {
-        let proto: protos::events::Event = protobuf::parse_from_bytes(bytes).map_err(|_| {
+        let proto: protos::events::Event = Message::parse_from_bytes(bytes).map_err(|_| {
             ProtoConversionError::SerializationError(
                 "Unable to get TransactionReceipt from bytes".to_string(),
             )
@@ -969,7 +969,7 @@ mod tests {
             protobuf::Message::write_to_bytes(&proto_transaction_receipt).unwrap();
 
         let proto: protos::transaction_receipt::TransactionReceipt =
-            protobuf::parse_from_bytes(&transaction_receipt_bytes).unwrap();
+            Message::parse_from_bytes(&transaction_receipt_bytes).unwrap();
 
         let transaction_receipt: TransactionReceipt = proto.into_native().unwrap();
         match transaction_receipt.transaction_result {

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -196,7 +196,7 @@ impl FromNative<TransactionHeader> for protos::transaction::TransactionHeader {
 
 impl FromBytes<TransactionHeader> for TransactionHeader {
     fn from_bytes(bytes: &[u8]) -> Result<TransactionHeader, ProtoConversionError> {
-        let proto: protos::transaction::TransactionHeader = protobuf::parse_from_bytes(bytes)
+        let proto: protos::transaction::TransactionHeader = Message::parse_from_bytes(bytes)
             .map_err(|err| {
                 ProtoConversionError::SerializationError(format!(
                     "unable to get TransactionHeader from bytes: {}",
@@ -312,7 +312,7 @@ impl FromNative<Transaction> for protos::transaction::Transaction {
 impl FromBytes<Transaction> for Transaction {
     fn from_bytes(bytes: &[u8]) -> Result<Transaction, ProtoConversionError> {
         let proto: protos::transaction::Transaction =
-            protobuf::parse_from_bytes(bytes).map_err(|err| {
+            Message::parse_from_bytes(bytes).map_err(|err| {
                 ProtoConversionError::SerializationError(format!(
                     "unable to get Transaction from bytes: {}",
                     err
@@ -814,7 +814,7 @@ mod tests {
 
         // Deserialize the header bytes into our protobuf
         let header_proto: protos::transaction::TransactionHeader =
-            protobuf::parse_from_bytes(&header_bytes).unwrap();
+            Message::parse_from_bytes(&header_bytes).unwrap();
 
         // Convert to a TransactionHeader
         let header: TransactionHeader = header_proto.into_native().unwrap();
@@ -871,7 +871,7 @@ mod tests {
 
         // Deserialize the header bytes into our protobuf
         let transaction_proto: protos::transaction::Transaction =
-            protobuf::parse_from_bytes(&transaction_bytes).unwrap();
+            Message::parse_from_bytes(&transaction_bytes).unwrap();
 
         // Convert to a Transaction
         let transaction: Transaction = transaction_proto

--- a/libtransact/src/state/merkle/change_log.rs
+++ b/libtransact/src/state/merkle/change_log.rs
@@ -99,7 +99,7 @@ impl ChangeLogEntry {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<ChangeLogEntry, StateDatabaseError> {
-        Ok(ChangeLogEntry::from_proto(protobuf::parse_from_bytes(
+        Ok(ChangeLogEntry::from_proto(Message::parse_from_bytes(
             bytes,
         )?)?)
     }
@@ -173,7 +173,7 @@ mod tests {
         let entry_bytes = protobuf::Message::write_to_bytes(&proto_entry).unwrap();
 
         let proto: protos::merkle::ChangeLogEntry =
-            protobuf::parse_from_bytes(&entry_bytes).unwrap();
+            Message::parse_from_bytes(&entry_bytes).unwrap();
 
         let change_log_entry: ChangeLogEntry = proto.into_native().unwrap();
         assert_eq!(BYTES1.to_vec(), change_log_entry.parent);


### PR DESCRIPTION
Use Message::parse_from_bytes instead of protobuf::parse_from_bytes to fix the deprecation warning.