### PR TITLE
Add MerkleRadixLeafReader trait

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -108,6 +108,7 @@ experimental = [
     "family-xo",
     "key-value-state",
     "protocol-sabre-exec",
+    "state-merkle-leaf-reader",
     "workload",
     "workload-batch-gen",
     "workload-runner"
@@ -163,6 +164,7 @@ sabre-compat = ["sabre-sdk"]
 sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 state-merkle = ["cbor-codec", "log", "openssl"]
+state-merkle-leaf-reader = []
 # This feature must be enabled to run the merkle tests using a redis db.  It is
 # not enabled by default, due to its requirement of an external redis instance.
 state-merkle-redis-db-tests = ["database-redis", "state-merkle"]

--- a/libtransact/src/state/merkle/error.rs
+++ b/libtransact/src/state/merkle/error.rs
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::error::Error;
+use std::fmt;
+
+use crate::error::{InternalError, InvalidStateError};
+
+#[derive(Debug)]
+pub enum MerkleRadixLeafReadError {
+    InternalError(InternalError),
+    InvalidStateError(InvalidStateError),
+}
+
+impl fmt::Display for MerkleRadixLeafReadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            MerkleRadixLeafReadError::InternalError(err) => f.write_str(&err.to_string()),
+            MerkleRadixLeafReadError::InvalidStateError(err) => f.write_str(&err.to_string()),
+        }
+    }
+}
+
+impl Error for MerkleRadixLeafReadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            MerkleRadixLeafReadError::InternalError(ref err) => Some(err),
+            MerkleRadixLeafReadError::InvalidStateError(ref err) => Some(err),
+        }
+    }
+}
+
+impl From<InternalError> for MerkleRadixLeafReadError {
+    fn from(err: InternalError) -> Self {
+        MerkleRadixLeafReadError::InternalError(err)
+    }
+}
+
+impl From<InvalidStateError> for MerkleRadixLeafReadError {
+    fn from(err: InvalidStateError) -> Self {
+        MerkleRadixLeafReadError::InvalidStateError(err)
+    }
+}

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -17,9 +17,34 @@
  * -----------------------------------------------------------------------------
  */
 
+#[cfg(feature = "state-merkle-leaf-reader")]
+mod error;
 pub mod kv;
 
+#[cfg(feature = "state-merkle-leaf-reader")]
+use crate::state::Read;
+
+#[cfg(feature = "state-merkle-leaf-reader")]
+pub use error::MerkleRadixLeafReadError;
 pub use kv::{
     MerkleRadixTree, MerkleState, StateDatabaseError, CHANGE_LOG_INDEX, DUPLICATE_LOG_INDEX,
     INDEXES,
 };
+
+// These types make the clippy happy
+#[cfg(feature = "state-merkle-leaf-reader")]
+type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
+#[cfg(feature = "state-merkle-leaf-reader")]
+type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
+
+#[cfg(feature = "state-merkle-leaf-reader")]
+pub trait MerkleRadixLeafReader: Read<StateId = String, Key = String, Value = Vec<u8>> {
+    /// Returns an iterator over the leaves of a merkle radix tree.
+    /// By providing an optional address prefix, the caller can limit the iteration
+    /// over the leaves in a specific subtree.
+    fn leaves(
+        &self,
+        state_id: &Self::StateId,
+        subtree: Option<&str>,
+    ) -> IterResult<LeafIter<(Self::Key, Self::Value)>>;
+}


### PR DESCRIPTION
This trait provides a generic leaf listing api, that matches the key-value backed implementation's provided method.

Additionally, implements this trait on the existing `kv::MerkleState`