### PR TITLE
Remove env output from 'just build'

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,6 @@ features := '\
 build:
     #!/usr/bin/env sh
     set -e
-    env
     for feature in $(echo {{features}})
     do
         for crate in $(echo {{crates}})
@@ -122,7 +121,6 @@ lint: clean
 test: build
     #!/usr/bin/env sh
     set -e
-    env
     for feature in $(echo {{features}})
     do
         for crate in $(echo {{crates}})


### PR DESCRIPTION
This is undesirable output when running the command in the developer workflow.
