### PR TITLE
 Add initial transact workload CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "libtransact",
   "examples/simple_xo",
   "examples/address_generator",
+  "cli"
   ]
 
 # Exclude sabre_smallbank to avoid incompatible features `sabre-compat` and

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
+cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
 flexi_logger = "0.14"
 log = "0.4"
 transact = {path = "../libtransact", features=["family-smallbank-workload"]}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,60 @@
+# Copyright 2018-2019 Bitwise IO, Inc.
+# Copyright 2019-2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "transact-cli"
+version = "0.3.7"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+license = "Apache-2.0"
+readme = "../README.md"
+description = """\
+    Transact is a transaction execution platform designed to be used as \
+    a library or component when implementing distributed ledgers, including \
+    blockchains.
+"""
+repository = "http://github.com/hyperledger/transact"
+
+[[bin]]
+name = "transact"
+path = "src/main.rs"
+
+[dependencies]
+clap = "2"
+flexi_logger = "0.14"
+log = "0.4"
+transact = {path = "../libtransact", features=["family-smallbank-workload"]}
+
+
+[features]
+default = []
+
+stable = [
+    # The stable feature extends default:
+    "default",
+]
+
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]
+
+[package.metadata.docs.rs]
+features = [
+  "default",
+  "experimental",
+  "stable",
+]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,9 +33,11 @@ path = "src/main.rs"
 
 [dependencies]
 clap = "2"
-cylinder = { version = "0.2.2", features = ["jwt", "key-load"] }
+ctrlc = { version = "3.0", optional = true }
+cylinder = { version = "0.2.2", features = ["jwt", "key-load"], optional = true }
 flexi_logger = "0.14"
 log = "0.4"
+rand = { version = "0.8", optional = true }
 transact = {path = "../libtransact", features=["family-smallbank-workload"]}
 
 
@@ -51,7 +53,10 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "workload"
 ]
+
+workload = ["ctrlc", "cylinder", "rand"]
 
 [package.metadata.docs.rs]
 features = [

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -13,10 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "workload")]
+pub mod workload;
+
 use std::collections::HashMap;
+#[cfg(feature = "workload")]
 use std::path::Path;
 
 use clap::ArgMatches;
+#[cfg(feature = "workload")]
 use cylinder::{
     current_user_search_path, jwt::JsonWebTokenBuilder, load_key, load_key_from_path,
     secp256k1::Secp256k1Context, Context, Signer,
@@ -38,6 +43,7 @@ pub struct SubcommandActions<'a> {
     actions: HashMap<String, Box<dyn Action + 'a>>,
 }
 
+#[cfg(feature = "workload")]
 impl<'a> SubcommandActions<'a> {
     pub fn new() -> Self {
         Self::default()
@@ -68,6 +74,7 @@ impl<'s> Action for SubcommandActions<'s> {
     }
 }
 
+#[cfg(feature = "workload")]
 // build a signed json web token using the private key
 fn create_cylinder_jwt_auth_signer_key(
     key_name: &str,

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -1,0 +1,65 @@
+// Copyright 2018-2021 Cargill Incorporated
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use clap::ArgMatches;
+
+use super::error::CliError;
+
+/// A CLI Command Action.
+///
+/// An Action is a single subcommand for CLI operations.
+pub trait Action {
+    /// Run a CLI Action with the given args
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError>;
+}
+
+/// A collection of Subcommands associated with a single parent command.
+#[derive(Default)]
+pub struct SubcommandActions<'a> {
+    actions: HashMap<String, Box<dyn Action + 'a>>,
+}
+
+impl<'a> SubcommandActions<'a> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_command<'action: 'a, A: Action + 'action>(
+        mut self,
+        command: &str,
+        action: A,
+    ) -> Self {
+        self.actions.insert(command.to_string(), Box::new(action));
+
+        self
+    }
+}
+
+impl<'s> Action for SubcommandActions<'s> {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let (subcommand, args) = args.subcommand();
+
+        if let Some(action) = self.actions.get_mut(subcommand) {
+            action.run(args)
+        } else {
+            Err(CliError::InvalidSubcommand)
+        }
+    }
+}

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -1,0 +1,198 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use clap::ArgMatches;
+use cylinder::Signer;
+use rand::Rng;
+use transact::families::smallbank::workload::{
+    playlist::SmallbankGeneratingIter, SmallbankBatchWorkload, SmallbankTransactionWorkload,
+};
+use transact::workload::WorkloadRunner;
+
+use crate::error::CliError;
+
+use super::{create_cylinder_jwt_auth_signer_key, Action};
+
+pub struct WorkloadAction;
+
+impl Action for WorkloadAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let key_path = args
+            .value_of("key")
+            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
+        let (auth, signer) = create_cylinder_jwt_auth_signer_key(key_path)?;
+
+        let targets_vec: Vec<String> = args
+            .values_of("targets")
+            .map(|values| values.map(String::from).collect::<Vec<String>>())
+            .ok_or_else(|| CliError::ActionError("'targets' are required".into()))?;
+
+        let targets: Vec<Vec<String>> = targets_vec
+            .iter()
+            .map(|target| target.split(';').map(String::from).collect::<Vec<String>>())
+            .collect::<Vec<Vec<String>>>();
+
+        let rate = args.value_of("target_rate").unwrap_or("1").to_string();
+
+        let (min, max): (u32, u32) = {
+            if rate.contains('-') {
+                let split_rate: Vec<String> = rate.split('-').map(String::from).collect();
+                let min = split_rate
+                    .get(0)
+                    .ok_or_else(|| CliError::ActionError("Min target rate not provided".into()))?
+                    .parse()
+                    .map_err(|_| {
+                        CliError::ActionError("Unable to parse provided min target rate".into())
+                    })?;
+
+                let max = split_rate
+                    .get(1)
+                    .ok_or_else(|| CliError::ActionError("Max target rate not provided".into()))?
+                    .parse()
+                    .map_err(|_| {
+                        CliError::ActionError("Unable to parse provided max target rate".into())
+                    })?;
+
+                (min, max)
+            } else {
+                let min = rate.parse().map_err(|_| {
+                    CliError::ActionError("Unable to parse provided target rate".into())
+                })?;
+
+                (min, min)
+            }
+        };
+
+        let workload = args
+            .value_of("workload")
+            .ok_or_else(|| CliError::ActionError("Workload type is required".into()))?;
+
+        let update: u32 = args
+            .value_of("update")
+            .unwrap_or("30")
+            .parse()
+            .map_err(|_| CliError::ActionError("Unable to parse provided update time".into()))?;
+
+        let mut workload_runner = WorkloadRunner::default();
+
+        match workload {
+            "smallbank" => {
+                let seed = match args.value_of("seed").map(str::parse).unwrap_or_else(|| {
+                    let mut rng = rand::thread_rng();
+                    Ok(rng.gen::<u64>())
+                }) {
+                    Ok(seed) => seed,
+                    Err(_) => {
+                        return Err(CliError::ActionError(
+                            "Unable to get seed for smallbank workload".into(),
+                        ))
+                    }
+                };
+
+                let num_accounts: usize = args
+                    .value_of("smallbank_num_account")
+                    .unwrap_or("100")
+                    .parse()
+                    .map_err(|_| {
+                        CliError::ActionError("Unable to parse number of accounts".into())
+                    })?;
+
+                start_smallbank_workloads(
+                    &mut workload_runner,
+                    targets,
+                    min,
+                    max,
+                    auth,
+                    signer,
+                    update,
+                    seed,
+                    num_accounts,
+                )?;
+            }
+            _ => {
+                return Err(CliError::ActionError(format!(
+                    "Unsupported workload type: {}",
+                    workload
+                )))
+            }
+        }
+
+        // setup control-c handling
+        let running = Arc::new(AtomicBool::new(true));
+        let r = running.clone();
+
+        ctrlc::set_handler(move || {
+            r.store(false, Ordering::SeqCst);
+        })
+        .map_err(|_| {
+            CliError::ActionError("Unable to set up workload ctrlc handler".to_string())
+        })?;
+
+        while running.load(Ordering::SeqCst) {}
+        // shutdown all workloads
+        workload_runner.shutdown();
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_smallbank_workloads(
+    workload_runner: &mut WorkloadRunner,
+    targets: Vec<Vec<String>>,
+    target_rate_min: u32,
+    target_rate_max: u32,
+    auth: String,
+    signer: Box<dyn Signer>,
+    update: u32,
+    seed: u64,
+    num_accounts: usize,
+) -> Result<(), CliError> {
+    let mut rng = rand::thread_rng();
+
+    for (i, target) in targets.into_iter().enumerate() {
+        let smallbank_generator = SmallbankGeneratingIter::new(num_accounts, seed);
+        let transaction_workload =
+            SmallbankTransactionWorkload::new(smallbank_generator, signer.clone());
+        let smallbank_workload = SmallbankBatchWorkload::new(transaction_workload, signer.clone());
+
+        let rate = if target_rate_min == target_rate_max {
+            target_rate_min
+        } else {
+            rng.gen_range(target_rate_min..=target_rate_max)
+        };
+
+        info!(
+            "Starting Smallbank-Workload-{} with target rate {}",
+            i, rate
+        );
+        workload_runner
+            .add_workload(
+                format!("Smallbank-Workload-{}", i),
+                Box::new(smallbank_workload),
+                target,
+                rate,
+                auth.to_string(),
+                update,
+            )
+            .map_err(|err| CliError::ActionError(format!("Unable to start workload: {}", err)))?
+    }
+
+    Ok(())
+}

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,57 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt;
+
+use clap::Error as ClapError;
+
+#[derive(Debug)]
+pub enum CliError {
+    /// A subcommand requires one or more arguments, but none were provided.
+    RequiresArgs,
+    /// A non-existent subcommand was specified.
+    InvalidSubcommand,
+    /// An error was detected by `clap`.
+    ClapError(ClapError),
+    /// A general error encountered by a subcommand.
+    ActionError(String),
+    /// The environment is not in the correct state to execute the subcommand as requested.
+    EnvironmentError(String),
+}
+
+impl Error for CliError {}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CliError::RequiresArgs => write!(
+                f,
+                "The specified subcommand requires arguments, but none were provided"
+            ),
+            CliError::InvalidSubcommand => write!(f, "An invalid subcommand was specified"),
+            CliError::ClapError(err) => f.write_str(&err.message),
+            CliError::ActionError(msg) => write!(f, "Subcommand encountered an error: {}", msg),
+            CliError::EnvironmentError(msg) => {
+                write!(f, "Environment not valid for subcommand: {}", msg)
+            }
+        }
+    }
+}
+
+impl From<ClapError> for CliError {
+    fn from(err: ClapError) -> Self {
+        Self::ClapError(err)
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,89 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#[macro_use]
+extern crate log;
+
+mod action;
+pub mod error;
+
+use std::ffi::OsString;
+
+use clap::{clap_app, Arg, SubCommand};
+use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
+use log::Record;
+
+use crate::error::CliError;
+
+const APP_NAME: &str = env!("CARGO_PKG_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// log format for cli that will only show the log message
+pub fn log_format(
+    w: &mut dyn std::io::Write,
+    _now: &mut DeferredNow,
+    record: &Record,
+) -> Result<(), std::io::Error> {
+    write!(w, "{}", record.args(),)
+}
+
+fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<(), CliError> {
+    let mut app = clap_app!(myapp =>
+        (name: APP_NAME)
+        (version: VERSION)
+        (author: "Cargill")
+        (about: "Command line for transact")
+        (@arg verbose: -v +multiple +global "Log verbosely")
+        (@arg quiet: -q --quiet +global "Do not display output")
+        (@setting SubcommandRequiredElseHelp));
+
+    let matches = app.get_matches_from_safe(args)?;
+
+    // set default to info
+    let log_level = if matches.is_present("quiet") {
+        log::LevelFilter::Error
+    } else {
+        match matches.occurrences_of("verbose") {
+            0 => log::LevelFilter::Info,
+            1 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
+        }
+    };
+
+    let mut log_spec_builder = LogSpecBuilder::new();
+    log_spec_builder.default(log_level);
+    log_spec_builder.module("reqwest", log::LevelFilter::Warn);
+    log_spec_builder.module("hyper", log::LevelFilter::Warn);
+    log_spec_builder.module("mio", log::LevelFilter::Warn);
+    log_spec_builder.module("want", log::LevelFilter::Warn);
+
+    match Logger::with(log_spec_builder.build())
+        .format(log_format)
+        .log_target(flexi_logger::LogTarget::StdOut)
+        .start()
+    {
+        Ok(_) => {}
+        Err(err) => panic!("Failed to start logger: {}", err),
+    }
+}
+
+fn main() {
+    match run(std::env::args_os()) {
+        Ok(_) => {}
+        Err(CliError::ClapError(err)) => err.exit(),
+        Err(e) => {
+            error!("ERROR: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/examples/sabre_smallbank/packaging/scar/manifest.yaml
+++ b/examples/sabre_smallbank/packaging/scar/manifest.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: sabre_smallbank
+name: smallbank
 version: '1.0'
 inputs:
   - '332514'

--- a/justfile
+++ b/justfile
@@ -17,6 +17,7 @@ crates := '\
     libtransact \
     examples/simple_xo \
     examples/address_generator \
+    cli \
     '
 
 features := '\

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -30,7 +30,7 @@ use crate::protos::IntoBytes;
 use super::error::WorkloadRunnerError;
 use super::BatchWorkload;
 
-const DEFAULT_LOG_TIME_SECS: u32 = 5; // time in seconds
+const DEFAULT_LOG_TIME_SECS: u32 = 30; // time in seconds
 
 /// Keeps track of the currenlty running workloads.
 ///
@@ -52,6 +52,7 @@ impl WorkloadRunner {
     ///              URL before adding `/batches` for submission
     /// * `rate`- How many tranactions per second to submit
     /// * `auth` - The string to be set in the Authorization header for the request
+    /// * `update_time` - The time between updates on the workload
     ///
     /// Returns an error if a workload with that ID is already running or if the workload thread
     /// could not be started
@@ -62,6 +63,7 @@ impl WorkloadRunner {
         targets: Vec<String>,
         rate: u32,
         auth: String,
+        update_time: u32,
     ) -> Result<(), WorkloadRunnerError> {
         if self.workloads.contains_key(&id) {
             return Err(WorkloadRunnerError::WorkloadAddError(format!(
@@ -76,6 +78,7 @@ impl WorkloadRunner {
             .with_targets(targets)
             .with_rate(rate)
             .with_auth(auth)
+            .with_update_time(update_time)
             .build()?;
 
         self.workloads.insert(id, worker);
@@ -155,6 +158,7 @@ struct WorkerBuilder {
     targets: Option<Vec<String>>,
     rate: Option<u32>,
     auth: Option<String>,
+    update_time: Option<u32>,
 }
 
 impl WorkerBuilder {
@@ -209,6 +213,16 @@ impl WorkerBuilder {
         self
     }
 
+    /// Sets the update time of the worker
+    ///
+    /// # Arguments
+    ///
+    ///  * `update_time` - How often to provide an update about the workload
+    pub fn with_update_time(mut self, update_time: u32) -> WorkerBuilder {
+        self.update_time = Some(update_time);
+        self
+    }
+
     pub fn build(self) -> Result<Worker, WorkloadRunnerError> {
         let id = self.id.ok_or_else(|| {
             WorkloadRunnerError::WorkloadAddError(
@@ -239,6 +253,8 @@ impl WorkerBuilder {
                 "unable to build, missing field: `auth`".to_string(),
             )
         })?;
+
+        let update_time = self.update_time.unwrap_or(DEFAULT_LOG_TIME_SECS);
 
         let (sender, receiver) = channel();
 
@@ -295,7 +311,7 @@ impl WorkerBuilder {
                                 }
 
                                 // log http submission stats if its been longer then update time
-                                log(&http_counter, &mut last_log_time, DEFAULT_LOG_TIME_SECS);
+                                log(&http_counter, &mut last_log_time, update_time);
 
                                 // get next target, round robin
                                 next_target = (next_target + 1) % targets.len();

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -275,7 +275,7 @@ impl WorkerBuilder {
                         match receiver.try_recv() {
                             // recieved shutdown
                             Ok(_) => {
-                                info!("Worker received shutdowm");
+                                info!("Worker received shutdown");
                                 break;
                             }
                             Err(TryRecvError::Empty) => {


### PR DESCRIPTION
`transact workload` allows a workload to be submitted against
groups of targets, a collection of URL that will share state
(aka need to work of the same workload).

Currently smallbank is the only supported workload type and
requires that the targets are running Sawtooth Sabre and the
smallbank sabre smart contract has already been configured.

The workload commands also assumes that the targets support
Cylinder JWTs for REST API authentication.

The workload will run until a ctrl-c, then the workloads will
be shutdown.

```
transact-workload 
Run a continuous workload against a set of targets

USAGE:
    transact workload [FLAGS] [OPTIONS] --target-rate <target_rate> --targets <targets>... --workload <workload>

FLAGS:
    -h, --help       Prints help information
    -q, --quiet      Do not display output
    -V, --version    Prints version information
    -v               Log verbosely

OPTIONS:
    -k, --key <private-key-file>               Path to private key file
        --smallbank-num-accounts <ACCOUNTS>    The number of smallbank accounts to make. Defaults to 100.
        --smallbank-seed <SEED>                An integer to use as a seed to make the smallbank workload reproducible.
        --target-rate <target_rate>            How many batches to submit per second, either provide a number or a range
                                               with the min and max separated by '-' ex: 5-15, default to 1
        --targets <targets>...                 Node URLS to submit batches to, combine groups with ;
    -u, --update <update>                      The time in seconds between updates, defaults to 30 seconds
        --workload <workload>                  The workload to be submitted [possible values: smallbank]
```


For example:
```
transact workload \
  --target-rate 1-5 \
  --key /Users/agunde/cargill/splinter/cli/alice.priv  \
  --workload smallbank \
  --update 5 \
  --smallbank-seed 10 \
  --smallbank-num-accounts 5 \
  --targets "http://0.0.0.0:8089/scabbard/jEWSK-jdjSM/a001;http://0.0.0.0:8088/scabbard/jEWSK-jdjSM/a000" \
  --targets "http://0.0.0.0:8089/scabbard/kdRjr-kpuNx/a001;http://0.0.0.0:8088/scabbard/kdRjr-kpuNx/a000"

```

Would start up two workloads running against two Splinter circuits that already have smallbank smart contract added to  scabbard. 


`transact workload` is behind an experimental features `workload`