### PR TITLE
Make smallbank workload re-runnable 

### DIFF
--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -93,10 +93,13 @@ impl Action for WorkloadAction {
 
         match workload {
             "smallbank" => {
-                let seed = match args.value_of("seed").map(str::parse).unwrap_or_else(|| {
-                    let mut rng = rand::thread_rng();
-                    Ok(rng.gen::<u64>())
-                }) {
+                let seed = match args
+                    .value_of("smallbank_seed")
+                    .map(str::parse)
+                    .unwrap_or_else(|| {
+                        let mut rng = rand::thread_rng();
+                        Ok(rng.gen::<u64>())
+                    }) {
                     Ok(seed) => seed,
                     Err(_) => {
                         return Err(CliError::ActionError(
@@ -106,7 +109,7 @@ impl Action for WorkloadAction {
                 };
 
                 let num_accounts: usize = args
-                    .value_of("smallbank_num_account")
+                    .value_of("smallbank_num_accounts")
                     .unwrap_or("100")
                     .parse()
                     .map_err(|_| {

--- a/libtransact/src/families/smallbank/handler.rs
+++ b/libtransact/src/families/smallbank/handler.rs
@@ -119,10 +119,14 @@ fn apply_create_account(
 ) -> Result<(), ApplyError> {
     match load_account(create_account_data.get_customer_id(), context)? {
         Some(_) => {
-            warn!("Invalid transaction: during CREATE_ACCOUNT, Customer Name must be set");
-            Err(ApplyError::InvalidTransaction(
-                "Customer Name must be set".into(),
-            ))
+            warn!(
+                "Invalid transaction: during CREATE_ACCOUNT, Customer {} already exists",
+                create_account_data.get_customer_id()
+            );
+            Err(ApplyError::InvalidTransaction(format!(
+                "Customer {} already exists",
+                create_account_data.get_customer_id()
+            )))
         }
         None => {
             if create_account_data.get_customer_name().is_empty() {

--- a/libtransact/src/families/smallbank/handler.rs
+++ b/libtransact/src/families/smallbank/handler.rs
@@ -194,7 +194,10 @@ fn apply_transact_savings(
             if transact_savings_data.get_amount() < 0
                 && (-transact_savings_data.get_amount() as u32) > account.get_savings_balance()
             {
-                warn!("Invalid transaction: during TRANSACT_SAVINGS, Insufficient funds in source savings account");
+                warn!(
+                    "Invalid transaction: during TRANSACT_SAVINGS, Insufficient funds in source \
+                    savings account"
+                );
                 return Err(ApplyError::InvalidTransaction(
                     "Insufficient funds in source savings account".into(),
                 ));
@@ -229,7 +232,10 @@ fn apply_send_payment(
         load_account(send_payment_data.get_dest_customer_id(), context)?.ok_or_else(err)?;
 
     if source_account.get_checking_balance() < send_payment_data.get_amount() {
-        warn!("Invalid transaction: during SEND_PAYMENT, Insufficient funds in source checking account");
+        warn!(
+            "Invalid transaction: during SEND_PAYMENT, Insufficient funds in source checking \
+            account"
+        );
         Err(ApplyError::InvalidTransaction(
             "Insufficient funds in source checking account".into(),
         ))


### PR DESCRIPTION
Before the number of accounts were generated with
client ids in order from 0 to number account requested.
This made it impossible to rerun the workload against
the same network with out having at least the number
of accounts invalid transactions. Instead, the client
id are now randomly generated.

If a seed is provided, the output will be generated the
same way, causing invalid transactions. To be rerun
without the invalid transactions, run again with a
different or no seed to create new accounts.