### PR TITLE
Fix unnecessary_wraps clippy errors

### DIFF
--- a/libtransact/src/database/btree.rs
+++ b/libtransact/src/database/btree.rs
@@ -237,7 +237,8 @@ impl<'a> DatabaseWriter for BTreeWriter<'a> {
     }
 
     fn commit(self: Box<Self>) -> Result<(), DatabaseError> {
-        BTreeWriter::commit(self.db, self.transactions)
+        BTreeWriter::commit(self.db, self.transactions);
+        Ok(())
     }
 
     fn as_reader(&self) -> &dyn DatabaseReader {
@@ -246,10 +247,7 @@ impl<'a> DatabaseWriter for BTreeWriter<'a> {
 }
 
 impl<'a> BTreeWriter<'a> {
-    fn commit(
-        mut db: RwLockWriteGuard<'a, BTreeDbInternal>,
-        transactions: Vec<WriterTransaction>,
-    ) -> Result<(), DatabaseError> {
+    fn commit(mut db: RwLockWriteGuard<'a, BTreeDbInternal>, transactions: Vec<WriterTransaction>) {
         for transaction in transactions {
             match transaction {
                 WriterTransaction::Put { key, value } => {
@@ -269,7 +267,6 @@ impl<'a> BTreeWriter<'a> {
                 }
             }
         }
-        Ok(())
     }
 }
 

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -210,7 +210,7 @@ impl MerkleRadixTree {
             let (deletion_candidates, duplicates) = MerkleRadixTree::remove_duplicate_hashes(
                 db_writer.as_reader(),
                 change_log.additions,
-            )?;
+            );
 
             for hash in &deletion_candidates {
                 let hash_hex = ::hex::encode(hash);
@@ -247,7 +247,7 @@ impl MerkleRadixTree {
                 MerkleRadixTree::remove_duplicate_hashes(
                     db_writer.as_reader(),
                     successor.deletions,
-                )?;
+                );
 
             for hash in &deletion_candidates {
                 let hash_hex = ::hex::encode(hash);
@@ -270,14 +270,14 @@ impl MerkleRadixTree {
     fn remove_duplicate_hashes(
         db_reader: &dyn DatabaseReader,
         deletions: Vec<Vec<u8>>,
-    ) -> Result<(Vec<StateHash>, Vec<StateHash>), StateDatabaseError> {
-        Ok(deletions.into_iter().partition(|key| {
+    ) -> (Vec<StateHash>, Vec<StateHash>) {
+        deletions.into_iter().partition(|key| {
             if let Ok(count) = get_ref_count(db_reader, &key) {
                 count == 0
             } else {
                 false
             }
-        }))
+        })
     }
     /// Returns the current merkle root for this MerkleRadixTree
     pub fn get_merkle_root(&self) -> String {


### PR DESCRIPTION
Removes wrapping function returns in Option or Error when
only Ok or Some is returned.

Fixes  clippy errors introduced in 1.50.0 Rust