### PR TITLE
Remove the clean dependency from just lint

### DIFF
--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ doc:
     set -e
     cargo doc
 
-lint: clean
+lint:
     #!/usr/bin/env sh
     set -e
     echo "\033[1mcargo fmt -- --check\033[0m"


### PR DESCRIPTION
To get the old behavior, run "just clean; just build". This change makes
the clean optional, which is a more desirable developer workflow.