### PR TITLE
Create command workload

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,7 +43,7 @@ rand = { version = "0.8", optional = true }
 reqwest = { version = "0.10", features = ["blocking"], optional = true}
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true}
-transact = {path = "../libtransact", features=["family-smallbank-workload"]}
+transact = {path = "../libtransact", features=["family-smallbank-workload", "family-command-workload"]}
 
 
 [features]

--- a/cli/man/transact-workload.1.md
+++ b/cli/man/transact-workload.1.md
@@ -48,8 +48,8 @@ OPTIONS
 `--smallbank-num-accounts ACCOUNTS`
 : The number of smallbank accounts to make. (default: `100`)
 
-`--smallbank-seed SEEDS`
-: An integer to use as a seed to make the smallbank workload reproducible.
+`---seed SEEDS`
+: An integer to use as a seed to make the workload reproducible.
 
 `--target-rate TARGET-RATE`
 : How many batches to submit per second, either provide a number or a range
@@ -66,8 +66,9 @@ OPTIONS
   of submitting the HTTP requests. (default: `30`)
 
 `--workload WORKLOAD `
-: The workload to be submitted. The possibly value is `smallbank`. The smallbank
-  workload submits batches containing sabre Transactions for smallbank payloads.
+: The workload to be submitted. The possible values are `smallbank` or `command`.
+  Determines the type of sabre transactions contained within the batches
+  submitted by the workload, either smallbank or command payloads.
 
 EXAMPLES
 ========

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -94,25 +94,22 @@ impl Action for WorkloadAction {
             .parse()
             .map_err(|_| CliError::ActionError("Unable to parse provided update time".into()))?;
 
+        let seed = match args.value_of("seed").map(str::parse).unwrap_or_else(|| {
+            let mut rng = rand::thread_rng();
+            Ok(rng.gen::<u64>())
+        }) {
+            Ok(seed) => seed,
+            Err(_) => {
+                return Err(CliError::ActionError(
+                    "Unable to get seed for workload".into(),
+                ))
+            }
+        };
+
         let mut workload_runner = WorkloadRunner::default();
 
         match workload {
             "smallbank" => {
-                let seed = match args
-                    .value_of("smallbank_seed")
-                    .map(str::parse)
-                    .unwrap_or_else(|| {
-                        let mut rng = rand::thread_rng();
-                        Ok(rng.gen::<u64>())
-                    }) {
-                    Ok(seed) => seed,
-                    Err(_) => {
-                        return Err(CliError::ActionError(
-                            "Unable to get seed for smallbank workload".into(),
-                        ))
-                    }
-                };
-
                 let num_accounts: usize = args
                     .value_of("smallbank_num_accounts")
                     .unwrap_or("100")

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -94,7 +94,7 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .long("workload")
                         .takes_value(true)
                         .required(true)
-                        .possible_values(&["smallbank"])
+                        .possible_values(&["smallbank", "command"])
                         .help("The workload to be submitted"),
                 )
                 .arg(
@@ -111,13 +111,10 @@ fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(args: I) -> Result<
                         .help("The number of smallbank accounts to make. Defaults to 100"),
                 )
                 .arg(
-                    Arg::with_name("smallbank_seed")
-                        .long("smallbank-seed")
+                    Arg::with_name("seed")
+                        .long("seed")
                         .value_name("SEED")
-                        .long_help(
-                            "An integer to use as a seed to make the smallbank workload \
-                        reproducible",
-                        ),
+                        .long_help("An integer to use as a seed to make the workload reproducible"),
                 ),
         );
     }

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -118,7 +118,7 @@ impl BatchWorkload for CommandBatchWorkload {
 }
 
 pub fn make_command_transaction(commands: &[Command], signer: &dyn Signer) -> TransactionPair {
-    let command_payload = protocol::command::CommandPayload::new(commands.to_vec());
+    let command_payload = CommandPayload::new(commands.to_vec());
     TransactionBuilder::new()
         .with_batcher_public_key(vec![0u8, 0u8, 0u8, 0u8])
         .with_family_name(String::from("command"))

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+pub mod playlist;
+
 use cylinder::Signer;
 
 use crate::protocol;

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -19,11 +19,103 @@ pub mod playlist;
 
 use cylinder::Signer;
 
-use crate::protocol;
-use crate::protocol::command::Command;
-use crate::protocol::transaction::HashMethod;
-use crate::protocol::transaction::{TransactionBuilder, TransactionPair};
-use crate::protos::IntoBytes;
+use crate::protocol::{
+    batch::{BatchBuilder, BatchPair},
+    command::{Command, CommandPayload},
+    sabre::ExecuteContractActionBuilder,
+    transaction::{HashMethod, TransactionBuilder, TransactionPair},
+};
+use crate::protos::{FromProto, IntoBytes};
+use crate::workload::{error::WorkloadError, BatchWorkload, TransactionWorkload};
+
+use self::playlist::CommandGeneratingIter;
+
+pub struct CommandTransactionWorkload {
+    generator: CommandGeneratingIter,
+    signer: Box<dyn Signer>,
+}
+
+impl CommandTransactionWorkload {
+    pub fn new(generator: CommandGeneratingIter, signer: Box<dyn Signer>) -> Self {
+        Self { generator, signer }
+    }
+}
+
+impl TransactionWorkload for CommandTransactionWorkload {
+    fn next_transaction(&mut self) -> Result<TransactionPair, WorkloadError> {
+        let (command_proto, address) = self
+            .generator
+            .next()
+            .ok_or_else(|| WorkloadError::InvalidState("No command available".to_string()))?;
+
+        let command = Command::from_proto(command_proto).map_err(|_| {
+            WorkloadError::InvalidState("Unable to convert from command proto".to_string())
+        })?;
+
+        let command_payload = CommandPayload::new(vec![command.clone()]);
+
+        let payload_bytes = command_payload
+            .into_bytes()
+            .expect("Unable to get bytes from Command Payload");
+
+        let addresses = match command {
+            Command::SetState(set_state) => set_state
+                .state_writes()
+                .iter()
+                .map(|b| String::from(b.key()))
+                .collect::<Vec<String>>(),
+            Command::DeleteState(delete_state) => delete_state.state_keys().to_vec(),
+            Command::GetState(get_state) => get_state.state_keys().to_vec(),
+            _ => vec![address],
+        };
+
+        let txn = ExecuteContractActionBuilder::new()
+            .with_name(String::from("command"))
+            .with_version(String::from("1.0"))
+            .with_inputs(addresses.clone())
+            .with_outputs(addresses)
+            .with_payload(payload_bytes)
+            .into_payload_builder()
+            .map_err(|err| {
+                WorkloadError::InvalidState(format!(
+                    "Unable to convert execute action into sabre payload: {}",
+                    err
+                ))
+            })?
+            .into_transaction_builder()
+            .map_err(|err| {
+                WorkloadError::InvalidState(format!(
+                    "Unable to convert execute payload into transaction: {}",
+                    err
+                ))
+            })?
+            .build_pair(&*self.signer)?;
+
+        Ok(txn)
+    }
+}
+
+pub struct CommandBatchWorkload {
+    transaction_workload: CommandTransactionWorkload,
+    signer: Box<dyn Signer>,
+}
+
+impl CommandBatchWorkload {
+    pub fn new(transaction_workload: CommandTransactionWorkload, signer: Box<dyn Signer>) -> Self {
+        Self {
+            transaction_workload,
+            signer,
+        }
+    }
+}
+
+impl BatchWorkload for CommandBatchWorkload {
+    fn next_batch(&mut self) -> Result<BatchPair, WorkloadError> {
+        Ok(BatchBuilder::new()
+            .with_transactions(vec![self.transaction_workload.next_transaction()?.take().0])
+            .build_pair(&*self.signer)?)
+    }
+}
 
 pub fn make_command_transaction(commands: &[Command], signer: &dyn Signer) -> TransactionPair {
     let command_payload = protocol::command::CommandPayload::new(commands.to_vec());

--- a/libtransact/src/families/command/workload/playlist.rs
+++ b/libtransact/src/families/command/workload/playlist.rs
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Tools for generating command family transactions
+use protobuf::RepeatedField;
+use rand::prelude::*;
+use sha2::{Digest, Sha512};
+
+use crate::protos::command;
+use crate::protos::command::{Command, Command_CommandType};
+
+pub struct CommandGeneratingIter {
+    rng: StdRng,
+    addresses: Vec<String>,
+    set_addresses: Vec<String>,
+}
+
+impl CommandGeneratingIter {
+    pub fn new(seed: u64) -> Self {
+        CommandGeneratingIter {
+            rng: SeedableRng::seed_from_u64(seed),
+            addresses: make_command_workload_addresses(),
+            set_addresses: Vec::new(),
+        }
+    }
+
+    pub fn add_set_address(&mut self, address: String) {
+        self.set_addresses.push(address);
+    }
+
+    pub fn remove_set_address(&mut self, index: usize) {
+        self.set_addresses.remove(index);
+    }
+}
+
+impl Iterator for CommandGeneratingIter {
+    type Item = (Command, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut command = Command::new();
+
+        // If no addresses are currently set, generate a number between 2 and 6
+        // to ensure `delete_state` will not be chosen
+        let rand = if self.set_addresses.is_empty() {
+            self.rng.gen_range(2, 6)
+        } else {
+            self.rng.gen_range(2, 7)
+        };
+
+        let command_type = match rand {
+            2 => Command_CommandType::SET_STATE,
+            3 => Command_CommandType::GET_STATE,
+            4 => Command_CommandType::ADD_EVENT,
+            5 => Command_CommandType::RETURN_INVALID,
+            6 => Command_CommandType::DELETE_STATE,
+            _ => panic!("Should not have generated outside of [2, 7)"),
+        };
+
+        command.set_command_type(command_type);
+
+        match command_type {
+            Command_CommandType::SET_STATE => {
+                let (set_state, address) = make_set_state_command(&mut self.rng, &self.addresses);
+                command.set_set_state(set_state);
+                // add address to list of set addresses
+                self.add_set_address(address.clone());
+                Some((command, address))
+            }
+            Command_CommandType::GET_STATE => {
+                let (get_state, address) = make_get_state_command(&mut self.rng, &self.addresses);
+                command.set_get_state(get_state);
+                Some((command, address))
+            }
+            Command_CommandType::ADD_EVENT => {
+                let (add_event, address) = make_add_event_command(&mut self.rng, &self.addresses);
+                command.set_add_event(add_event);
+                Some((command, address))
+            }
+            Command_CommandType::RETURN_INVALID => {
+                let (return_invalid, address) =
+                    make_return_invalid_command(&mut self.rng, &self.addresses);
+                command.set_return_invalid(return_invalid);
+                Some((command, address))
+            }
+            Command_CommandType::DELETE_STATE => {
+                // get a state address that has been set
+                let address_index = self.rng.gen_range(0, self.set_addresses.len());
+                let address = String::from(&self.set_addresses[address_index]);
+                // remove the address from the list of set addresses
+                self.remove_set_address(address_index);
+
+                let delete_state = make_delete_state_command(address.clone());
+                command.set_delete_state(delete_state);
+                Some((command, address))
+            }
+            _ => panic!("Should not have generated outside of [2, 7)"),
+        }
+    }
+}
+
+fn make_set_state_command(rng: &mut StdRng, addresses: &[String]) -> (command::SetState, String) {
+    let mut bytes_entry = command::BytesEntry::new();
+
+    let address = &addresses[rng.gen_range(0, addresses.len())];
+
+    bytes_entry.set_key(address.to_string());
+    bytes_entry.set_value(rng.gen_range(0, 1000).to_string().as_bytes().to_vec());
+
+    let mut set_state = command::SetState::new();
+    set_state.set_state_writes(RepeatedField::from_vec(vec![bytes_entry]));
+
+    (set_state, address.to_string())
+}
+
+fn make_get_state_command(rng: &mut StdRng, addresses: &[String]) -> (command::GetState, String) {
+    let address = &addresses[rng.gen_range(0, addresses.len())];
+
+    let state_keys = vec![address.to_string()];
+
+    let mut get_state = command::GetState::new();
+    get_state.set_state_keys(RepeatedField::from_vec(state_keys));
+
+    (get_state, address.to_string())
+}
+
+fn make_add_event_command(rng: &mut StdRng, addresses: &[String]) -> (command::AddEvent, String) {
+    let address = &addresses[rng.gen_range(0, addresses.len())];
+    let mut bytes_entry = command::BytesEntry::new();
+
+    bytes_entry.set_key("key".to_string());
+    bytes_entry.set_value(rng.gen_range(0, 1000).to_string().as_bytes().to_vec());
+
+    let mut add_event = command::AddEvent::new();
+
+    add_event.set_event_type("event_type".to_string());
+    add_event.set_attributes(RepeatedField::from_vec(vec![bytes_entry]));
+    add_event.set_data(rng.gen_range(0, 1000).to_string().as_bytes().to_vec());
+
+    (add_event, address.to_string())
+}
+
+fn make_return_invalid_command(
+    rng: &mut StdRng,
+    addresses: &[String],
+) -> (command::ReturnInvalid, String) {
+    let address = &addresses[rng.gen_range(0, addresses.len())];
+
+    let mut return_invalid = command::ReturnInvalid::new();
+    return_invalid.set_error_message("'return_invalid' command mock error message".to_string());
+
+    (return_invalid, address.to_string())
+}
+
+fn make_delete_state_command(address: String) -> command::DeleteState {
+    let state_keys = vec![address];
+
+    let mut delete_state = command::DeleteState::new();
+    delete_state.set_state_keys(RepeatedField::from_vec(state_keys));
+
+    delete_state
+}
+
+fn make_command_workload_addresses() -> Vec<String> {
+    let mut addresses = Vec::new();
+
+    // Create 100 addresses
+    for i in 0..100 {
+        let mut sha = Sha512::new();
+        sha.input(format!("address{}", i).as_bytes());
+        let hash = &mut sha.result();
+
+        let hex = bytes_to_hex_str(hash);
+
+        // Using the precomputed Sha512 hash of "command"
+        addresses.push(String::from("06abbc") + &hex[0..64]);
+    }
+    addresses
+}
+
+pub fn bytes_to_hex_str(b: &[u8]) -> String {
+    b.iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>()
+        .join("")
+}


### PR DESCRIPTION
This PR creates a Command family workload that can be run using the `transact workload` CLI command

- Add `command` as a workload type to the transact workload subcommand
- Update WorkloadAction to handle command workloads
- Implement `CommandGeneratingIter`, `CommandTransactionWorkload` and `CommandBatchWorkload` which work together to create the command family workload


### **Testing:**
1. Start two splinter nodes with the experimental feature "back-pressure"
2. Create a circuit between the nodes, ensure that the scabbard version is set to 2 when creating the circuit
3. Use scabbard CLI to upload the command smart contract
4. Use the transact CLI to start a command workload, for example:
```
transact workload --targets http://localhost:8085/scabbard/<circuit-id>/<service-id> \
--key <private-key-path> \
--target-rate 5 \
--update 2 \
--workload command \
--seed 10 \
-vv
```
Observe splinterd logs to see command family transactions being executed
Note: Because one of the possible commands is `return_invalid` occasionally the logs will show:
```
T["StaticExecutionAdapter"] INFO [sawtooth_sabre::wasm_executor::wasm_externals] InvalidTransaction: 'return_invalid' command mock error message
...
T["consensus-gsAA"] ERROR [splinter::consensus::two_phase::v2] Error while creating proposal: proposal manager error occurred: scabbard state error: transaction failed: "Wasm contract returned invalid transaction: command, 1.0"
```