### PR TITLE
Add missing check for if source savings balance is zero

### DIFF
--- a/libtransact/src/families/smallbank/handler.rs
+++ b/libtransact/src/families/smallbank/handler.rs
@@ -262,6 +262,13 @@ fn apply_amalgamate(
     let mut dest_account =
         load_account(amalgamate_data.get_dest_customer_id(), context)?.ok_or_else(err)?;
 
+    if source_account.get_savings_balance() == 0 {
+        warn!("Invalid transaction: Source account savings balance cannot be 0 in amalgamate");
+        return Err(ApplyError::InvalidTransaction(
+            "Source account savings balance cannot be 0 in amalgamate".to_string(),
+        ));
+    }
+
     let balance = dest_account.get_checking_balance() + source_account.get_savings_balance();
     source_account.set_savings_balance(0);
     dest_account.set_checking_balance(balance);

--- a/libtransact/src/families/smallbank/handler.rs
+++ b/libtransact/src/families/smallbank/handler.rs
@@ -312,8 +312,8 @@ fn save_account(account: &Account, context: &mut dyn TransactionContext) -> Resu
     })?;
 
     context.set_state_entry(address, data).map_err(|err| {
-        warn!("Invalid transaction: Failed to load Account: {:?}", err);
-        ApplyError::InvalidTransaction(format!("Failed to load Account: {:?}", err))
+        warn!("Invalid transaction: Failed to save Account: {:?}", err);
+        ApplyError::InvalidTransaction(format!("Failed to save Account: {:?}", err))
     })
 }
 


### PR DESCRIPTION
The amalgamate transaction should check to see if the savings
balance of the source account is 0 and return an invalid
transaction if it is.

This was specified in the transaction family specification
but was missed in the implementation.

Without this check the transaction would act as an unexpected
noop transaction.
