### PR TITLE
TooManyRequests response bug fix

### DIFF
--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -273,7 +273,7 @@ impl WorkerBuilder {
                     let http_counter = HttpRequestCounter::new(thread_id.to_string());
                     // the last time http request information was logged
                     let mut last_log_time = time::Instant::now();
-                    let start_time = time::Instant::now();
+                    let mut start_time = time::Instant::now();
                     // total number of batches that have been submitted
                     let mut submitted_batches = 0;
                     let mut submission_start = time::Instant::now();
@@ -324,7 +324,8 @@ impl WorkerBuilder {
                                                 submitted_batches,
                                             ) {
                                                 Ok(()) => {
-                                                    submitted_batches += 1;
+                                                    submitted_batches = 1;
+                                                    start_time = time::Instant::now();
                                                     http_counter.increment_sent()
                                                 }
                                                 Err(err) => error!("{}:{}", thread_id, err),


### PR DESCRIPTION
This PR fixes a bug in the recent update to handle `TooManyRequests`. Previously if control-c was pressed while the `slow_rate` method was attempting to resubmit a batch the workload would not stop until `slow_rate` had returned and it would usually result in a panic caused by a divide by zero error.

The following changes are added in this PR to fix this bug:
- After each time `slow_rate` is called the time and total batches counters used to calculate the effective submission rate are reset
- The `slow_rate` method is updated to default to 1 second of sleep if the effective rate is calculated to be 0, this avoids any possible divide by zero errors that were possible before
- A `receiver` argument is added to the `slow_rate` method, the method uses the receiver to check if a shutdown message has been sent each time it loops
- The `slow_rate` method is updated to return a boolean representing whether or not a shutdown message was sent. If `slow_rate` returns `true` the loop will break and the workload will stop

### **Testing:**
1. Start two splinter nodes with the experimental feature "back-pressure"
2. Create a circuit between the nodes, ensure that the scabbard version is set to 2 when creating the circuit
3. Use scabbard CLI to upload the smallbank smart contract
4. Use the transact CLI to start a smallbank workload, for example:
```
transact workload --targets http://localhost:8085/scabbard/<circuit-id>/<service-id> \
--key <private-key-path> \
--target-rate 5 \
--update 2 \
--workload smallbank \
-vv
```
5. Control-c immediately after seeing the log message:
```Received TooManyRequests message from target, attempting to resubmit batch```
check that the log shows:
```
Shutting down worker Smallbank-Workload-0
Worker received shutdown
```
and the workload stops
6. Run the workload command again
7. Control-c while batches are being successfully submitted
check that the same shutdown log message shows:
```
Shutting down worker Smallbank-Workload-0
Worker received shutdown
```
and the workload stops