### PR TITLE
Command family smart contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 
 /cli/packaging/man/*.1
 
+/examples/sabre_command/target
+/examples/sabre_command/Cargo.lock
 /examples/sabre_smallbank/target
 /examples/sabre_smallbank/Cargo.lock
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ members = [
   "cli"
   ]
 
-# Exclude sabre_smallbank to avoid incompatible features `sabre-compat` and
-# `log`
-exclude = ["examples/sabre_smallbank"]
+# Exclude sabre_smallbank and sabre_command to avoid incompatible features
+# `sabre-compat` and `log`
+exclude = ["examples/sabre_smallbank", "examples/sabre_command"]

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -24,6 +24,14 @@ services:
       - REPO_VERSION=${REPO_VERSION}
     image: smallbank-scar:${ISOLATION_ID}
 
+  command-scar:
+    build:
+      context: .
+      dockerfile: examples/sabre_command/Dockerfile-scar
+      args:
+      - REPO_VERSION=${REPO_VERSION}
+    image: command-scar:${ISOLATION_ID}
+
   transact-cli:
     build:
       context: .

--- a/docker/compose/copy-debs.yaml
+++ b/docker/compose/copy-debs.yaml
@@ -25,6 +25,15 @@ services:
         cp /tmp/*.scar /build/scar
       "
 
+  command-scar:
+    image: command-scar:${ISOLATION_ID}
+    volumes:
+      - ../../build/scar:/build/scar
+    command: |
+      bash -c "
+        cp /tmp/*.scar /build/scar
+      "
+
   transact-cli:
     image: transact-cli:${ISOLATION_ID}
     volumes:

--- a/examples/sabre_command/Cargo.toml
+++ b/examples/sabre_command/Cargo.toml
@@ -1,0 +1,44 @@
+# Copyright 2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "sabre-command"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+
+[dependencies]
+protobuf = "2.19"
+sabre-sdk = "0.7.1"
+
+[dependencies.transact]
+path = "../../libtransact"
+default-features = false
+features = ["family-command", "sabre-compat"]
+
+
+[features]
+default = []
+
+stable = [
+    # The stable feature extends default:
+    "default",
+    # The following features are stable:
+]
+
+experimental = [
+    # The experimental feature extends stable:
+    "stable",
+    # The following features are experimental:
+]

--- a/examples/sabre_command/Dockerfile-scar
+++ b/examples/sabre_command/Dockerfile-scar
@@ -1,0 +1,100 @@
+# Copyright 2019-2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:bionic
+
+# Install base dependencies
+
+RUN apt-get update \
+ && apt-get install -y \
+ curl \
+ gcc \
+ libssl-dev \
+ libzmq3-dev \
+ pkg-config \
+ unzip
+
+ENV PATH=$PATH:/protoc3/bin:/root/.cargo/bin
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
+ && chmod +x /usr/bin/rustup-init \
+ && rustup-init -y
+
+RUN rustup update \
+ && rustup target add wasm32-unknown-unknown
+
+# Install protoc
+RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip \
+ && unzip -o protoc-3.7.1-linux-x86_64.zip -d /usr/local \
+ && rm protoc-3.7.1-linux-x86_64.zip
+
+WORKDIR /build
+
+# Create empty cargo project for transact
+RUN USER=root cargo new --lib libtransact
+
+# Copy over Cargo.toml file
+COPY libtransact/Cargo.toml /build/libtransact/Cargo.toml
+COPY libtransact/build.rs /build/libtransact/build.rs
+COPY libtransact/protos /build/libtransact/protos
+
+WORKDIR /build/libtransact
+
+# Do a release build to cache dependencies
+RUN cargo build --no-default-features --features sabre-compat,family-command
+
+# Copy over source files
+COPY libtransact/src /build/libtransact/src
+
+WORKDIR /build
+
+# Create empty cargo project for sabre command
+RUN mkdir examples \
+ && USER=root cargo new --bin examples/sabre_command
+
+# Copy over Cargo.toml file
+COPY examples/sabre_command/Cargo.toml /build/examples/sabre_command/Cargo.toml
+
+WORKDIR /build/examples/sabre_command
+
+# Do a release build to cache dependencies
+RUN cargo build --target wasm32-unknown-unknown --release
+
+# Remove the auto-generated .rs files and the built files
+RUN rm target/wasm32-unknown-unknown/release/sabre-command* \
+    target/wasm32-unknown-unknown/release/deps/sabre_command*
+
+# Copy over source files
+COPY examples/sabre_command/src /build/examples/sabre_command/src
+
+# Update version in Cargo.toml
+ARG REPO_VERSION
+RUN sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${REPO_VERSION}\"/" Cargo.toml
+
+# Build the contract
+RUN cargo build --target wasm32-unknown-unknown --release
+
+# Copy the packaging directory
+COPY examples/sabre_command/packaging/scar/* \
+     /build/examples/sabre_command/packaging/scar/
+
+# Copy the contract to the packaging directory
+RUN cp target/wasm32-unknown-unknown/release/sabre-command.wasm \
+    packaging/scar
+
+WORKDIR /build/examples/sabre_command/packaging/scar
+
+# Create .scar file
+RUN tar -jcvf /tmp/command_${REPO_VERSION}.scar .

--- a/examples/sabre_command/packaging/scar/manifest.yaml
+++ b/examples/sabre_command/packaging/scar/manifest.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: command
+version: '1.0'
+inputs:
+  - '06abbc'
+outputs:
+  - '06abbc'

--- a/examples/sabre_command/src/main.rs
+++ b/examples/sabre_command/src/main.rs
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! A Sabre compatible Command family smart contract
+
+#[macro_use]
+extern crate sabre_sdk;
+
+use protobuf::Message;
+
+use sabre_sdk::ApplyError as SabreApplyError;
+use sabre_sdk::TpProcessRequest as SabreTpProcessRequest;
+use sabre_sdk::TransactionContext as SabreTransactionContext;
+use sabre_sdk::{execute_entrypoint, WasmPtr};
+use transact::families::command::CommandTransactionHandler;
+use transact::handler::sabre::SabreContext;
+use transact::handler::{ApplyError, TransactionHandler};
+use transact::protocol::transaction::Transaction;
+use transact::protos::transaction::TransactionHeader;
+
+fn main() {}
+
+// Sabre apply must return a bool
+fn apply(
+    request: &SabreTpProcessRequest,
+    context: &mut dyn SabreTransactionContext,
+) -> Result<bool, SabreApplyError> {
+    // convert SabreTpProcessRequest into TransactionPair
+    let commands = request.get_payload().to_vec();
+
+    let mut header = TransactionHeader::new();
+    header.set_signer_public_key(request.get_header().get_signer_public_key().to_string());
+
+    let header_bytes = header.write_to_bytes().map_err(|_| {
+        SabreApplyError::InvalidTransaction("Unable to convert header to bytes".to_string())
+    })?;
+
+    let txn = Transaction::new(header_bytes, request.get_signature(), commands);
+
+    let txn_pair = txn
+        .into_pair()
+        .map_err(|err| SabreApplyError::InvalidTransaction(err.to_string()))?;
+
+    let mut context = SabreContext { context };
+
+    let handler = CommandTransactionHandler::new();
+
+    // wrap SabreTransactionContext into SabreContext that can be passed to a transact
+    // TransactionHandler
+    match handler.apply(&txn_pair, &mut context) {
+        Ok(_) => Ok(true),
+        Err(err) => {
+            info!("{}", err);
+
+            match err {
+                ApplyError::InvalidTransaction(msg) => {
+                    Err(SabreApplyError::InvalidTransaction(msg))
+                }
+                ApplyError::InternalError(msg) => Err(SabreApplyError::InternalError(msg)),
+            }
+        }
+    }
+}
+
+/// # Safety
+///
+/// This function is required to be able to execute the wasm smart contract
+#[no_mangle]
+pub unsafe fn entrypoint(payload: WasmPtr, signer: WasmPtr, signature: WasmPtr) -> i32 {
+    execute_entrypoint(payload, signer, signature, apply)
+}

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -102,6 +102,7 @@ experimental = [
     "database-redis",
     "database-sqlite",
     "family-command",
+    "family-command-cylinder",
     "family-smallbank",
     "family-smallbank-workload",
     "family-xo",
@@ -140,7 +141,8 @@ database-lmdb = ["lmdb-zero"]
 database-redis = ["redis"]
 database-sqlite = ["rusqlite", "r2d2", "r2d2_sqlite"]
 execution = ["context", "handler", "log", "protocol-transaction", "scheduler"]
-family-command = ["cylinder", "handler", "protocol-transaction-builder"]
+family-command = ["handler"]
+family-command-cylinder = ["cylinder", "family-command", "protocol-transaction-builder"]
 family-smallbank = ["handler"]
 family-smallbank-workload = [
   "family-smallbank",

--- a/libtransact/src/families/command.rs
+++ b/libtransact/src/families/command.rs
@@ -35,7 +35,7 @@ use crate::protocol::transaction::TransactionPair;
 use crate::protos::{FromBytes, IntoBytes};
 
 const COMMAND_FAMILY_NAME: &str = "command";
-const COMMAND_VERSION: &str = "0.1";
+const COMMAND_VERSION: &str = "1.0";
 
 #[derive(Default)]
 pub struct CommandTransactionHandler {

--- a/libtransact/src/families/command.rs
+++ b/libtransact/src/families/command.rs
@@ -19,12 +19,18 @@
 
 use std::{thread, time};
 
+#[cfg(feature = "family-command-cylinder")]
 use cylinder::Signer;
 
 use crate::handler::{ApplyError, TransactionContext, TransactionHandler};
+#[cfg(feature = "family-command-cylinder")]
 use crate::protocol;
 use crate::protocol::command::{Command, CommandPayload, SleepType};
-use crate::protocol::transaction::{HashMethod, TransactionBuilder, TransactionPair};
+#[cfg(feature = "family-command-cylinder")]
+use crate::protocol::transaction::HashMethod;
+#[cfg(feature = "family-command-cylinder")]
+use crate::protocol::transaction::TransactionBuilder;
+use crate::protocol::transaction::TransactionPair;
 use crate::protos::{FromBytes, IntoBytes};
 
 const COMMAND_FAMILY_NAME: &str = "command";
@@ -122,6 +128,7 @@ impl TransactionHandler for CommandTransactionHandler {
     }
 }
 
+#[cfg(feature = "family-command-cylinder")]
 pub fn make_command_transaction(commands: &[Command], signer: &dyn Signer) -> TransactionPair {
     let command_payload = protocol::command::CommandPayload::new(commands.to_vec());
     TransactionBuilder::new()

--- a/libtransact/src/families/command.rs
+++ b/libtransact/src/families/command.rs
@@ -39,6 +39,7 @@ const COMMAND_VERSION: &str = "1.0";
 
 #[derive(Default)]
 pub struct CommandTransactionHandler {
+    family_name: String,
     versions: Vec<String>,
     namespaces: Vec<String>,
 }
@@ -46,6 +47,7 @@ pub struct CommandTransactionHandler {
 impl CommandTransactionHandler {
     pub fn new() -> Self {
         CommandTransactionHandler {
+            family_name: COMMAND_FAMILY_NAME.to_string(),
             versions: vec![COMMAND_VERSION.to_owned()],
             namespaces: vec![get_command_prefix()],
         }
@@ -58,7 +60,7 @@ impl CommandTransactionHandler {
 
 impl TransactionHandler for CommandTransactionHandler {
     fn family_name(&self) -> &str {
-        COMMAND_FAMILY_NAME
+        &self.family_name
     }
 
     fn family_versions(&self) -> &[String] {

--- a/libtransact/src/families/command.rs
+++ b/libtransact/src/families/command.rs
@@ -21,6 +21,7 @@ use std::{thread, time};
 
 #[cfg(feature = "family-command-cylinder")]
 use cylinder::Signer;
+use sha2::{Digest, Sha512};
 
 use crate::handler::{ApplyError, TransactionContext, TransactionHandler};
 #[cfg(feature = "family-command-cylinder")]
@@ -39,13 +40,19 @@ const COMMAND_VERSION: &str = "0.1";
 #[derive(Default)]
 pub struct CommandTransactionHandler {
     versions: Vec<String>,
+    namespaces: Vec<String>,
 }
 
 impl CommandTransactionHandler {
     pub fn new() -> Self {
         CommandTransactionHandler {
             versions: vec![COMMAND_VERSION.to_owned()],
+            namespaces: vec![get_command_prefix()],
         }
+    }
+
+    pub fn namespaces(&self) -> Vec<String> {
+        self.namespaces.clone()
     }
 }
 
@@ -193,6 +200,12 @@ pub fn make_command_transaction(commands: &[Command], signer: &dyn Signer) -> Tr
         )
         .build_pair(signer)
         .unwrap()
+}
+
+fn get_command_prefix() -> String {
+    let mut sha = Sha512::new();
+    sha.input("command");
+    hex::encode(&sha.result())[..6].to_string()
 }
 
 fn sleep(sleep_type: SleepType, duration: u32) {


### PR DESCRIPTION
This PR updates the command family and adds a sabre compatible command smart contract.

The `make_command_transaction` method is moved behind a separate experimental feature to allow for the command smart contract to be compiled into wasm.

The command family transaction handler is updated to use namespaces and a method is added to generate the sha512 hash of "command".

The necessary information is added to the docker files to allow for the command smart contract scar file to be build and archived in Jenkins.