### PR TITLE
Add transact playlist subcommands to the CLI 

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,9 +53,11 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "playlist",
     "workload"
 ]
 
+playlist = ["cylinder"]
 workload = ["ctrlc", "cylinder", "rand"]
 
 [package.metadata.docs.rs]

--- a/cli/man/transact-playlist-batch.1.md
+++ b/cli/man/transact-playlist-batch.1.md
@@ -1,0 +1,77 @@
+% TRANSACT-PLAYLIST-BATCH(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-playlist-batch** — Generates signed batches from transaction input
+
+SYNOPSIS
+========
+**transact playlist batch** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command generates signed batches from transaction input. The transaction
+input is expected to be length-delimited protobuf transaction messages, which
+should also be pre-signed for submission to the validator.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-i, --input FILE`
+: The source of input transactions. The transaction input is expected to be
+  length-delimited protobuf.
+
+`-k, --key PRIVATE-KEY-FILE`
+: Specifies the full path to the private key file. The key will be used to
+  sign the batches.
+
+`-n, --max-batch-size NUMBER`
+: The maximum number of transactions to include in a batch. (Defaults to 1)
+
+`-o, --output FILE`
+: The target for the signed batches.
+
+
+EXAMPLES
+========
+The following shows providing a transaction file `txns.txt` and creating
+`batches.txt` file of length-delimited protobuf batches.
+
+```
+transact playlist batch
+  --input txns.txt \
+  --key ./alice.priv
+  --output batches.txt
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-playlist(1)`
+| `transact-playlist-create(1)`
+| `transact-playlist-process(1)`
+| `transact-playlist-submit(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-playlist-create.1.md
+++ b/cli/man/transact-playlist-create.1.md
@@ -1,0 +1,85 @@
+% TRANSACT-PLAYLIST-CREATE(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-playlist-create** — Generates a workload transaction playlist
+
+SYNOPSIS
+========
+**transact playlist create ** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command generates a workload transaction playlist. A playlist is a series
+of transactions, described in YAML.  This command generates a playlist and
+writes it to file or standard out.
+
+`transact-playlist-process` takes this playlist and creates signed transactions
+for the payloads.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-o, --output FILE`
+: The target for the generated playlist
+
+`--smallbank-num-accounts ACCOUNTS`
+: The number of smallbank accounts to make. (Defaults to 10)
+
+`--smallbank-seed SEED`
+: An integer to use as a seed generate the same smallbank playlist
+
+`-n, --transactions NUMBER`
+: The number of transactions to generate. This includes the account creation
+  payloads. (Defaults to 10)
+
+
+`--workload WORKLOAD`
+:  The workload type to create a playlist for. [possible values: smallbank]
+
+
+EXAMPLES
+========
+The following shows creating a smallbank playlist file `smallbank.yaml` with 20
+transactions.
+
+```
+transact playlist create \
+  --smallbank-num-accounts 10\
+  --output smallbank.yaml  \
+  --smallbank-seed 10 \
+  --transactions 20  \
+  --workload smallbank
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-playlist(1)`
+| `transact-playlist-batch(1)`
+| `transact-playlist-process(1)`
+| `transact-playlist-submit(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-playlist-process.1.md
+++ b/cli/man/transact-playlist-process.1.md
@@ -1,0 +1,78 @@
+% TRANSACT-PLAYLIST-PROCESS(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-playlist-processe** — Processes a transaction playlist
+
+SYNOPSIS
+========
+**transact playlist create ** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+Processes a transaction playlist. A playlist is a series of transactions,
+described in YAML.  This command processes a playlist, converting it into
+transactions and writes it to file or standard out.
+
+`transact-playlist-batch` takes the output file and creates signed batches
+for the payloads.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-i, --input FILE`
+: The source of the input playlist yaml.
+
+`--k, --key FILE`
+: The signing key for the transactions.
+
+`-o, --output FILE`
+: The target for the generated transactions.
+
+`--workload WORKLOAD`
+: The workload type to the playlist is for. [possible values: smallbank]
+
+
+EXAMPLES
+========
+The following shows creating a file, `txns.text`
+
+```
+transact playlist process \
+  -i smallbank.yaml \
+  --key ./alice.priv \
+  --output txns.text \
+  --workload smallbank
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-playlist(1)`
+| `transact-playlist-create(1)`
+| `transact-playlist-batch(1)`
+| `transact-playlist-submit(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-playlist-submit.1.md
+++ b/cli/man/transact-playlist-submit.1.md
@@ -1,0 +1,88 @@
+% TRANSACT-PLAYLIST-SUBMIT(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-paylist-submit** — Submits signed batches to targets from batch input
+
+SYNOPSIS
+========
+**transact playlist submit** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command submits signed batches to one or more targets from batch input.
+The batch input is expected to be length-delimited protobuf Batch messages,
+which should also be pre-signed for submission to the distributed ledger.
+The command will continue to submit the batches at the provided rate until
+the source is exhausted.
+
+The submit tool assumes the distributed ledger's REST API supports Cylinder
+JWT authentication.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-i, --input FILE`
+: The source of batch transactions
+
+`-k, --key PRIVATE-KEY-FILE`
+: Specifies the full path to the private key file. The key will be used to
+  sign the batches as well as generate a JWT for authentication.
+
+`--rate RATE`
+: How many batches to submit per second, ex `5`. (default: `1`)
+
+`--targets TARGETS`
+: Node URLS to submit batches to, combine groups with `;`. The URL should
+  include all of the information required to append `/batches` to the end.
+
+`-u, --update UPDATE `
+: The time in seconds between updates. The command will log the success rate
+  of submitting the HTTP requests. (default: `30`)
+
+EXAMPLES
+========
+The following shows submitting a batch source against a Splinter circuit
+`jEWSK-jdjSM` with scabbard services. A Scabbard service runs a sabre
+transaction handler. The smallbank smart contract must already be submitted to
+scabbard.
+
+```
+transact playlist submit\
+  --input batches.txt \
+  --key ./alice.priv \
+  --rate 1  \
+  --target "http://0.0.0.0:8089/scabbard/XOHZe-GE1oY/a001"
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-playlist(1)`
+| `transact-playlist-batch(1)`
+| `transact-playlist-create(1)`
+| `transact-playlist-process(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-playlist.1.md
+++ b/cli/man/transact-playlist.1.md
@@ -1,0 +1,73 @@
+% TRANSACT-PLAYLIST(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+**transact-playlist** — Create and process playlists of pregenerated payloads
+
+SYNOPSIS
+========
+**transact playlist** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command can be used to generate files of pregenerated payloads,
+transactions, and batches. The file containing the batches can then be submitted
+against a distributed ledger.
+
+Payload, transactions and batch generation can be very expensive and can skew
+performance results during testing. Using a pregenerated batch file makes for a
+more accurate and repeatable test.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+`batch`
+: Generates signed batches from transaction input. The transaction input is
+  expected to be length-delimited protobuf Transaction messages, which should
+  also be pre-signed for submission to the validator.
+
+`create`
+: Generates a workload transaction playlist. A playlist is a series of
+  transactions, described in YAML. This command generates a playlist and writes
+  it to file or standard out.
+
+`help`
+:  Prints this message or the help of the given subcommand(s)
+
+`process`
+: Processes a transaction playlist. A playlist is a series of transactions,
+  described in YAML.  This command processes a playlist, converting it into
+  transactions and writes it to file or standard out.
+
+`submit`
+: Submits signed batches to one or more targets from batch input. The batch
+  input is expected to be length-delimited protobuf Batch messages, which
+  should also be pre-signed for submission to the validator.
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-playlist-batch(1)`
+| `transact-playlist-create(1)`
+| `transact-playlist-process(1)`
+| `transact-playlist-submit(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/src/action/playlist.rs
+++ b/cli/src/action/playlist.rs
@@ -1,0 +1,250 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use std::fs::File;
+use std::io::Write;
+
+use clap::ArgMatches;
+use transact::families::smallbank::workload::playlist::{
+    generate_smallbank_playlist, process_smallbank_playlist,
+};
+use transact::workload::batch_gen::generate_signed_batches;
+use transact::workload::{submit_batches_from_source, DEFAULT_LOG_TIME_SECS};
+
+use crate::error::CliError;
+
+use super::{create_cylinder_jwt_auth_signer_key, load_cylinder_signer_key, Action};
+
+const DEFAULT_ACCOUNTS: &str = "10";
+const DEFAULT_TRANSACTIONS: &str = "10";
+const DEFAULT_BATCH_SIZE: &str = "1";
+const DEFAULT_RATE: &str = "1";
+
+pub struct CreatePlaylistAction;
+
+impl Action for CreatePlaylistAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let mut output_writer: Box<dyn Write> = match args.value_of("output") {
+            Some(file_name) => File::create(file_name).map(Box::new).map_err(|_| {
+                CliError::ActionError("Unable to create provided output file".to_string())
+            })?,
+            None => Box::new(std::io::stdout()),
+        };
+
+        let workload = args
+            .value_of("workload")
+            .ok_or_else(|| CliError::ActionError("Workload type is required".into()))?;
+
+        match workload {
+            "smallbank" => {
+                let num_accounts = args
+                    .value_of("smallbank_num_account")
+                    .unwrap_or(DEFAULT_ACCOUNTS)
+                    .parse()
+                    .map_err(|_| {
+                        CliError::ActionError("Unable to parse number of accounts".into())
+                    })?;
+
+                if num_accounts < 2 {
+                    return Err(CliError::ActionError(
+                        "'accounts' must be a number greater than 2".to_string(),
+                    ));
+                }
+
+                let num_transactions = args
+                    .value_of("transactions")
+                    .unwrap_or(DEFAULT_TRANSACTIONS)
+                    .parse()
+                    .map_err(|_| {
+                        CliError::ActionError("Unable to parse number of accounts".into())
+                    })?;
+
+                let random_seed = match args.value_of("smallbank_seed") {
+                    Some(seed) => match seed.parse::<i32>() {
+                        Ok(n) => Some(n),
+                        Err(_) => {
+                            return Err(CliError::ActionError(
+                                "'seed' must be a valid number".to_string(),
+                            ))
+                        }
+                    },
+                    None => None,
+                };
+
+                generate_smallbank_playlist(
+                    &mut *output_writer,
+                    num_accounts,
+                    num_transactions,
+                    random_seed,
+                )
+                .map_err(|err| {
+                    CliError::ActionError(format!("Unable to generate smallbank playlist: {}", err))
+                })?;
+
+                Ok(())
+            }
+            _ => Err(CliError::ActionError(format!(
+                "Unsupported workload type: {}",
+                workload
+            ))),
+        }
+    }
+}
+
+pub struct ProcessPlaylistAction;
+
+impl Action for ProcessPlaylistAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let mut in_file = File::open(
+            args.value_of("input")
+                .ok_or_else(|| CliError::ActionError("'input' is required".into()))?,
+        )
+        .map_err(|_| CliError::ActionError("Unable to open input file".to_string()))?;
+
+        let mut output_writer: Box<dyn Write> = match args.value_of("output") {
+            Some(file_name) => File::create(file_name).map(Box::new).map_err(|_| {
+                CliError::ActionError("Unable to create provided output file".to_string())
+            })?,
+            None => Box::new(std::io::stdout()),
+        };
+
+        let key_path = args
+            .value_of("key")
+            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
+        let signer = load_cylinder_signer_key(key_path)?;
+
+        let workload = args
+            .value_of("workload")
+            .ok_or_else(|| CliError::ActionError("Workload type is required".into()))?;
+
+        match workload {
+            "smallbank" => process_smallbank_playlist(&mut output_writer, &mut in_file, &*signer)
+                .map_err(|err| {
+                CliError::ActionError(format!("Unable to processes smallbank playlist: {}", err))
+            })?,
+            _ => {
+                return Err(CliError::ActionError(format!(
+                    "Unsupported workload type: {}",
+                    workload
+                )))
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct BatchPlaylistAction;
+
+impl Action for BatchPlaylistAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let max_txns: usize = args
+            .value_of("max-batch-size")
+            .unwrap_or(DEFAULT_BATCH_SIZE)
+            .parse()
+            .map_err(|_| CliError::ActionError("Unable to parse provided max-batch-size".into()))?;
+
+        if max_txns == 0 {
+            return Err(CliError::ActionError(
+                "max-batch-size must be a number greater than 0".to_string(),
+            ));
+        }
+
+        let mut in_file = File::open(
+            args.value_of("input")
+                .ok_or_else(|| CliError::ActionError("'input' is required".into()))?,
+        )
+        .map_err(|_| CliError::ActionError("Unable to open input file".to_string()))?;
+
+        let mut out_file = File::create(
+            args.value_of("output")
+                .ok_or_else(|| CliError::ActionError("'output' is required".into()))?,
+        )
+        .map_err(|_| CliError::ActionError("Unable to open output file".to_string()))?;
+
+        let key_path = args
+            .value_of("key")
+            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
+        let signer = load_cylinder_signer_key(key_path)?;
+
+        generate_signed_batches(&mut in_file, &mut out_file, max_txns, &*signer).map_err(
+            |err| CliError::ActionError(format!("Unable to generate signed batches: {}", err)),
+        )?;
+
+        Ok(())
+    }
+}
+
+pub struct SubmitPlaylistAction;
+
+impl Action for SubmitPlaylistAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let key_path = args
+            .value_of("key")
+            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
+        let (auth, _) = create_cylinder_jwt_auth_signer_key(key_path)?;
+
+        let rate: u32 = args
+            .value_of("rate")
+            .unwrap_or(DEFAULT_RATE)
+            .parse()
+            .map_err(|_| CliError::ActionError("Unable to parse provided rate".into()))?;
+
+        if rate == 0 {
+            return Err(CliError::ActionError(
+                "rate must be a number greater than 0".to_string(),
+            ));
+        }
+
+        let target = args
+            .value_of("target")
+            .ok_or_else(|| CliError::ActionError("'targets' are required".into()))?;
+
+        let input = args
+            .value_of("input")
+            .ok_or_else(|| CliError::ActionError("'input' is required".into()))?;
+
+        let mut in_file = File::open(&input)
+            .map_err(|_| CliError::ActionError("Unable to open input file".to_string()))?;
+
+        info!("Input: {} Target: {:?} Rate: {}", input, target, rate);
+
+        let update: u32 = args
+            .value_of("update")
+            .unwrap_or(&DEFAULT_LOG_TIME_SECS.to_string())
+            .parse()
+            .map_err(|_| CliError::ActionError("Unable to parse provided update time".into()))?;
+
+        let target_vec: Vec<String> = target.split(';').map(String::from).collect();
+
+        submit_batches_from_source(
+            &mut in_file,
+            input.to_string(),
+            target_vec,
+            rate,
+            auth,
+            update,
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -21,7 +21,7 @@ use rand::Rng;
 use transact::families::smallbank::workload::{
     playlist::SmallbankGeneratingIter, SmallbankBatchWorkload, SmallbankTransactionWorkload,
 };
-use transact::workload::WorkloadRunner;
+use transact::workload::{WorkloadRunner, DEFAULT_LOG_TIME_SECS};
 
 use crate::error::CliError;
 
@@ -85,7 +85,7 @@ impl Action for WorkloadAction {
 
         let update: u32 = args
             .value_of("update")
-            .unwrap_or("30")
+            .unwrap_or(&DEFAULT_LOG_TIME_SECS.to_string())
             .parse()
             .map_err(|_| CliError::ActionError("Unable to parse provided update time".into()))?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,14 +18,17 @@ mod action;
 pub mod error;
 
 use clap::clap_app;
-#[cfg(feature = "workload")]
+#[cfg(any(feature = "workload", feature = "playlist"))]
 use clap::{Arg, SubCommand};
 use flexi_logger::{DeferredNow, LogSpecBuilder, Logger};
 use log::Record;
 use std::ffi::OsString;
 
+#[cfg(feature = "playlist")]
+use crate::action::playlist;
 #[cfg(feature = "workload")]
-use crate::action::{workload, Action, SubcommandActions};
+use crate::action::workload;
+use crate::action::{Action, SubcommandActions};
 use crate::error::CliError;
 
 const APP_NAME: &str = env!("CARGO_PKG_NAME");
@@ -116,6 +119,193 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                 ),
         );
     }
+    #[cfg(feature = "playlist")]
+    {
+        app = app.subcommand(
+            SubCommand::with_name("playlist")
+                .about("Create and process playlists of pregenerated payloads")
+                .subcommand(
+                    SubCommand::with_name("create")
+                        .about(
+                            "Generates a workload transaction playlist. \
+                         A playlist is a series of transactions, described in \
+                         YAML.  This command generates a playlist and writes it \
+                         to file or standard out.",
+                        )
+                        .arg(
+                            Arg::with_name("workload")
+                                .long("workload")
+                                .takes_value(true)
+                                .required(true)
+                                .possible_values(&["smallbank"])
+                                .help("The workload type to create a playlist for"),
+                        )
+                        .arg(
+                            Arg::with_name("output")
+                                .short("o")
+                                .long("output")
+                                .value_name("FILE")
+                                .help("The target for the generated playlist"),
+                        )
+                        .arg(
+                            Arg::with_name("smallbank_num_accounts")
+                                .long("smallbank-num-accounts")
+                                .value_name("ACCOUNTS")
+                                .help("The number of smallbank accounts to make. Defaults to 10"),
+                        )
+                        .arg(
+                            Arg::with_name("smallbank_seed")
+                                .long("smallbank-seed")
+                                .value_name("SEED")
+                                .long_help(
+                                    "An integer to use as a seed generate the same smallbank \
+                                    playlist",
+                                ),
+                        )
+                        .arg(
+                            Arg::with_name("transactions")
+                                .short("n")
+                                .long("transactions")
+                                .value_name("NUMBER")
+                                .required(true)
+                                .help("The number of transactions to generate. Defaults to 10"),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("process")
+                        .about(
+                            "Processes a transaction playlist. \
+                     A playlist is a series of transactions, described in \
+                     YAML.  This command processes a playlist, converting it into \
+                     transactions and writes it to file or standard out.",
+                        )
+                        .arg(
+                            Arg::with_name("input")
+                                .short("i")
+                                .long("input")
+                                .value_name("FILE")
+                                .required(true)
+                                .help("The source of the input playlist yaml"),
+                        )
+                        .arg(
+                            Arg::with_name("key")
+                                .short("k")
+                                .long("key")
+                                .value_name("FILE")
+                                .required(true)
+                                .help("The signing key for the transactions"),
+                        )
+                        .arg(
+                            Arg::with_name("output")
+                                .short("o")
+                                .long("output")
+                                .value_name("FILE")
+                                .help("The target for the generated transactions"),
+                        )
+                        .arg(
+                            Arg::with_name("workload")
+                                .long("workload")
+                                .takes_value(true)
+                                .required(true)
+                                .possible_values(&["smallbank"])
+                                .help("The workload to be submitted"),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("batch")
+                        .about(
+                            "Generates signed batches from transaction input. \
+                     The transaction input is expected to be length-delimited protobuf \
+                     Transaction messages, which should also be pre-signed for \
+                     submission to the validator.",
+                        )
+                        .arg(
+                            Arg::with_name("input")
+                                .short("i")
+                                .long("input")
+                                .value_name("FILE")
+                                .required(true)
+                                .help("The source of input transactions"),
+                        )
+                        .arg(
+                            Arg::with_name("output")
+                                .short("o")
+                                .long("output")
+                                .value_name("FILE")
+                                .required(true)
+                                .help("The target for the signed batches"),
+                        )
+                        .arg(
+                            Arg::with_name("key")
+                                .short("k")
+                                .long("key")
+                                .value_name("FILE")
+                                .required(true)
+                                .help("The signing key for the transactions"),
+                        )
+                        .arg(
+                            Arg::with_name("max-batch-size")
+                                .short("n")
+                                .long("max-batch-size")
+                                .value_name("NUMBER")
+                                .help(
+                                    "The maximum number of transactions to include in a batch; \
+                             Defaults to 1.",
+                                ),
+                        ),
+                )
+                .subcommand(
+                    SubCommand::with_name("submit")
+                        .about(
+                            "Submits signed batches to one or more targets from batch input. \
+                     The batch input is expected to be length-delimited protobuf \
+                     Batch messages, which should also be pre-signed for \
+                     submission to the validator.",
+                        )
+                        .arg(
+                            Arg::with_name("target")
+                                .long("target")
+                                .takes_value(true)
+                                .required(true)
+                                .help("Node URLS to submit batches to, combine mulitple with ;"),
+                        )
+                        .arg(
+                            Arg::with_name("rate")
+                                .short("r")
+                                .long("rate")
+                                .value_name("RATE")
+                                .long_help(
+                                    "The number of batches per second to submit to the target, \
+                                defaults to 1",
+                                ),
+                        )
+                        .arg(
+                            Arg::with_name("key")
+                                .value_name("private-key-file")
+                                .short("k")
+                                .long("key")
+                                .takes_value(true)
+                                .help("Path to private key file"),
+                        )
+                        .arg(
+                            Arg::with_name("input")
+                                .short("i")
+                                .long("input")
+                                .value_name("FILE")
+                                .help("The source of batch transactions"),
+                        )
+                        .arg(
+                            Arg::with_name("update")
+                                .long("update")
+                                .short("u")
+                                .takes_value(true)
+                                .help(
+                                    "The time in seconds between updates, defaults to 30 seconds",
+                                ),
+                        ),
+                ),
+        );
+    }
 
     let matches = app.get_matches_from_safe(args)?;
 
@@ -146,13 +336,28 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
         Err(err) => panic!("Failed to start logger: {}", err),
     }
 
+    // needs to be mut if workload or playlist is enabled
+    #[allow(unused_mut)]
+    let mut subcommands = SubcommandActions::new();
+
     #[cfg(feature = "workload")]
     {
-        let mut subcommands =
-            SubcommandActions::new().with_command("workload", workload::WorkloadAction);
-
-        subcommands.run(Some(&matches))?;
+        subcommands = subcommands.with_command("workload", workload::WorkloadAction)
     }
+
+    #[cfg(feature = "playlist")]
+    {
+        subcommands = subcommands.with_command(
+            "playlist",
+            SubcommandActions::new()
+                .with_command("create", playlist::CreatePlaylistAction)
+                .with_command("process", playlist::ProcessPlaylistAction)
+                .with_command("submit", playlist::SubmitPlaylistAction)
+                .with_command("batch", playlist::BatchPlaylistAction),
+        );
+    }
+
+    subcommands.run(Some(&matches))?;
     Ok(())
 }
 

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -108,6 +108,7 @@ experimental = [
     "key-value-state",
     "protocol-sabre-exec",
     "workload",
+    "workload-batch-gen",
     "workload-runner"
 ]
 
@@ -164,7 +165,13 @@ state-merkle = ["cbor-codec", "log", "openssl"]
 # not enabled by default, due to its requirement of an external redis instance.
 state-merkle-redis-db-tests = ["database-redis", "state-merkle"]
 workload = []
-workload-runner = ["chrono", "reqwest", "serde", "serde_derive"]
+workload-batch-gen = ["workload"]
+workload-runner = [
+  "chrono",
+  "reqwest",
+  "serde",
+  "serde_derive",
+  "workload-batch-gen"]
 
 [package.metadata.docs.rs]
 features = [

--- a/libtransact/src/protocol/sabre.rs
+++ b/libtransact/src/protocol/sabre.rs
@@ -590,8 +590,6 @@ impl std::fmt::Display for AddressingError {
 mod tests {
     use super::*;
 
-    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
-
     #[test]
     // check that a execute contract action is built correctly
     fn check_execute_contract_action() {
@@ -629,11 +627,5 @@ mod tests {
 
         let execute = ExecuteContractAction::from_bytes(&bytes).unwrap();
         assert_eq!(execute, original);
-    }
-
-    fn new_signer() -> Box<dyn Signer> {
-        let context = Secp256k1Context::new();
-        let key = context.new_random_private_key();
-        context.new_signer(key)
     }
 }

--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Tools for generating signed batches from a stream of transactions
+
+use std::io::Read;
+use std::io::Write;
+
+use cylinder::Signer;
+use protobuf::Message;
+
+use crate::protocol::batch::BatchPair;
+use crate::protos::FromProto;
+use crate::protos::{
+    batch::{Batch, BatchHeader},
+    transaction::Transaction,
+};
+
+use super::error::{BatchReadingError, BatchingError};
+use super::source::LengthDelimitedMessageSource;
+
+/// Generates signed batches from a stream of length-delimited transactions.
+/// Constrains the batches to `max_batch_size` number of transactions per
+/// batch.  The resulting batches are written in a length-delimited fashion to
+/// the given writer.
+pub fn generate_signed_batches<'a>(
+    reader: &'a mut dyn Read,
+    writer: &'a mut dyn Write,
+    max_batch_size: usize,
+    signer: &dyn Signer,
+) -> Result<(), BatchingError> {
+    let mut producer = SignedBatchProducer::new(reader, max_batch_size, signer);
+    loop {
+        match producer.next() {
+            Some(Ok(batch)) => {
+                if let Err(err) = batch.write_length_delimited_to_writer(writer) {
+                    return Err(BatchingError::MessageError(err));
+                }
+            }
+            None => break,
+            Some(Err(err)) => return Err(err),
+        }
+    }
+
+    Ok(())
+}
+
+type TransactionSource<'a> = LengthDelimitedMessageSource<'a, Transaction>;
+
+/// Produces signed batches from a length-delimited source of Transactions.
+pub struct SignedBatchProducer<'a> {
+    transaction_source: TransactionSource<'a>,
+    max_batch_size: usize,
+    signer: &'a dyn Signer,
+}
+
+/// Resulting batch or error.
+pub type BatchResult = Result<Batch, BatchingError>;
+
+impl<'a> SignedBatchProducer<'a> {
+    /// Creates a new `SignedBatchProducer` with a given Transaction source and
+    /// a max number of transactions per batch.
+    pub fn new(source: &'a mut dyn Read, max_batch_size: usize, signer: &'a dyn Signer) -> Self {
+        let transaction_source = LengthDelimitedMessageSource::new(source);
+        SignedBatchProducer {
+            transaction_source,
+            max_batch_size,
+            signer,
+        }
+    }
+}
+
+impl<'a> Iterator for SignedBatchProducer<'a> {
+    type Item = BatchResult;
+
+    /// Gets the next BatchResult.
+    /// `Ok(None)` indicates that the underlying source has been consumed.
+    fn next(&mut self) -> Option<BatchResult> {
+        let txns = match self.transaction_source.next(self.max_batch_size) {
+            Ok(txns) => txns,
+            Err(err) => return Some(Err(BatchingError::MessageError(err))),
+        };
+        if txns.is_empty() {
+            None
+        } else {
+            Some(batch_transactions(txns, self.signer))
+        }
+    }
+}
+
+fn batch_transactions(txns: Vec<Transaction>, signer: &dyn Signer) -> BatchResult {
+    let mut batch_header = BatchHeader::new();
+
+    // set signer_public_key
+    let pk = match signer.public_key() {
+        Ok(pk) => pk,
+        Err(err) => return Err(BatchingError::SigningError(err)),
+    };
+    let public_key = pk.as_hex();
+
+    let txn_ids = txns
+        .iter()
+        .map(|txn| String::from(txn.get_header_signature()))
+        .collect();
+    batch_header.set_transaction_ids(protobuf::RepeatedField::from_vec(txn_ids));
+    batch_header.set_signer_public_key(public_key);
+
+    let header_bytes = batch_header.write_to_bytes()?;
+    let signature = signer
+        .sign(&header_bytes)
+        .map_err(BatchingError::SigningError);
+    match signature {
+        Ok(signature) => {
+            let mut batch = Batch::new();
+            batch.set_header_signature(signature.as_hex());
+            batch.set_header(header_bytes);
+            batch.set_transactions(protobuf::RepeatedField::from_vec(txns));
+
+            Ok(batch)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+pub struct SignedBatchIterator<'a> {
+    transaction_iterator: &'a mut dyn Iterator<Item = Transaction>,
+    max_batch_size: usize,
+    signer: &'a dyn Signer,
+}
+
+impl<'a> SignedBatchIterator<'a> {
+    pub fn new(
+        iterator: &'a mut dyn Iterator<Item = Transaction>,
+        max_batch_size: usize,
+        signer: &'a dyn Signer,
+    ) -> Self {
+        SignedBatchIterator {
+            transaction_iterator: iterator,
+            max_batch_size,
+            signer,
+        }
+    }
+}
+
+impl<'a> Iterator for SignedBatchIterator<'a> {
+    type Item = BatchResult;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let txns = self
+            .transaction_iterator
+            .take(self.max_batch_size)
+            .collect();
+
+        Some(batch_transactions(txns, self.signer))
+    }
+}
+
+type BatchSource<'a> = LengthDelimitedMessageSource<'a, Batch>;
+
+/// Produces batches from length-delimited source of Batches.
+pub struct BatchListFeeder<'a> {
+    batch_source: BatchSource<'a>,
+}
+
+/// Resulting BatchList or error.
+pub type BatchListResult = Result<BatchPair, BatchReadingError>;
+
+impl<'a> BatchListFeeder<'a> {
+    /// Creates a new `BatchListFeeder` with a given Batch source
+    pub fn new(source: &'a mut dyn Read) -> Self {
+        let batch_source = LengthDelimitedMessageSource::new(source);
+        BatchListFeeder { batch_source }
+    }
+}
+
+impl<'a> Iterator for BatchListFeeder<'a> {
+    type Item = BatchListResult;
+
+    /// Gets the next Batch.
+    /// `Ok(None)` indicates that the underlying source has been consumed.
+    fn next(&mut self) -> Option<Self::Item> {
+        let batches = match self.batch_source.next(1) {
+            Ok(batches) => batches,
+            Err(err) => return Some(Err(BatchReadingError::MessageError(err))),
+        };
+
+        let batch_proto = match batches.get(0) {
+            Some(batch_proto) => batch_proto,
+            None => return None,
+        };
+
+        match BatchPair::from_proto(batch_proto.clone()) {
+            Ok(batch) => Some(Ok(batch)),
+            Err(err) => Some(Err(BatchReadingError::ProtoConversionError(err))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::{Cursor, Write};
+
+    use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
+
+    use crate::protos::transaction::TransactionHeader;
+
+    type BatchSource<'a> = LengthDelimitedMessageSource<'a, Batch>;
+
+    #[test]
+    fn empty_transaction_source() {
+        let encoded_bytes: Vec<u8> = Vec::new();
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut txn_stream: TransactionSource = LengthDelimitedMessageSource::new(&mut source);
+        let txns = txn_stream.next(2).unwrap();
+        assert_eq!(txns.len(), 0);
+    }
+
+    #[test]
+    fn next_transactions() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+        write_txn_with_sig("sig2", &mut encoded_bytes);
+        write_txn_with_sig("sig3", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut txn_stream: TransactionSource = LengthDelimitedMessageSource::new(&mut source);
+
+        let mut txns = txn_stream.next(2).unwrap();
+        assert_eq!(txns.len(), 2);
+
+        // ensure that it is exhausted, even when more are requested
+        txns = txn_stream.next(2).unwrap();
+        assert_eq!(txns.len(), 1);
+    }
+
+    #[test]
+    fn signed_batches_empty_transactions() {
+        let encoded_bytes: Vec<u8> = Vec::new();
+        let mut source = Cursor::new(encoded_bytes);
+
+        let signer = new_signer();
+
+        let mut producer = SignedBatchProducer::new(&mut source, 2, &*signer);
+        let batch_result = producer.next();
+
+        assert!(batch_result.is_none());
+    }
+
+    #[test]
+    fn signed_batches_single_transaction() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+
+        let signer = new_signer();
+
+        let mut producer = SignedBatchProducer::new(&mut source, 2, &*signer);
+        let mut batch_result = producer.next();
+        assert!(batch_result.is_some());
+
+        let batch = batch_result.unwrap().unwrap();
+
+        let batch_header: BatchHeader = Message::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 1);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig1"));
+
+        // test exhaustion
+        batch_result = producer.next();
+        assert!(batch_result.is_none());
+    }
+
+    #[test]
+    fn signed_batches_multiple_batches() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+        write_txn_with_sig("sig2", &mut encoded_bytes);
+        write_txn_with_sig("sig3", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+
+        let signer = new_signer();
+
+        let mut producer = SignedBatchProducer::new(&mut source, 2, &*signer);
+        let mut batch_result = producer.next();
+        assert!(batch_result.is_some());
+
+        let batch = batch_result.unwrap().unwrap();
+
+        let signature = signer
+            .sign(&batch.header)
+            .expect("Unable to sign batch header");
+
+        let batch_header: BatchHeader = Message::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 2);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig1"));
+        assert_eq!(batch_header.transaction_ids[1], String::from("sig2"));
+        assert_eq!(batch.header_signature, signature.as_hex());
+
+        // pull the next batch
+        batch_result = producer.next();
+        assert!(batch_result.is_some());
+
+        let batch = batch_result.unwrap().unwrap();
+
+        let batch_header: BatchHeader = Message::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 1);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig3"));
+
+        // test exhaustion
+        batch_result = producer.next();
+        assert!(batch_result.is_none());
+    }
+
+    #[test]
+    fn generate_signed_batches() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+        write_txn_with_sig("sig2", &mut encoded_bytes);
+        write_txn_with_sig("sig3", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+        let output_bytes: Vec<u8> = Vec::new();
+        let mut output = Cursor::new(output_bytes);
+
+        let signer = new_signer();
+
+        super::generate_signed_batches(&mut source, &mut output, 2, &*signer)
+            .expect("Should have generated batches!");
+
+        // reset for reading
+        output.set_position(0);
+        let mut batch_source: BatchSource = LengthDelimitedMessageSource::new(&mut output);
+
+        let batch = &(batch_source.next(1).unwrap())[0];
+        let batch_header: BatchHeader = Message::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 2);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig1"));
+        assert_eq!(batch_header.transaction_ids[1], String::from("sig2"));
+
+        let batch = &(batch_source.next(1).unwrap())[0];
+        let batch_header: BatchHeader = Message::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 1);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig3"));
+    }
+
+    fn make_txn(sig: &str) -> Transaction {
+        let mut txn_header = TransactionHeader::new();
+
+        txn_header.set_batcher_public_key(String::from("some_public_key"));
+        txn_header.set_family_name(String::from("test_family"));
+        txn_header.set_family_version(String::from("1.0"));
+        txn_header.set_signer_public_key(String::from("some_public_key"));
+        txn_header.set_payload_sha512(String::from("some_sha512_hash"));
+
+        let mut txn = Transaction::new();
+        txn.set_header(txn_header.write_to_bytes().unwrap());
+        txn.set_header_signature(String::from(sig));
+        txn.set_payload(sig.as_bytes().to_vec());
+
+        txn
+    }
+
+    fn write_txn_with_sig(sig: &str, out: &mut dyn Write) {
+        let txn = make_txn(sig);
+        txn.write_length_delimited_to_writer(out)
+            .expect("Unable to write delimiter");
+    }
+
+    fn new_signer() -> Box<dyn Signer> {
+        let context = Secp256k1Context::new();
+        let key = context.new_random_private_key();
+        context.new_signer(key)
+    }
+}

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -16,8 +16,11 @@
  * -----------------------------------------------------------------------------
  */
 
+use cylinder::SigningError;
+
 use crate::protocol::batch::BatchBuildError;
 use crate::protocol::transaction::TransactionBuildError;
+use crate::protos::ProtoConversionError;
 
 #[derive(Debug)]
 pub enum WorkloadError {
@@ -98,6 +101,88 @@ impl std::fmt::Display for WorkloadRunnerError {
             WorkloadRunnerError::WorkloadRemoveError(ref err) => {
                 write!(f, "Unable to remove workload: {}", err)
             }
+        }
+    }
+}
+
+// Errors that may occur during the generation of batches from a source.
+#[derive(Debug)]
+pub enum BatchingError {
+    MessageError(protobuf::ProtobufError),
+    SigningError(SigningError),
+}
+
+impl From<SigningError> for BatchingError {
+    fn from(err: SigningError) -> Self {
+        BatchingError::SigningError(err)
+    }
+}
+
+impl From<protobuf::ProtobufError> for BatchingError {
+    fn from(err: protobuf::ProtobufError) -> Self {
+        BatchingError::MessageError(err)
+    }
+}
+
+impl std::fmt::Display for BatchingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BatchingError::MessageError(ref err) => {
+                write!(f, "Error occurred reading messages: {}", err)
+            }
+            BatchingError::SigningError(ref err) => write!(f, "Unable to sign batch: {}", err),
+        }
+    }
+}
+
+impl std::error::Error for BatchingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            BatchingError::MessageError(ref err) => Some(err),
+            BatchingError::SigningError(ref err) => Some(err),
+        }
+    }
+}
+
+/// Errors that may occur during the reading of batches.
+#[derive(Debug)]
+pub enum BatchReadingError {
+    MessageError(protobuf::ProtobufError),
+    BatchingError(BatchingError),
+    UnknownError,
+    ProtoConversionError(ProtoConversionError),
+}
+
+impl From<protobuf::ProtobufError> for BatchReadingError {
+    fn from(err: protobuf::ProtobufError) -> Self {
+        BatchReadingError::MessageError(err)
+    }
+}
+
+impl std::fmt::Display for BatchReadingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            BatchReadingError::MessageError(ref err) => {
+                write!(f, "Error occurred reading messages: {}", err)
+            }
+            BatchReadingError::BatchingError(ref err) => {
+                write!(f, "Error creating the batch: {}", err)
+            }
+            BatchReadingError::UnknownError => write!(f, "There was an unknown batching error."),
+            BatchReadingError::ProtoConversionError(ref err) => {
+                write!(f, "Error converting batch from proto: {}", err)
+            }
+        }
+    }
+}
+
+impl std::error::Error for BatchReadingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            BatchReadingError::MessageError(ref err) => Some(err),
+            BatchReadingError::BatchingError(ref err) => Some(err),
+            BatchReadingError::UnknownError => Some(&BatchReadingError::UnknownError),
+            BatchReadingError::ProtoConversionError(ref err) => Some(err),
         }
     }
 }

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -15,10 +15,12 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
-
+#[cfg(feature = "workload-batch-gen")]
+pub mod batch_gen;
 pub mod error;
 #[cfg(feature = "workload-runner")]
 pub mod runner;
+pub mod source;
 
 use crate::protocol::batch::BatchPair;
 use crate::protocol::transaction::TransactionPair;

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -27,7 +27,7 @@ use crate::protocol::transaction::TransactionPair;
 use crate::workload::error::WorkloadError;
 #[cfg(feature = "workload-runner")]
 pub use crate::workload::runner::{
-    submit_batches_from_source, WorkloadRunner,
+    submit_batches_from_source, WorkloadRunner, DEFAULT_LOG_TIME_SECS,
 };
 
 pub trait TransactionWorkload: Send {

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -26,7 +26,9 @@ use crate::protocol::batch::BatchPair;
 use crate::protocol::transaction::TransactionPair;
 use crate::workload::error::WorkloadError;
 #[cfg(feature = "workload-runner")]
-pub use crate::workload::runner::WorkloadRunner;
+pub use crate::workload::runner::{
+    submit_batches_from_source, WorkloadRunner,
+};
 
 pub trait TransactionWorkload: Send {
     fn next_transaction(&mut self) -> Result<TransactionPair, WorkloadError>;

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -32,7 +32,7 @@ use super::batch_gen::BatchListFeeder;
 use super::error::WorkloadRunnerError;
 use super::BatchWorkload;
 
-const DEFAULT_LOG_TIME_SECS: u32 = 30; // time in seconds
+pub const DEFAULT_LOG_TIME_SECS: u32 = 30; // time in seconds
 
 /// Keeps track of the currenlty running workloads.
 ///

--- a/libtransact/src/workload/source.rs
+++ b/libtransact/src/workload/source.rs
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Tools for generating signed batches from a stream of transactions
+
+use std::io::Read;
+use std::marker::PhantomData;
+
+use protobuf::Message;
+
+/// Decodes Protocol Buffer messages from a length-delimited input reader.
+pub struct LengthDelimitedMessageSource<'a, T: 'a> {
+    source: protobuf::CodedInputStream<'a>,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> LengthDelimitedMessageSource<'a, T>
+where
+    T: Message,
+{
+    /// Creates a new `LengthDelimitedMessageSource` from a given reader.
+    pub fn new(source: &'a mut dyn Read) -> Self {
+        let source = protobuf::CodedInputStream::new(source);
+        LengthDelimitedMessageSource {
+            source,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns the next set of messages.
+    /// The vector of messages will contain up to `max_msgs` number of
+    /// messages.  An empty vector indicates that the source has been consumed.
+    pub fn next(&mut self, max_msgs: usize) -> Result<Vec<T>, protobuf::ProtobufError> {
+        let mut results = Vec::with_capacity(max_msgs);
+        for _ in 0..max_msgs {
+            if self.source.eof()? {
+                break;
+            }
+
+            // read the delimited length
+            let next_len = self.source.read_raw_varint32()?;
+            let buf = self.source.read_raw_bytes(next_len)?;
+
+            let msg = Message::parse_from_bytes(&buf)?;
+            results.push(msg);
+        }
+        Ok(results)
+    }
+}


### PR DESCRIPTION
This command can be used to generate files of pregenerated
payloads, transactions, and batches. The file containing
the batches can then be submitted against a distributed
ledger.

Payload, transactions and batch generation can be very
expensive and can skew performance results during testing.
Using a pregenerated batch file makes for a more accurate
and repeatable test.

This commit adds the following subscommands and man pages:

batch: Generates signed batches from transaction input.
create: Generates a workload transaction playlist.
process: Processes a transaction playlist.
submit: Submits signed batches to one or more targets from
	batch input.

These subcommands are all behind the experimental feature
"playlist"

To test run the following commands:

```
transact playlist create --smallbank-num-accounts 10 \
  --output test.yaml  \
  --smallbank-seed 10 --transactions 20  \
  --workload smallbank
```

```
transact playlist process -i test.yaml \
  --key PATH_TO_KEY \
  --output test_txn.txt \
  --workload smallbank
```

```
transact playlist batch --input test_txn.txt \
   --key PATH_TO_KEY \
  --output test_batch.txt
```

Before running submit, you would need a splinter circuit running with a scabbard service and the smallbank smart contract submitted to sabre. Then you can run 

```
transact playlist submit --input test_batch.txt \
  --key PATH_TO_KEY \
  --rate 1  \
  --target "http://0.0.0.0:8089/scabbard/CIRCUIT_ID/SERVICE_ID"
```
