### PR TITLE
Add examples/sabre_command to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,6 +17,7 @@ crates := '\
     libtransact \
     examples/simple_xo \
     examples/address_generator \
+    examples/sabre_command \
     examples/sabre_smallbank \
     cli \
     '


### PR DESCRIPTION
This is required to catch build, lint, and testing errors in this
example crate.