### PR TITLE
Update Sha2::Sha512 usage

### DIFF
--- a/libtransact/src/families/command/workload/playlist.rs
+++ b/libtransact/src/families/command/workload/playlist.rs
@@ -180,8 +180,8 @@ fn make_command_workload_addresses() -> Vec<String> {
     // Create 100 addresses
     for i in 0..100 {
         let mut sha = Sha512::new();
-        sha.input(format!("address{}", i).as_bytes());
-        let hash = &mut sha.result();
+        sha.update(format!("address{}", i).as_bytes());
+        let hash = &mut sha.finalize();
 
         let hex = bytes_to_hex_str(hash);
 


### PR DESCRIPTION
Update to work with the current version of sha2 used in transact.