### PR TITLE
Add a SabreContext behind an experimental sabre-compat features 

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -44,6 +44,7 @@ rand = "0.6"
 rand_hc = { version = "0.1", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
 rusqlite = { version = "0.22", optional = true }
+sabre-sdk = { version ="0.7.1", optional = true }
 sawtooth-sdk = { version = "0.5", optional = true }
 semver = { version = "0.9", optional = true }
 serde = { version = "1.0", optional = true }
@@ -103,6 +104,19 @@ experimental = [
     "workload",
 ]
 
+# stable features in support of wasm
+wasm = [
+    # The following features are stable:
+]
+
+wasm-experimental = [
+    # The experimental feature extends stable:
+    "wasm",
+    # The following features are experimental:
+    "sabre-compat",
+
+]
+
 nightly = []
 
 context = ["uuid"]
@@ -126,6 +140,7 @@ protocol-batch = ["protocol-transaction"]
 protocol-batch-builder = ["cylinder", "protocol-batch"]
 protocol-transaction = []
 protocol-transaction-builder = ["cylinder", "protocol-transaction", "protocol-batch-builder"]
+sabre-compat = ["sabre-sdk"]
 sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 state-merkle = ["cbor-codec", "log", "openssl"]

--- a/libtransact/src/handler/mod.rs
+++ b/libtransact/src/handler/mod.rs
@@ -1,6 +1,6 @@
 /*
  * Copyright 2017 Bitwise IO, Inc.
- * Copyright 2019 Cargill Incorporated
+ * Copyright 2019-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -136,9 +136,17 @@ pub mod state;
 #[cfg(feature = "workload")]
 pub mod workload;
 
+// #[macro_use]` on the `sabre-sdk` enables the sabre log macros, this however cannot be
+// enabled at the same time as the `log` crate's macros due to linker conflicts
+#[cfg(all(feature = "sabre-compat", feature = "log"))]
+compile_error!("Incompatible features enabled: 'sabre-compat' and 'log'");
+
 #[cfg(feature = "log")]
 #[macro_use]
 extern crate log;
+#[cfg(feature = "sabre-compat")]
+#[macro_use]
+extern crate sabre_sdk;
 #[cfg(feature = "contract-archive")]
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
The SabreContext will wrap the sabre_sdk::TransactionContext provided
by the Sabre smart contract apply() method required by the wasm
entrypoint function.

SabreContext will then implement transact::handler::TransactionContext
trait. This will allow the sabre_sdk::TransactionContext to be passed
to a smart contract that implements  transact::handler::TransactHandler
and also compiled into wasm.

Also includes calling macro_use on sabre_sdk if enabled to turn on logging
in the smart contracts.