### PR TITLE
Remove InternalError::reduce_to_string

### DIFF
--- a/libtransact/src/error/internal.rs
+++ b/libtransact/src/error/internal.rs
@@ -126,18 +126,6 @@ impl InternalError {
             source: None,
         }
     }
-
-    /// Reduces the `InternalError` to the display string
-    ///
-    /// If the error includes a source, the debug format will be logged to provide
-    /// information that may be lost on the conversion.
-    pub fn reduce_to_string(self) -> String {
-        if self.source.is_some() {
-            debug!("{:?}", self);
-        }
-
-        self.to_string()
-    }
 }
 
 impl error::Error for InternalError {


### PR DESCRIPTION
This method is a wrapper around to_string that also logs a message if there is a source.  The logging and to_string call should be left to the caller.
