### PR TITLE
Update justfile to build additional feature combinations

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,6 +39,12 @@ build:
             $cmd
         done
     done
+    cmd="cargo build --tests --manifest-path=libtransact/Cargo.toml --features=sawtooth-compat"
+    echo "\033[1m$cmd\033[0m"
+    $cmd
+    cmd="cargo build --tests --manifest-path=libtransact/Cargo.toml --features=experimental,state-merkle-redis-db-tests"
+    echo "\033[1m$cmd\033[0m"
+    $cmd
     echo "\n\033[92mBuild Success\033[0m\n"
 
 clean:


### PR DESCRIPTION
There are two features enabled during testing which were not previously
built in the justfile. One is sawtooth compat and the other is
redis-related tests. This modification builds both of these to make it
easier to detect compilation errors which impact those features.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>