### PR TITLE
Sqlite support updates

### DIFF
--- a/libtransact/src/database/sqlite.rs
+++ b/libtransact/src/database/sqlite.rs
@@ -106,6 +106,51 @@ impl ToSql for Synchronous {
     }
 }
 
+/// Journal Mode setting values.
+///
+/// See the [PRAGMA "journal_mode"](https://sqlite.org/pragma.html#pragma_journal_mode)
+/// documentation for more details.
+#[derive(Debug)]
+pub enum JournalMode {
+    /// The DELETE journaling mode is the normal behavior. In the DELETE mode, the rollback journal
+    /// is deleted at the conclusion of each transaction. Indeed, the delete operation is the
+    /// action that causes the transaction to commit.
+    Delete,
+    /// The TRUNCATE journaling mode commits transactions by truncating the rollback journal to
+    /// zero-length instead of deleting it.
+    Truncate,
+    /// The PERSIST journaling mode prevents the rollback journal from being deleted at the end of
+    /// each transaction. Instead, the header of the journal is overwritten with zeros. This will
+    /// prevent other database connections from rolling the journal back.
+    Persist,
+    /// The MEMORY journaling mode stores the rollback journal in volatile RAM.
+    Memory,
+    /// Enable "Write-Ahead Log" (WAL) journal mode.
+    ///
+    /// In SQLite, WAL journal mode provides considerable performance improvements in most
+    /// scenarios.  See [https://sqlite.org/wal.html](https://sqlite.org/wal.html) for more
+    /// details on this mode.
+    ///
+    /// While many of the disadvantages of this mode are unlikely to effect transact and its
+    /// use-cases, WAL mode cannot be used with a database file on a networked file system.
+    Wal,
+    /// Disables the rollback journal completely.
+    Off,
+}
+
+impl ToSql for JournalMode {
+    fn to_sql(&self) -> Result<ToSqlOutput, rusqlite::Error> {
+        match self {
+            JournalMode::Delete => Ok(ToSqlOutput::Borrowed(ValueRef::Text(b"DELETE"))),
+            JournalMode::Truncate => Ok(ToSqlOutput::Borrowed(ValueRef::Text(b"TRUNCATE"))),
+            JournalMode::Persist => Ok(ToSqlOutput::Borrowed(ValueRef::Text(b"PERSIST"))),
+            JournalMode::Memory => Ok(ToSqlOutput::Borrowed(ValueRef::Text(b"MEMORY"))),
+            JournalMode::Wal => Ok(ToSqlOutput::Borrowed(ValueRef::Text(b"WAL"))),
+            JournalMode::Off => Ok(ToSqlOutput::Borrowed(ValueRef::Text(b"OFF"))),
+        }
+    }
+}
+
 /// A builder for generating SqliteDatabase instances.
 pub struct SqliteDatabaseBuilder {
     path: Option<String>,
@@ -113,7 +158,7 @@ pub struct SqliteDatabaseBuilder {
     indexes: Vec<&'static str>,
     pool_size: Option<u32>,
     memory_map_size: i64,
-    write_ahead_log_mode: bool,
+    journal_mode: Option<JournalMode>,
     synchronous: Option<Synchronous>,
 }
 
@@ -125,7 +170,7 @@ impl SqliteDatabaseBuilder {
             indexes: vec![],
             pool_size: None,
             memory_map_size: DEFAULT_MMAP_SIZE,
-            write_ahead_log_mode: false,
+            journal_mode: None,
             synchronous: None,
         }
     }
@@ -169,16 +214,14 @@ impl SqliteDatabaseBuilder {
         self
     }
 
-    /// Enable "Write-Ahead Log" (WAL) journal mode.
+    /// Modify the "journal mode" setting for the SQLite connection.
     ///
-    /// In SQLite, WAL journal mode provides considerable performance improvements in most
-    /// scenarios.  See [https://sqlite.org/wal.html](https://sqlite.org/wal.html) for more
-    /// details on this mode.
+    /// See the [pragma journal_mode
+    /// documentation](https://sqlite.org/pragma.html#pragma_journal_mode) for more information.
     ///
-    /// While many of the disadvantages of this mode are unlikely to effect transact and its
-    /// use-cases, WAL mode cannot be used with a database file on a networked file system.
-    pub fn with_write_ahead_log_mode(mut self) -> Self {
-        self.write_ahead_log_mode = true;
+    /// If unchanged, the default value is left to underlying SQLite installation.
+    pub fn with_journal_mode(mut self, journal_mode: JournalMode) -> Self {
+        self.journal_mode = Some(journal_mode);
         self
     }
 
@@ -203,7 +246,7 @@ impl SqliteDatabaseBuilder {
     /// * No path provided
     /// * Unable to connect to the database.
     /// * Unable to configure the provided memory map size
-    /// * Unable to configure the WAL journal mode, if requested
+    /// * Unable to configure the journal mode, if requested
     /// * Unable to create tables, as required.
     pub fn build(self) -> Result<SqliteDatabase, SqliteDatabaseError> {
         let path = self.path.ok_or_else(|| SqliteDatabaseError {
@@ -235,10 +278,10 @@ impl SqliteDatabaseBuilder {
                 source: Some(Box::new(err)),
             })?;
 
-        if self.write_ahead_log_mode {
-            conn.pragma_update(None, "journal_mode", &String::from("WAL"))
+        if let Some(journal_mode) = self.journal_mode {
+            conn.pragma_update(None, "journal_mode", &journal_mode)
                 .map_err(|err| SqliteDatabaseError {
-                    context: "unable to configure WAL journal mode".into(),
+                    context: "unable to modify journal mode setting".into(),
                     source: Some(Box::new(err)),
                 })?;
         }

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1421,6 +1421,7 @@ mod sqlitedb {
         })
     }
 
+    /// Atomic Commit/Rollback is the default journal model.
     #[test]
     fn merkle_trie_update_atomic_commit_rollback() {
         run_test(|db_path| {

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1019,6 +1019,7 @@ mod btree {
     }
 }
 
+#[cfg(feature = "database-lmdb")]
 mod lmdb {
     //! LMDB-backed tests for the merkle state implementation.
 
@@ -1380,7 +1381,7 @@ mod redisdb {
     }
 }
 
-#[cfg(feature = "sqlite-db")]
+#[cfg(feature = "database-sqlite")]
 mod sqlitedb {
     use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1438,7 +1438,7 @@ mod sqlitedb {
                 SqliteDatabase::builder()
                     .with_path(db_path)
                     .with_indexes(&INDEXES)
-                    .with_write_ahead_log_mode()
+                    .with_journal_mode(transact::database::sqlite::JournalMode::Wal)
                     .build()
                     .expect("Unable to create Sqlite database"),
             );
@@ -1453,7 +1453,7 @@ mod sqlitedb {
                 SqliteDatabase::builder()
                     .with_path(db_path)
                     .with_indexes(&INDEXES)
-                    .with_write_ahead_log_mode()
+                    .with_journal_mode(transact::database::sqlite::JournalMode::Wal)
                     .with_synchronous(transact::database::sqlite::Synchronous::Full)
                     .build()
                     .expect("Unable to create Sqlite database"),

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -929,11 +929,11 @@ fn assert_has_successors(change_log: &ChangeLogEntry, successor_roots: &[&[u8]])
             }
         }
         if !has_root {
-            panic!(format!(
+            panic!(
                 "Root {} not found in change log {:?}",
                 ::hex::encode(successor_root),
                 change_log
-            ));
+            );
         }
     }
 }


### PR DESCRIPTION
This PR makes several changes to the SqliteDatabase implementation:

-  increases the journal mode options to match the possibilities available in the underlying sqlite library
- Applies PRAGMA only on connection creation

Additionally,
- Fixes some feature guards
- Fixes a warning in the tests