### PR TITLE
Fix manual implementation of Option::map lint

### DIFF
--- a/libtransact/src/database/btree.rs
+++ b/libtransact/src/database/btree.rs
@@ -457,17 +457,17 @@ impl BTreeDatabaseCursor {
 
 impl DatabaseReaderCursor for BTreeDatabaseCursor {
     fn seek_first(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
-        match self.db.iter().next() {
-            Some((key, value)) => Some((key.to_vec(), value.to_vec())),
-            None => None,
-        }
+        self.db
+            .iter()
+            .next()
+            .map(|(key, value)| (key.to_vec(), value.to_vec()))
     }
 
     fn seek_last(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
-        match self.db.iter().last() {
-            Some((key, value)) => Some((key.to_vec(), value.to_vec())),
-            None => None,
-        }
+        self.db
+            .iter()
+            .last()
+            .map(|(key, value)| (key.to_vec(), value.to_vec()))
     }
 }
 

--- a/libtransact/src/database/sqlite.rs
+++ b/libtransact/src/database/sqlite.rs
@@ -840,11 +840,9 @@ pub struct SqliteDatabaseError {
 
 impl std::error::Error for SqliteDatabaseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        if let Some(ref err) = self.source {
-            Some(&**err)
-        } else {
-            None
-        }
+        self.source
+            .as_ref()
+            .map(|err| &**err as &(dyn std::error::Error + 'static))
     }
 }
 


### PR DESCRIPTION
This change fixes a lint introduced in the 1.52.0 release of Rust
flagging items like

    match Some(0) {
        Some(x) => Some(x + 1),
        None => None,
    };

Use instead:

    Some(0).map(|x| x + 1);

In some cases this requires an `as &(dyn Error + 'static)`

See for
    https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
for details

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>