### PR TITLE
Backport: Fix clippy errors introduced in Rust 1.50

### DIFF
--- a/libtransact/src/contract/context/key_value.rs
+++ b/libtransact/src/contract/context/key_value.rs
@@ -350,11 +350,11 @@ where
                     .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))
             })
             .collect::<Result<Vec<StateEntryValue>, ContractContextError>>()?;
-        Ok(StateEntryBuilder::new()
+        StateEntryBuilder::new()
             .with_normalized_key(self.addresser.normalize(key.to_owned()))
             .with_state_entry_values(state_values)
             .build()
-            .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))?)
+            .map_err(|err| ContractContextError::ProtocolBuildError(Box::new(err)))
     }
 }
 

--- a/libtransact/src/database/btree.rs
+++ b/libtransact/src/database/btree.rs
@@ -237,7 +237,8 @@ impl<'a> DatabaseWriter for BTreeWriter<'a> {
     }
 
     fn commit(self: Box<Self>) -> Result<(), DatabaseError> {
-        BTreeWriter::commit(self.db, self.transactions)
+        BTreeWriter::commit(self.db, self.transactions);
+        Ok(())
     }
 
     fn as_reader(&self) -> &dyn DatabaseReader {
@@ -246,10 +247,7 @@ impl<'a> DatabaseWriter for BTreeWriter<'a> {
 }
 
 impl<'a> BTreeWriter<'a> {
-    fn commit(
-        mut db: RwLockWriteGuard<'a, BTreeDbInternal>,
-        transactions: Vec<WriterTransaction>,
-    ) -> Result<(), DatabaseError> {
+    fn commit(mut db: RwLockWriteGuard<'a, BTreeDbInternal>, transactions: Vec<WriterTransaction>) {
         for transaction in transactions {
             match transaction {
                 WriterTransaction::Put { key, value } => {
@@ -269,7 +267,6 @@ impl<'a> BTreeWriter<'a> {
                 }
             }
         }
-        Ok(())
     }
 }
 

--- a/libtransact/src/execution/executor/internal.rs
+++ b/libtransact/src/execution/executor/internal.rs
@@ -441,11 +441,7 @@ impl ExecutorThread {
                 p.push(execution_event);
                 None
             }
-            None => {
-                let mut p = vec![];
-                p.push(execution_event);
-                Some(p)
-            }
+            None => Some(vec![execution_event]),
         };
         if let Some(p) = p {
             parked.insert(transaction_family, p);

--- a/libtransact/src/families/xo.rs
+++ b/libtransact/src/families/xo.rs
@@ -93,6 +93,7 @@ impl BatchWorkload for XoBatchWorkload {
 }
 
 enum Action {
+    #[allow(clippy::upper_case_acronyms)]
     CREATE,
 }
 

--- a/libtransact/src/protocol/transaction.rs
+++ b/libtransact/src/protocol/transaction.rs
@@ -39,6 +39,8 @@ static DEFAULT_NONCE_SIZE: usize = 32;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum HashMethod {
+    // For backwards compatibility ignore clippy error
+    #[allow(clippy::upper_case_acronyms)]
     SHA512,
 }
 

--- a/libtransact/src/scheduler/mod.rs
+++ b/libtransact/src/scheduler/mod.rs
@@ -90,13 +90,13 @@ pub struct InvalidTransactionResult {
     pub error_data: Vec<u8>,
 }
 
-impl Into<TransactionReceipt> for InvalidTransactionResult {
-    fn into(self) -> TransactionReceipt {
+impl From<InvalidTransactionResult> for TransactionReceipt {
+    fn from(result: InvalidTransactionResult) -> Self {
         TransactionReceipt {
-            transaction_id: self.transaction_id,
+            transaction_id: result.transaction_id,
             transaction_result: TransactionResult::Invalid {
-                error_message: self.error_message,
-                error_data: self.error_data,
+                error_message: result.error_message,
+                error_data: result.error_data,
             },
         }
     }

--- a/libtransact/src/scheduler/parallel/tree.rs
+++ b/libtransact/src/scheduler/parallel/tree.rs
@@ -65,8 +65,7 @@ impl<T: Clone> RadixTree<T> {
     /// Collects all children below ADDRESS, as well as the children's descendants
     fn walk_to_address(&self, address: &str) -> Vec<Rc<RefCell<Node<T>>>> {
         let mut current_node = Rc::clone(&self.root);
-        let mut results = vec![];
-        results.push(Rc::clone(&current_node));
+        let mut results = vec![Rc::clone(&current_node)];
 
         // A node's address is always a proper prefix of the addresses of its children
         while address != current_node.borrow().address.as_str()

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -210,7 +210,7 @@ impl MerkleRadixTree {
             let (deletion_candidates, duplicates) = MerkleRadixTree::remove_duplicate_hashes(
                 db_writer.as_reader(),
                 change_log.additions,
-            )?;
+            );
 
             for hash in &deletion_candidates {
                 let hash_hex = ::hex::encode(hash);
@@ -247,7 +247,7 @@ impl MerkleRadixTree {
                 MerkleRadixTree::remove_duplicate_hashes(
                     db_writer.as_reader(),
                     successor.deletions,
-                )?;
+                );
 
             for hash in &deletion_candidates {
                 let hash_hex = ::hex::encode(hash);
@@ -270,14 +270,14 @@ impl MerkleRadixTree {
     fn remove_duplicate_hashes(
         db_reader: &dyn DatabaseReader,
         deletions: Vec<Vec<u8>>,
-    ) -> Result<(Vec<StateHash>, Vec<StateHash>), StateDatabaseError> {
-        Ok(deletions.into_iter().partition(|key| {
+    ) -> (Vec<StateHash>, Vec<StateHash>) {
+        deletions.into_iter().partition(|key| {
             if let Ok(count) = get_ref_count(db_reader, &key) {
                 count == 0
             } else {
                 false
             }
-        }))
+        })
     }
     /// Returns the current merkle root for this MerkleRadixTree
     pub fn get_merkle_root(&self) -> String {


### PR DESCRIPTION
This differs from the main branch in that it allows errors that would have changed the public api.