### PR TITLE
Command family cli subcommands

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,8 +36,13 @@ clap = "2"
 ctrlc = { version = "3.0", optional = true }
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"], optional = true }
 flexi_logger = "0.14"
+hex = { version = "0.3", optional = true }
 log = "0.4"
+protobuf = { version = "2.19", optional = true }
 rand = { version = "0.8", optional = true }
+reqwest = { version = "0.10", features = ["blocking"], optional = true}
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true}
 transact = {path = "../libtransact", features=["family-smallbank-workload"]}
 
 
@@ -53,10 +58,12 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
+    "command",
     "playlist",
     "workload"
 ]
 
+command = ["cylinder", "hex", "protobuf", "reqwest", "serde", "serde_json"]
 playlist = ["cylinder"]
 workload = ["ctrlc", "cylinder", "rand"]
 

--- a/cli/man/transact-command-get-state.1.md
+++ b/cli/man/transact-command-get-state.1.md
@@ -1,0 +1,95 @@
+% TRANSACT-COMMAND-GET-STATE(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-command-get-state** — Submits a Sabre transaction to request a state 
+read
+
+SYNOPSIS
+========
+| **transact command get state** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command submits a Sabre transaction to request a state read of the
+addresses given.
+
+This command assumes the distributed ledger's REST API supports Cylinder
+JWT authentication.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k, --key PRIVATE-KEY-FILE`
+: Specifies the full path to the private key file. The key will be used to
+  sign the batches as well as generate a JWT for authentication.
+
+`--target TARGET`
+: Node URL to submit batches to. The URL should include all of the information
+  required to append `/batches` to the end.
+
+`--address ADDRESS`
+: State address of the state to be read. This option can be used multiple times
+  to specify more than one address to be read.
+
+
+EXAMPLES
+========
+The following shows submitting a get state transaction to a Splinter circuit
+`vpENT-eSfFZ` with scabbard services. A scabbard service runs a Sabre 
+transaction handler. The command smart contract must already be uploaded to
+scabbard.
+
+```
+transact command get-state \
+  --key /alice.priv
+  --target "http://0.0.0.0:8080/scabbard/vpENT-eSfFZ/gsAA"
+  --address \
+  06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583
+```
+
+The following shows submitting two get state transactions to a Splinter circuit
+`kpHVT-sjpQM` with scabbard services. A scabbard service runs a Sabre 
+transaction handler. The command smart contract must already be uploaded to
+scabbard.
+
+```
+transact command set-state \
+  --key /alice.priv
+  --target "http://0.0.0.0:8080/scabbard/kpHVT-sjpQM/gsAA"
+  --address \
+  06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583
+  --address \
+  06abbc6d201beeefb589b08ef0672dac82353d0cbd9ad99e1642c83a1601f3d647bcca
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-command(1)`
+| `transact-command-set-state(1)`
+| `transact-command-show-state(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-command-set-state.1.md
+++ b/cli/man/transact-command-set-state.1.md
@@ -1,0 +1,96 @@
+% TRANSACT-COMMAND-SET-STATE(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-command-set-state** — Submits a Sabre transaction to request a state 
+write
+
+SYNOPSIS
+========
+| **transact command set state** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+This command submits a Sabre transaction to request one or more state write of
+the state entries given. The state entry is a key value pair where the key is a
+state address and the value is the value to be set for the given address.
+
+This command assumes the distributed ledger's REST API supports Cylinder
+JWT authentication.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k, --key PRIVATE-KEY-FILE`
+: Specifies the full path to the private key file. The key will be used to
+  sign the batches as well as generate a JWT for authentication.
+
+`--target TARGET`
+: Node URL to submit batches to. The URL should include all of the information
+  required to append `/batches` to the end.
+
+`--state-entry STATE-ENTRY`
+: Key-value pair where the key is a state address and the value is the value to
+  be set for that address. (format: address:value)
+
+
+EXAMPLES
+========
+The following shows submitting a set state transaction to a Splinter circuit
+`vpENT-eSfFZ` with scabbard services. A scabbard service runs a Sabre 
+transaction handler. The command smart contract must already be uploaded to
+scabbard.
+
+```
+transact command set-state \
+  --key /alice.priv
+  --target "http://0.0.0.0:8080/scabbard/vpENT-eSfFZ/gsAA"
+  --state-entry \
+  06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583:value
+```
+
+The following shows submitting two set state transactions to a Splinter circuit
+`kpHVT-sjpQM` with scabbard services. A scabbard service runs a Sabre 
+transaction handler. The command smart contract must already be uploaded to
+scabbard.
+
+```
+transact command set-state \
+  --key /alice.priv
+  --target "http://0.0.0.0:8080/scabbard/kpHVT-sjpQM/gsAA"
+  --state-entry \
+  06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583:value1
+  --state-entry \
+  06abbc6d201beeefb589b08ef0672dac82353d0cbd9ad99e1642c83a1601f3d647bcca:value2
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-command(1)`
+| `transact-command-get-state(1)`
+| `transact-command-show-state(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-command-show-state.1.md
+++ b/cli/man/transact-command-show-state.1.md
@@ -1,0 +1,80 @@
+% TRANSACT-COMMAND-SHOW-STATE(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+NAME
+====
+
+**transact-command-show-state** — Displays the state value at a given address
+
+SYNOPSIS
+========
+| **transact command show state** \[**FLAGS**\] \[**OPTIONS**\]
+
+DESCRIPTION
+===========
+Display the state value at the given state address if it exists.
+
+This command assumes the distributed ledger's REST API supports Cylinder
+JWT authentication.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-t`, `--text`
+: Attempt to convert the state value from bytes and display it as an ascii
+  string.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+OPTIONS
+=======
+`-k, --key PRIVATE-KEY-FILE`
+: Specifies the full path to the private key file. The key will be used to
+  sign the batches as well as generate a JWT for authentication.
+
+`--target TARGET`
+: Node URL to retrieve the state value from.
+
+`--address ADDRESS`
+: State address of the state value to be retrieved.
+
+
+EXAMPLES
+========
+The following shows retrieving the state value at the address 
+`06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583`
+from a Splinter circuit `vpENT-eSfFZ` with scabbard services. The command smart
+contract must already be uploaded to scabbard.
+
+```
+transact command show-state \
+  --key /alice.priv
+  --target "http://0.0.0.0:8080/scabbard/vpENT-eSfFZ/gsAA"
+  --address \
+  06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583
+```
+
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-command(1)`
+| `transact-command-set-state(1)`
+| `transact-command-get-state(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/man/transact-command.md
+++ b/cli/man/transact-command.md
@@ -1,0 +1,58 @@
+% TRANSACT-COMMAND(1) Cargill, Incorporated | Transact Commands
+<!--
+  Copyright 2018-2021 Cargill Incorporated
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+**transact-command** — Interacts with the command family smart contract
+
+SYNOPSIS
+========
+**transact command** \[**FLAGS**\] \[**SUBCOMMAND**\]
+
+DESCRIPTION
+===========
+This command can be used to interact with a command family smart contract on a
+Splinter circuit with scabbard services.
+
+FLAGS
+=====
+`-h`, `--help`
+: Prints help information
+
+`-q`, `--quiet`
+: Decrease verbosity (the opposite of -v). When specified, only errors or
+  warnings will be output.
+
+`-V`, `--version`
+: Prints version information
+
+`-v`
+: Increases verbosity (the opposite of -q). Specify multiple times for more
+  output.
+
+SUBCOMMANDS
+===========
+`get-state`
+: Submits a Sabre transaction to request a state read of the addresses given.
+
+`help`
+:  Prints this message or the help of the given subcommand(s)
+
+`set-state`
+: Submits a Sabre transaction to request one or more state write of the state
+  entries given. The state entry is a key value pair where the key is a state
+  address and the value is the value to be set for the given address.
+
+`show-state`
+: Display the state value at the given state address if it exists.
+
+SEE ALSO
+========
+| `transact(1)`
+| `transact-command-get-state(1)`
+| `transact-command-set-state(1)`
+| `transact-command-show-state(1)`
+|
+| Transact documentation: https://docs.rs/transact/latest

--- a/cli/src/action/command.rs
+++ b/cli/src/action/command.rs
@@ -188,6 +188,155 @@ impl Action for CommandSetStateAction {
     }
 }
 
+pub struct CommandGetStateAction;
+
+impl Action for CommandGetStateAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let key_path = args
+            .value_of("key")
+            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
+        let (auth, signer) = create_cylinder_jwt_auth_signer_key(key_path)?;
+
+        let target = args
+            .value_of("target")
+            .ok_or_else(|| CliError::ActionError("'target' is required".into()))?;
+
+        let addresses = args
+            .values_of("address")
+            .ok_or_else(|| CliError::ActionError("'address' is required".into()))?;
+
+        let mut get_state = GetState::new();
+        let state_keys = addresses.map(String::from).collect::<Vec<String>>();
+
+        get_state.set_state_keys(RepeatedField::from_vec(state_keys.clone()));
+
+        let mut command = Command::new();
+        command.set_command_type(Command_CommandType::GET_STATE);
+        command.set_get_state(get_state);
+
+        // build the command payload
+        let mut payload = CommandPayload::new();
+        payload.set_commands(RepeatedField::from_vec(vec![command]));
+
+        let payload_bytes = payload.write_to_bytes().map_err(|err| {
+            CliError::ActionError(format!("Unable to convert payload to bytes: {}", err))
+        })?;
+
+        // build the transaction
+        let txn = ExecuteContractActionBuilder::new()
+            .with_name(String::from("command"))
+            .with_version(String::from("1.0"))
+            .with_inputs(state_keys.clone())
+            .with_outputs(state_keys)
+            .with_payload(payload_bytes)
+            .into_payload_builder()
+            .map_err(|err| {
+                CliError::ActionError(format!(
+                    "Unable to convert execute action into sabre payload: {}",
+                    err
+                ))
+            })?
+            .into_transaction_builder()
+            .map_err(|err| {
+                CliError::ActionError(format!(
+                    "Unable to convert execute payload into transaction: {}",
+                    err
+                ))
+            })?
+            .build(&*signer)
+            .map_err(|err| {
+                CliError::ActionError(format!("Unable to build transaction: {}", err))
+            })?;
+
+        let txn_proto = txn.into_proto().map_err(|err| {
+            CliError::ActionError(format!(
+                "Unable to convert transaction to protobuf: {}",
+                err
+            ))
+        })?;
+
+        let txn_id = txn_proto.get_header_signature().to_string();
+
+        // create the batch header
+        let mut batch_header = BatchHeader::new();
+        batch_header.set_transaction_ids(protobuf::RepeatedField::from_vec(vec![txn_id]));
+        batch_header.set_signer_public_key(
+            signer
+                .public_key()
+                .map_err(|err| {
+                    CliError::ActionError(format!("Unable to get signer public key: {}", err))
+                })?
+                .as_hex(),
+        );
+
+        let header_bytes = batch_header.write_to_bytes().map_err(|err| {
+            CliError::ActionError(format!("Unable to convert header to bytes: {}", err))
+        })?;
+
+        // build the batch
+        let mut batch = Batch::new();
+        let signature = signer
+            .sign(&header_bytes)
+            .map_err(|err| CliError::ActionError(format!("Unable to sign batch: {}", err)))?
+            .as_hex();
+        batch.set_header_signature(signature);
+        batch.set_header(header_bytes);
+        batch.set_transactions(protobuf::RepeatedField::from_vec(vec![txn_proto]));
+
+        let batch_pair = BatchPair::from_proto(batch).map_err(|err| {
+            CliError::ActionError(format!(
+                "Unable to convert to batch pair from batch proto: {}",
+                err
+            ))
+        })?;
+
+        let batch_bytes = match vec![batch_pair.batch().clone()].into_bytes() {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                return Err(CliError::ActionError(format!(
+                    "Unable to convert batch to bytes: {}",
+                    err
+                )))
+            }
+        };
+
+        // send batch to target
+        Client::new()
+            .post(&format!("{}/batches", target))
+            .header(header::CONTENT_TYPE, "octet-stream")
+            .header("Authorization", auth)
+            .body(batch_bytes)
+            .send()
+            .map_err(|err| {
+                CliError::ActionError(format!("Failed to submit get state transaction: {}", err))
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            CliError::ActionError(format!(
+                                "Get state request failed with status code '{}', but \
+                                    error response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(CliError::ActionError(format!(
+                        "Failed to submit get state transaction: {}",
+                        message
+                    )))
+                }
+            })
+    }
+}
+
 fn parse_bytes_entry(bytes_entry: &str) -> Result<(String, Vec<u8>), CliError> {
     let mut parts = bytes_entry.splitn(2, ':');
     match (parts.next(), parts.next()) {

--- a/cli/src/action/command.rs
+++ b/cli/src/action/command.rs
@@ -1,0 +1,217 @@
+// Copyright 2018-2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+use clap::ArgMatches;
+use protobuf::{Message, RepeatedField};
+use reqwest::{blocking::Client, header};
+use serde::Deserialize;
+use transact::protocol::batch::BatchPair;
+use transact::protocol::sabre::ExecuteContractActionBuilder;
+use transact::protos::FromProto;
+use transact::protos::{
+    batch::{Batch, BatchHeader},
+    command::{BytesEntry, Command, CommandPayload, Command_CommandType, GetState, SetState},
+    IntoBytes, IntoProto,
+};
+
+use crate::error::CliError;
+
+use super::{create_cylinder_jwt_auth_signer_key, Action};
+
+pub struct CommandSetStateAction;
+
+impl Action for CommandSetStateAction {
+    fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
+        let args = arg_matches.ok_or(CliError::RequiresArgs)?;
+
+        let key_path = args
+            .value_of("key")
+            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
+        let (auth, signer) = create_cylinder_jwt_auth_signer_key(key_path)?;
+
+        let target = args
+            .value_of("target")
+            .ok_or_else(|| CliError::ActionError("'target' is required".into()))?;
+
+        let bytes_entries = args
+            .values_of("state-entry")
+            .ok_or_else(|| CliError::ActionError("'state-entry' is required".into()))?;
+
+        let mut state_writes = Vec::new();
+        let mut addresses = Vec::new();
+
+        for bytes_entry in bytes_entries {
+            let (address, value) = parse_bytes_entry(bytes_entry)?;
+
+            let mut entry = BytesEntry::new();
+            entry.set_key(address.clone());
+            entry.set_value(value);
+
+            state_writes.push(entry);
+
+            addresses.push(address);
+        }
+
+        let mut set_state = SetState::new();
+        set_state.set_state_writes(RepeatedField::from_vec(state_writes));
+
+        let mut command = Command::new();
+        command.set_command_type(Command_CommandType::SET_STATE);
+        command.set_set_state(set_state);
+
+        // build the command payload
+        let mut payload = CommandPayload::new();
+        payload.set_commands(RepeatedField::from_vec(vec![command]));
+
+        let payload_bytes = payload.write_to_bytes().map_err(|err| {
+            CliError::ActionError(format!("Unable to convert payload to bytes: {}", err))
+        })?;
+
+        // build the transaction
+        let txn = ExecuteContractActionBuilder::new()
+            .with_name(String::from("command"))
+            .with_version(String::from("1.0"))
+            .with_inputs(addresses.clone())
+            .with_outputs(addresses)
+            .with_payload(payload_bytes)
+            .into_payload_builder()
+            .map_err(|err| {
+                CliError::ActionError(format!(
+                    "Unable to convert execute action into sabre payload: {}",
+                    err
+                ))
+            })?
+            .into_transaction_builder()
+            .map_err(|err| {
+                CliError::ActionError(format!(
+                    "Unable to convert execute payload into transaction: {}",
+                    err
+                ))
+            })?
+            .build(&*signer)
+            .map_err(|err| CliError::ActionError(format!("Unable to build transaction: {}", err)))?
+            .into_proto()
+            .map_err(|err| {
+                CliError::ActionError(format!(
+                    "Unable to convert transaction to protobuf: {}",
+                    err
+                ))
+            })?;
+
+        // create the batch header
+        let mut batch_header = BatchHeader::new();
+        let txn_id = txn.get_header_signature().to_string();
+        batch_header.set_transaction_ids(RepeatedField::from_vec(vec![txn_id]));
+        batch_header.set_signer_public_key(
+            signer
+                .public_key()
+                .map_err(|err| {
+                    CliError::ActionError(format!("Unable to get signer public key: {}", err))
+                })?
+                .as_hex(),
+        );
+
+        let header_bytes = batch_header.write_to_bytes().map_err(|err| {
+            CliError::ActionError(format!("Unable to convert header to bytes: {}", err))
+        })?;
+
+        // build the batch
+        let mut batch = Batch::new();
+        let signature = signer
+            .sign(&header_bytes)
+            .map_err(|err| CliError::ActionError(format!("Unable to sign batch: {}", err)))?
+            .as_hex();
+        batch.set_header_signature(signature);
+        batch.set_header(header_bytes.to_vec());
+        batch.set_transactions(RepeatedField::from_vec(vec![txn]));
+
+        let batch_pair = BatchPair::from_proto(batch).map_err(|err| {
+            CliError::ActionError(format!(
+                "Unable to convert to batch pair from batch proto: {}",
+                err
+            ))
+        })?;
+
+        let batch_bytes = match vec![batch_pair.batch().clone()].into_bytes() {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                return Err(CliError::ActionError(format!(
+                    "Unable to convert batch to bytes: {}",
+                    err
+                )))
+            }
+        };
+
+        // send batch to target
+        Client::new()
+            .post(&format!("{}/batches", target))
+            .header(header::CONTENT_TYPE, "octet-stream")
+            .header("Authorization", auth)
+            .body(batch_bytes)
+            .send()
+            .map_err(|err| {
+                CliError::ActionError(format!("Failed to submit set state transaction: {}", err))
+            })
+            .and_then(|res| {
+                let status = res.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let message = res
+                        .json::<ServerError>()
+                        .map_err(|_| {
+                            CliError::ActionError(format!(
+                                "Set state request failed with status code '{}', but \
+                                    error response was not valid",
+                                status
+                            ))
+                        })?
+                        .message;
+
+                    Err(CliError::ActionError(format!(
+                        "Failed to submit set state transaction: {}",
+                        message
+                    )))
+                }
+            })
+    }
+}
+
+fn parse_bytes_entry(bytes_entry: &str) -> Result<(String, Vec<u8>), CliError> {
+    let mut parts = bytes_entry.splitn(2, ':');
+    match (parts.next(), parts.next()) {
+        (Some(key), Some(value)) => match key {
+            "" => Err(CliError::ActionError(
+                "Empty '--bytes-entry' argument detected".into(),
+            )),
+            _ => match value {
+                "" => Err(CliError::ActionError(format!(
+                    "Empty value detected for address: {}",
+                    key
+                ))),
+                _ => Ok((key.to_string(), value.as_bytes().to_vec())),
+            },
+        },
+        (Some(key), None) => Err(CliError::ActionError(format!(
+            "Missing value for address '{}'",
+            key
+        ))),
+        _ => unreachable!(), // splitn always returns at least one item
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ServerError {
+    pub message: String,
+}

--- a/cli/src/action/mod.rs
+++ b/cli/src/action/mod.rs
@@ -13,17 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "command")]
+pub mod command;
 #[cfg(feature = "playlist")]
 pub mod playlist;
 #[cfg(feature = "workload")]
 pub mod workload;
 
 use std::collections::HashMap;
-#[cfg(any(feature = "workload", feature = "playlist"))]
+#[cfg(any(feature = "workload", feature = "playlist", feature = "command"))]
 use std::path::Path;
 
 use clap::ArgMatches;
-#[cfg(any(feature = "workload", feature = "playlist"))]
+#[cfg(any(feature = "workload", feature = "playlist", feature = "command"))]
 use cylinder::{
     current_user_search_path, jwt::JsonWebTokenBuilder, load_key, load_key_from_path,
     secp256k1::Secp256k1Context, Context, Signer,
@@ -50,7 +52,7 @@ impl<'a> SubcommandActions<'a> {
         Self::default()
     }
 
-    #[cfg(any(feature = "playlist", feature = "workload"))]
+    #[cfg(any(feature = "playlist", feature = "workload", feature = "command"))]
     pub fn with_command<'action: 'a, A: Action + 'action>(
         mut self,
         command: &str,
@@ -76,7 +78,7 @@ impl<'s> Action for SubcommandActions<'s> {
     }
 }
 
-#[cfg(any(feature = "playlist", feature = "workload"))]
+#[cfg(any(feature = "playlist", feature = "workload", feature = "command"))]
 // build a signed json web token using the private key
 fn create_cylinder_jwt_auth_signer_key(
     key_name: &str,


### PR DESCRIPTION
Adds subcommands to the transact cli to interact with the command family smart contract. This is behind the experimental feature "command".

### **Testing:**

1. Checkout the branch in this PR which updates the command family and adds a command family smart contract: https://github.com/hyperledger/transact/pull/126
2. Start two splinter nodes and create a circuit between them with scabbard services
3. Download the command family smart contract scar file found here: https://build.sawtooth.me/job/Transact-Hyperledger/job/transact/job/PR-127/1/artifact/build/scar/
4. Upload the command family smart contract to the circuit using the scabbard CLI
5. Create a namespace registry for the contract using the namespace "06abbc"
```
scabbard ns create 06abbc \
    --owner <public_key> \
    --key <path_to_private_key> \
    --url http://0.0.0.0:8080 \
    --service-id <circuit-id>::<scabbard-service-id>
```
6. Add read and write permissions for the contract
```
scabbard perm 06abbc command --read --write \
    --key <path_to_private_key> \
    --url http://0.0.0.0:8080 \
    --service-id <circuit-id>::<scabbard-service-id>
```
7. Start the transact CLI using the branch from step 1, if you are using a docker file for your splinter nodes you can add something similar to the following to your docker file: 
```
  transact-cli:
    image: transact-cli
    build:
      context: ../transact
      dockerfile: ./cli/Dockerfile
      args:
      - CARGO_ARGS=${CARGO_ARGS}
      - REPO_VERSION=0.4.1-dev
    container_name: transact-cli
    hostname: transact-cli
```
and then set the environment variable `CARGO_ARGS="-- --features=experimental"` and then run `docker-compose -f <docker-file-name>.yaml run transact-cli bash` in a new terminal window to start the transact CLI 
(alternatively the transact commands can be run from the transact/cli directory as `cargo run --features=experimental ...`)

8. Run a set-state command
```
transact command set-state \
  --key /alice.priv
  --target "http://0.0.0.0:8080/scabbard/<circuit-id>/<scabbard-service-id>"
  --state-entry 06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583:state-value
```
9. Check the splinterd logs to see if the transaction was successfully submitted
10. Run a show-state command
```
transact command show-state \
  --key /alice.priv
  --target "http://0.0.0.0:8080/scabbard/<circuit-id>/<scabbard-service-id>"
  --address 06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583
  --text
```
11. Check that the "state-value" is returned
12. Run a get-state command 
```
transact command get-state \
  --key /alice.priv
  --target "http://0.0.0.0:8080/scabbard/<circuit-id>/<scabbard-service-id>"
  --address 06abbcb16ed7d24b3ecbd4164dcdad374e08c0ab7518aa07f9d3683f34c2b3c67a1583
```
13. Check the splinterd logs to see if the get state transaction was successfully submitted, the transact cli should not display anything after running this command.