### PR TITLE
Add WorkloadRunner to run BatchWorkloads

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -30,6 +30,7 @@ repository = "http://github.com/hyperledger/transact"
 [dependencies]
 bzip2 = { version = "0.3", optional = true }
 cbor-codec = { version = "0.7", optional = true }
+chrono = { version = "0.4", optional = true }
 cylinder = { version = "0.2", optional = true }
 glob = { version = "0.3", optional = true }
 hex = "0.3"
@@ -43,6 +44,7 @@ r2d2_sqlite = { version = "0.15", optional = true }
 rand = "0.6"
 rand_hc = { version = "0.1", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
+reqwest = { version = "0.10", features = ["blocking", "json"], optional = true}
 rusqlite = { version = "0.22", optional = true }
 sabre-sdk = { version ="0.7.1", optional = true }
 sawtooth-sdk = { version = "0.5", optional = true }
@@ -106,6 +108,7 @@ experimental = [
     "key-value-state",
     "protocol-sabre-exec",
     "workload",
+    "workload-runner"
 ]
 
 # stable features in support of wasm
@@ -142,7 +145,8 @@ family-smallbank-workload = [
   "family-smallbank",
   "protocol-sabre-exec",
   "yaml-rust",
-  "workload"
+  "workload",
+  "workload-runner"
 ]
 family-xo = ["handler", "rand_hc", "workload"]
 handler = ["protocol-transaction"]
@@ -160,6 +164,7 @@ state-merkle = ["cbor-codec", "log", "openssl"]
 # not enabled by default, due to its requirement of an external redis instance.
 state-merkle-redis-db-tests = ["database-redis", "state-merkle"]
 workload = []
+workload-runner = ["chrono", "reqwest", "serde", "serde_derive"]
 
 [package.metadata.docs.rs]
 features = [

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -138,7 +138,12 @@ database-sqlite = ["rusqlite", "r2d2", "r2d2_sqlite"]
 execution = ["context", "handler", "log", "protocol-transaction", "scheduler"]
 family-command = ["cylinder", "handler", "protocol-transaction-builder"]
 family-smallbank = ["handler"]
-family-smallbank-workload = ["family-smallbank", "protocol-sabre-exec", "workload"]
+family-smallbank-workload = [
+  "family-smallbank",
+  "protocol-sabre-exec",
+  "yaml-rust",
+  "workload"
+]
 family-xo = ["handler", "rand_hc", "workload"]
 handler = ["protocol-transaction"]
 key-value-state = []
@@ -154,7 +159,7 @@ state-merkle = ["cbor-codec", "log", "openssl"]
 # This feature must be enabled to run the merkle tests using a redis db.  It is
 # not enabled by default, due to its requirement of an external redis instance.
 state-merkle-redis-db-tests = ["database-redis", "state-merkle"]
-workload = ["yaml-rust"]
+workload = []
 
 [package.metadata.docs.rs]
 features = [

--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -147,6 +147,6 @@ extern crate log;
 #[cfg(feature = "sabre-compat")]
 #[macro_use]
 extern crate sabre_sdk;
-#[cfg(feature = "contract-archive")]
+#[cfg(feature = "serde_derive")]
 #[macro_use]
 extern crate serde_derive;

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -48,3 +48,38 @@ impl From<TransactionBuildError> for WorkloadError {
         WorkloadError::TransactionBuildError(err)
     }
 }
+
+#[cfg(feature = "workload-runner")]
+#[derive(Debug, PartialEq)]
+pub enum WorkloadRunnerError {
+    /// Error raised when failing to submit the batch
+    SubmitError(String),
+    TooManyRequests,
+    /// Error raised when adding workload to the runner
+    WorkloadAddError(String),
+    /// Error raised when removing workload from the runner
+    WorkloadRemoveError(String),
+}
+
+#[cfg(feature = "workload-runner")]
+impl std::error::Error for WorkloadRunnerError {}
+
+#[cfg(feature = "workload-runner")]
+impl std::fmt::Display for WorkloadRunnerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            WorkloadRunnerError::SubmitError(ref err) => {
+                write!(f, "Unable to submit batch: {}", err)
+            }
+            WorkloadRunnerError::TooManyRequests => {
+                write!(f, "Unable to submit batch because of TooManyRequests")
+            }
+            WorkloadRunnerError::WorkloadAddError(ref err) => {
+                write!(f, "Unable to add workload: {}", err)
+            }
+            WorkloadRunnerError::WorkloadRemoveError(ref err) => {
+                write!(f, "Unable to remove workload: {}", err)
+            }
+        }
+    }
+}

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2018 Bitwise IO, Inc.
+ * Copyright 2019-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
 use crate::protocol::batch::BatchBuildError;
 use crate::protocol::transaction::TransactionBuildError;
 

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -1,6 +1,6 @@
 /*
  * Copyright 2018 Bitwise IO, Inc.
- * Copyright 2019 Cargill Incorporated
+ * Copyright 2019-2021 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,20 @@
  */
 
 pub mod error;
+#[cfg(feature = "workload-runner")]
+pub mod runner;
 
 use crate::protocol::batch::BatchPair;
 use crate::protocol::transaction::TransactionPair;
 use crate::workload::error::WorkloadError;
+#[cfg(feature = "workload-runner")]
+pub use crate::workload::runner::WorkloadRunner;
 
-pub trait TransactionWorkload {
+pub trait TransactionWorkload: Send {
     fn next_transaction(&mut self) -> Result<TransactionPair, WorkloadError>;
 }
 
-pub trait BatchWorkload {
+pub trait BatchWorkload: Send {
     fn next_batch(&mut self) -> Result<BatchPair, WorkloadError>;
 }
 

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Provides a runner to submit `BatchWorkload`s
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{channel, Sender, TryRecvError};
+use std::{thread, time};
+
+use reqwest::{blocking::Client, header, StatusCode};
+
+use crate::protos::IntoBytes;
+
+use super::error::WorkloadRunnerError;
+use super::BatchWorkload;
+
+const DEFAULT_LOG_TIME_SECS: u32 = 5; // time in seconds
+
+/// Keeps track of the currenlty running workloads.
+///
+/// The `WorkloadRunner` enables running different workloads, against different targets at
+/// different rates without needing to set up multiple runners.
+#[derive(Default)]
+pub struct WorkloadRunner {
+    workloads: HashMap<String, Worker>,
+}
+
+impl WorkloadRunner {
+    /// Starts running a new workload
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - A unique ID for the workload
+    /// * `workload` - The `BatchWorkload` used to generate the batches that will be submitted
+    /// * `targets` - A list of URL for submitting the batches. The URL provided must be the full
+    ///              URL before adding `/batches` for submission
+    /// * `rate`- How many tranactions per second to submit
+    /// * `auth` - The string to be set in the Authorization header for the request
+    ///
+    /// Returns an error if a workload with that ID is already running or if the workload thread
+    /// could not be started
+    pub fn add_workload(
+        &mut self,
+        id: String,
+        workload: Box<dyn BatchWorkload>,
+        targets: Vec<String>,
+        rate: u32,
+        auth: String,
+    ) -> Result<(), WorkloadRunnerError> {
+        if self.workloads.contains_key(&id) {
+            return Err(WorkloadRunnerError::WorkloadAddError(format!(
+                "Workload already running with ID: {}",
+                id,
+            )));
+        }
+
+        let worker = WorkerBuilder::default()
+            .with_id(id.to_string())
+            .with_workload(workload)
+            .with_targets(targets)
+            .with_rate(rate)
+            .with_auth(auth)
+            .build()?;
+
+        self.workloads.insert(id, worker);
+
+        Ok(())
+    }
+
+    /// Stops running a workload
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - A unique ID for the workload that should be stopped
+    ///
+    /// Returns an error if a workload with that ID does not exist or if the workload cannot be
+    /// cleanly shutdown
+    pub fn remove_workload(&mut self, id: &str) -> Result<(), WorkloadRunnerError> {
+        if let Some(mut worker) = self.workloads.remove(id) {
+            debug!("Shutting down worker {}", worker.id);
+            if worker.sender.send(ShutdownMessage).is_err() {
+                return Err(WorkloadRunnerError::WorkloadRemoveError(format!(
+                    "Failed to send shutdown messages to {}",
+                    id,
+                )));
+            }
+
+            if let Some(thread) = worker.thread.take() {
+                if let Err(err) = thread.join() {
+                    return Err(WorkloadRunnerError::WorkloadRemoveError(format!(
+                        "Failed to cleanly join worker thread {}: {:?}",
+                        id, err,
+                    )));
+                }
+            }
+        } else {
+            return Err(WorkloadRunnerError::WorkloadRemoveError(format!(
+                "Workload with ID {} does not exist",
+                id,
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Shutsdown all running workloads
+    pub fn shutdown(self) {
+        for (_, worker) in self.workloads.iter() {
+            if worker.sender.send(ShutdownMessage).is_err() {
+                warn!("Failed to send shutdown messages to {}", worker.id);
+            }
+        }
+
+        for (_, mut worker) in &mut self.workloads.into_iter() {
+            debug!("Shutting down worker {}", worker.id);
+            if let Some(thread) = worker.thread.take() {
+                if let Err(_err) = thread.join() {
+                    warn!("Failed to cleanly join worker thread {}", worker.id);
+                }
+            }
+        }
+    }
+}
+
+/// Sent to a workload to signal it should stop
+struct ShutdownMessage;
+
+/// Represents a running workload
+struct Worker {
+    id: String,
+    thread: Option<thread::JoinHandle<()>>,
+    sender: Sender<ShutdownMessage>,
+}
+
+#[derive(Default)]
+struct WorkerBuilder {
+    id: Option<String>,
+    workload: Option<Box<dyn BatchWorkload>>,
+    targets: Option<Vec<String>>,
+    rate: Option<u32>,
+    auth: Option<String>,
+}
+
+impl WorkerBuilder {
+    /// Sets the ID of the worker
+    ///
+    /// # Arguments
+    ///
+    ///  * `id` - The unique ID of the worker
+    pub fn with_id(mut self, id: String) -> WorkerBuilder {
+        self.id = Some(id);
+        self
+    }
+
+    /// Sets the workload that will be run against the targets
+    ///
+    /// # Arguments
+    ///
+    ///  * `workload` - The workload that will return batches to submit
+    pub fn with_workload(mut self, workload: Box<dyn BatchWorkload>) -> WorkerBuilder {
+        self.workload = Some(workload);
+        self
+    }
+
+    /// Sets the targets for the worker
+    ///
+    /// # Arguments
+    ///
+    ///  * `targets` - A list of URL for submitting the batches. The URL provided must be the full
+    ///               URL before adding `/batches` for submission
+    pub fn with_targets(mut self, targets: Vec<String>) -> WorkerBuilder {
+        self.targets = Some(targets);
+        self
+    }
+
+    /// Sets the rate for the worker
+    ///
+    /// # Arguments
+    ///
+    ///  * `rate` - How many batches to submit per second
+    pub fn with_rate(mut self, rate: u32) -> WorkerBuilder {
+        self.rate = Some(rate);
+        self
+    }
+
+    /// Sets the auth for the worker
+    ///
+    /// # Arguments
+    ///
+    ///  * `auth` - The auth string to set against the Authorization header for the http request
+    pub fn with_auth(mut self, auth: String) -> WorkerBuilder {
+        self.auth = Some(auth);
+        self
+    }
+
+    pub fn build(self) -> Result<Worker, WorkloadRunnerError> {
+        let id = self.id.ok_or_else(|| {
+            WorkloadRunnerError::WorkloadAddError(
+                "unable to build, missing field: `id`".to_string(),
+            )
+        })?;
+
+        let rate = self.rate.ok_or_else(|| {
+            WorkloadRunnerError::WorkloadAddError(
+                "unable to build, missing field: `rate`".to_string(),
+            )
+        })?;
+
+        let workload = self.workload.ok_or_else(|| {
+            WorkloadRunnerError::WorkloadAddError(
+                "unable to build, missing field: `workload`".to_string(),
+            )
+        })?;
+
+        let targets = self.targets.ok_or_else(|| {
+            WorkloadRunnerError::WorkloadAddError(
+                "unable to build, missing field: `target`".to_string(),
+            )
+        })?;
+
+        let auth = self.auth.ok_or_else(|| {
+            WorkloadRunnerError::WorkloadAddError(
+                "unable to build, missing field: `auth`".to_string(),
+            )
+        })?;
+
+        let (sender, receiver) = channel();
+
+        let time_to_wait = time::Duration::from_secs(1) / rate;
+        let thread_id = id.to_string();
+        let thread = Some(
+            thread::Builder::new()
+                .name(id.to_string())
+                .spawn(move || {
+                    // set first target
+                    let mut next_target = 0;
+                    let mut workload = workload;
+                    // keep track of status of http requests for logging
+                    let http_counter = HTTPRequestCounter::new(thread_id.to_string());
+                    // the last time http request information was logged
+                    let mut last_log_time = time::Instant::now();
+                    loop {
+                        match receiver.try_recv() {
+                            // recieved shutdown
+                            Ok(_) => {
+                                info!("Worker received shutdowm");
+                                break;
+                            }
+                            Err(TryRecvError::Empty) => {
+                                // get target to submit batch to
+                                let target = match targets.get(next_target) {
+                                    Some(target) => target,
+                                    None => {
+                                        error!("No targets provided");
+                                        break;
+                                    }
+                                };
+
+                                // get next batch
+                                let batch = workload.next_batch().expect("Unable to get batch");
+                                let batch_bytes = match vec![batch.batch().clone()].into_bytes() {
+                                    Ok(bytes) => bytes,
+                                    Err(err) => {
+                                        error!("Unable to get batch bytes {}", err);
+                                        break;
+                                    }
+                                };
+
+                                // submit batch to the target
+                                match submit_batch(target, &auth, batch_bytes) {
+                                    Ok(()) => http_counter.increment_sent(),
+                                    Err(err) => {
+                                        if err == WorkloadRunnerError::TooManyRequests {
+                                            http_counter.increment_queue_full()
+                                        } else {
+                                            error!("{}:{}", thread_id, err);
+                                        }
+                                    }
+                                }
+
+                                // log http submission stats if its been longer then update time
+                                log(&http_counter, &mut last_log_time, DEFAULT_LOG_TIME_SECS);
+
+                                // get next target, round robin
+                                next_target = (next_target + 1) % targets.len();
+                                thread::sleep(time_to_wait);
+                            }
+
+                            Err(TryRecvError::Disconnected) => {
+                                error!("Channel has disconnected");
+                                break;
+                            }
+                        }
+                    }
+                })
+                .map_err(|err| {
+                    WorkloadRunnerError::WorkloadAddError(format!(
+                        "Unable to spawn worker thread: {}",
+                        err
+                    ))
+                })?,
+        );
+
+        Ok(Worker { id, thread, sender })
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ServerError {
+    pub message: String,
+}
+
+fn submit_batch(target: &str, auth: &str, batch_bytes: Vec<u8>) -> Result<(), WorkloadRunnerError> {
+    Client::new()
+        .post(&format!("{}/batches", target))
+        .header(header::CONTENT_TYPE, "octet-stream")
+        .header("Authorization", auth)
+        .body(batch_bytes)
+        .send()
+        .map_err(|err| WorkloadRunnerError::SubmitError(format!("Failed to submit batch: {}", err)))
+        .and_then(|res| {
+            let status = res.status();
+            if status.is_success() {
+                Ok(())
+            } else {
+                if status == StatusCode::TOO_MANY_REQUESTS {
+                    return Err(WorkloadRunnerError::TooManyRequests);
+                };
+
+                let message = res
+                    .json::<ServerError>()
+                    .map_err(|_| {
+                        WorkloadRunnerError::SubmitError(format!(
+                            "Batch submit request failed with status code '{}', but \
+                                 error response was not valid",
+                            status
+                        ))
+                    })?
+                    .message;
+
+                Err(WorkloadRunnerError::SubmitError(format!(
+                    "Failed to submit batch: {}",
+                    message
+                )))
+            }
+        })
+}
+
+/// Counts sent and queue full for Batches submmissions from the target REST Api.
+pub struct HTTPRequestCounter {
+    id: String,
+    sent_count: AtomicUsize,
+    queue_full_count: AtomicUsize,
+}
+
+impl HTTPRequestCounter {
+    pub fn new(id: String) -> Self {
+        HTTPRequestCounter {
+            id,
+            sent_count: AtomicUsize::new(0),
+            queue_full_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn increment_sent(&self) {
+        self.sent_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_queue_full(&self) {
+        self.queue_full_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn log(&self, seconds: u64, nanoseconds: u32) {
+        let update = seconds as f64 + f64::from(nanoseconds) * 1e-9;
+        println!(
+            "{}, Batches/s {:.3}",
+            self,
+            self.sent_count.load(Ordering::Relaxed) as f64 / update
+        );
+
+        self.sent_count.store(0, Ordering::Relaxed);
+        self.queue_full_count.store(0, Ordering::Relaxed);
+    }
+}
+
+impl fmt::Display for HTTPRequestCounter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let time = chrono::Utc::now();
+        write!(
+            f,
+            "{0}: {1}, Sent: {2}, Queue Full {3}",
+            self.id,
+            time.format("%h-%d-%Y %H:%M:%S%.3f").to_string(),
+            self.sent_count.load(Ordering::Relaxed),
+            self.queue_full_count.load(Ordering::Relaxed)
+        )
+    }
+}
+
+/// Log if time since last log is greater than update time.
+pub fn log(counter: &HTTPRequestCounter, last_log_time: &mut time::Instant, update_time: u32) {
+    let log_time = time::Instant::now() - *last_log_time;
+    if log_time.as_secs() as u32 >= update_time {
+        counter.log(log_time.as_secs(), log_time.subsec_nanos());
+        *last_log_time = time::Instant::now();
+    }
+}


### PR DESCRIPTION
The WorkloadRunner makes it easy to run multiple workloads
against different groups of URLS. The workload groups can
be started and removed dynamically, allowing for more
complicated workload test.

This required updating the TransactionWorkload and
BatchWorkload traits to require they can be Send because
the workloads will be run in their own thread.

This is behind an experimental feature "workload-runner"