### PR TITLE
Add SQL operations for new SQL-backed merkle radix implementation

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -45,17 +45,24 @@ rand = "0.6"
 rand_hc = { version = "0.1", optional = true }
 redis = { version = "0.20", default-features = false, optional = true }
 reqwest = { version = "0.11", features = ["blocking", "json"], optional = true}
-rusqlite = { version = "0.25", optional = true }
 sabre-sdk = { version ="0.7.1", optional = true }
 sawtooth-sdk = { version = "0.5", optional = true }
 semver = { version = "1", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
+serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0.8", optional = true }
 sha2 = "0.9"
 tar = { version = "0.4", optional = true }
 uuid = { version = "0.8", optional = true, features = ["v4"] }
 yaml-rust =  { version = "0.4", optional = true }
+
+# The following dependencies are interdependent.
+#
+# diesel 1.4.7 is the minimum version that does not conflict with rusqlite in
+# that they both require a transient dependency of libsqlite-sys.
+diesel = { version = "~1.4.7", features = ["r2d2"], optional = true }
+rusqlite = { version = "0.25", optional = true }
 
 [dev-dependencies]
 rusty-fork = "0.3"
@@ -108,7 +115,9 @@ experimental = [
     "family-xo",
     "key-value-state",
     "protocol-sabre-exec",
+    "sqlite",
     "state-merkle-leaf-reader",
+    "state-merkle-sql",
     "workload",
     "workload-batch-gen",
     "workload-runner"
@@ -163,8 +172,10 @@ protocol-sabre-exec = []
 sabre-compat = ["sabre-sdk"]
 sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
+sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log", "openssl"]
 state-merkle-leaf-reader = []
+state-merkle-sql = ["diesel"]
 # This feature must be enabled to run the merkle tests using a redis db.  It is
 # not enabled by default, due to its requirement of an external redis instance.
 state-merkle-redis-db-tests = ["database-redis", "state-merkle"]

--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -115,6 +115,10 @@
 
 #![cfg_attr(feature = "nightly", feature(test))]
 
+#[cfg(feature = "state-merkle-sql")]
+#[macro_use]
+extern crate diesel;
+
 #[cfg(feature = "context")]
 pub mod context;
 #[cfg(feature = "contract")]

--- a/libtransact/src/state/merkle/kv/error.rs
+++ b/libtransact/src/state/merkle/kv/error.rs
@@ -17,6 +17,7 @@
 use std::error::Error;
 use std::fmt;
 
+use crate::error::InternalError;
 use crate::protos::ProtoConversionError;
 use cbor::decoder::DecodeError;
 use cbor::encoder::EncodeError;
@@ -30,6 +31,7 @@ pub enum StateDatabaseError {
     DeserializationError(DecodeError),
     SerializationError(EncodeError),
     ChangeLogEncodingError(String),
+    InternalError(InternalError),
     InvalidRecord,
     InvalidHash(String),
     InvalidChangeLogIndex(String),
@@ -51,6 +53,7 @@ impl fmt::Display for StateDatabaseError {
             StateDatabaseError::ChangeLogEncodingError(ref msg) => {
                 write!(f, "Unable to serialize change log entry: {}", msg)
             }
+            StateDatabaseError::InternalError(ref err) => f.write_str(&err.to_string()),
             StateDatabaseError::InvalidRecord => write!(f, "A node was malformed"),
             StateDatabaseError::InvalidHash(ref msg) => {
                 write!(f, "The given hash is invalid: {}", msg)
@@ -76,6 +79,7 @@ impl Error for StateDatabaseError {
             StateDatabaseError::DeserializationError(ref err) => Some(err),
             StateDatabaseError::SerializationError(ref err) => Some(err),
             StateDatabaseError::ChangeLogEncodingError(_) => None,
+            StateDatabaseError::InternalError(ref err) => Some(err),
             StateDatabaseError::InvalidRecord => None,
             StateDatabaseError::InvalidHash(_) => None,
             StateDatabaseError::InvalidChangeLogIndex(_) => None,
@@ -121,5 +125,11 @@ impl From<ProtobufError> for StateDatabaseError {
 impl From<ProtoConversionError> for StateDatabaseError {
     fn from(err: ProtoConversionError) -> Self {
         StateDatabaseError::ProtobufConversionError(err)
+    }
+}
+
+impl From<InternalError> for StateDatabaseError {
+    fn from(err: InternalError) -> Self {
+        StateDatabaseError::InternalError(err)
     }
 }

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -20,13 +20,7 @@ mod change_log;
 mod error;
 
 use std::cmp::Reverse;
-use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::io::Cursor;
-
-use cbor::decoder::GenericDecoder;
-use cbor::encoder::GenericEncoder;
-use cbor::value::{Bytes, Key, Text, Value};
 
 use crate::database::error::DatabaseError;
 use crate::database::{Database, DatabaseReader, DatabaseWriter};
@@ -35,6 +29,7 @@ use crate::error::{InternalError, InvalidStateError};
 use crate::state::error::{StatePruneError, StateReadError, StateWriteError};
 use crate::state::{Prune, Read, StateChange, Write};
 
+use super::node::Node;
 #[cfg(feature = "state-merkle-leaf-reader")]
 use super::{MerkleRadixLeafReadError, MerkleRadixLeafReader};
 
@@ -788,93 +783,8 @@ fn tokenize_address(address: &str) -> Box<[&str]> {
 /// Fetch a node by its hash
 fn get_node_by_hash(db: &dyn Database, hash: &str) -> Result<Node, StateDatabaseError> {
     match db.get_reader()?.get(hash.as_bytes())? {
-        Some(bytes) => Node::from_bytes(&bytes),
+        Some(bytes) => Node::from_bytes(&bytes).map_err(StateDatabaseError::from),
         None => Err(StateDatabaseError::NotFound(hash.to_string())),
-    }
-}
-
-/// Internal Node structure of the Radix tree
-#[derive(Default, Debug, PartialEq, Clone)]
-struct Node {
-    value: Option<Vec<u8>>,
-    children: BTreeMap<String, String>,
-}
-
-impl Node {
-    /// Consumes this node and serializes it to bytes
-    fn into_bytes(self) -> Result<Vec<u8>, StateDatabaseError> {
-        let mut e = GenericEncoder::new(Cursor::new(Vec::new()));
-
-        let mut map = BTreeMap::new();
-        map.insert(
-            Key::Text(Text::Text("v".to_string())),
-            match self.value {
-                Some(bytes) => Value::Bytes(Bytes::Bytes(bytes)),
-                None => Value::Null,
-            },
-        );
-
-        let children = self
-            .children
-            .into_iter()
-            .map(|(k, v)| (Key::Text(Text::Text(k)), Value::Text(Text::Text(v))))
-            .collect();
-
-        map.insert(Key::Text(Text::Text("c".to_string())), Value::Map(children));
-
-        e.value(&Value::Map(map))?;
-
-        Ok(e.into_inner().into_writer().into_inner())
-    }
-
-    /// Deserializes the given bytes to a Node
-    fn from_bytes(bytes: &[u8]) -> Result<Node, StateDatabaseError> {
-        let input = Cursor::new(bytes);
-        let mut decoder = GenericDecoder::new(cbor::Config::default(), input);
-        let decoder_value = decoder.value()?;
-        let (val, children_raw) = match decoder_value {
-            Value::Map(mut root_map) => (
-                root_map.remove(&Key::Text(Text::Text("v".to_string()))),
-                root_map.remove(&Key::Text(Text::Text("c".to_string()))),
-            ),
-            _ => return Err(StateDatabaseError::InvalidRecord),
-        };
-
-        let value = match val {
-            Some(Value::Bytes(Bytes::Bytes(bytes))) => Some(bytes),
-            Some(Value::Null) => None,
-            _ => return Err(StateDatabaseError::InvalidRecord),
-        };
-
-        let children = match children_raw {
-            Some(Value::Map(child_map)) => {
-                let mut result = BTreeMap::new();
-                for (k, v) in child_map {
-                    result.insert(key_to_string(k)?, text_to_string(v)?);
-                }
-                result
-            }
-            None => BTreeMap::new(),
-            _ => return Err(StateDatabaseError::InvalidRecord),
-        };
-
-        Ok(Node { value, children })
-    }
-}
-
-/// Converts a CBOR Key to its String content
-fn key_to_string(key_val: Key) -> Result<String, StateDatabaseError> {
-    match key_val {
-        Key::Text(Text::Text(s)) => Ok(s),
-        _ => Err(StateDatabaseError::InvalidRecord),
-    }
-}
-
-/// Converts a CBOR Text Value to its String content
-fn text_to_string(text_val: Value) -> Result<String, StateDatabaseError> {
-    match text_val {
-        Value::Text(Text::Text(s)) => Ok(s),
-        _ => Err(StateDatabaseError::InvalidRecord),
     }
 }
 
@@ -884,71 +794,4 @@ fn hash(input: &[u8]) -> Vec<u8> {
     bytes.extend(openssl::sha::sha512(input).iter());
     let (hash, _rest) = bytes.split_at(bytes.len() / 2);
     hash.to_vec()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn node_serialize() {
-        let n = Node {
-            value: Some(b"hello".to_vec()),
-            children: vec![("ab".to_string(), "123".to_string())]
-                .into_iter()
-                .collect(),
-        };
-
-        let packed = n
-            .into_bytes()
-            .unwrap()
-            .iter()
-            .map(|b| format!("{:x}", b))
-            .collect::<Vec<_>>()
-            .join("");
-        // This expected output was generated using the python structures
-        let output = "a26163a16261626331323361764568656c6c6f";
-
-        assert_eq!(output, packed);
-    }
-
-    #[test]
-    fn node_deserialize() {
-        let packed =
-            ::hex::decode("a26163a162303063616263617647676f6f64627965").expect("improper hex");
-
-        let unpacked = Node::from_bytes(&packed).unwrap();
-        assert_eq!(
-            Node {
-                value: Some(b"goodbye".to_vec()),
-                children: vec![("00".to_string(), "abc".to_string())]
-                    .into_iter()
-                    .collect(),
-            },
-            unpacked
-        );
-    }
-
-    #[test]
-    fn node_roundtrip() {
-        let n = Node {
-            value: Some(b"hello".to_vec()),
-            children: vec![("ab".to_string(), "123".to_string())]
-                .into_iter()
-                .collect(),
-        };
-
-        let packed = n.into_bytes().unwrap();
-        let unpacked = Node::from_bytes(&packed).unwrap();
-
-        assert_eq!(
-            Node {
-                value: Some(b"hello".to_vec()),
-                children: vec![("ab".to_string(), "123".to_string())]
-                    .into_iter()
-                    .collect(),
-            },
-            unpacked
-        )
-    }
 }

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -20,6 +20,7 @@
 #[cfg(feature = "state-merkle-leaf-reader")]
 mod error;
 pub mod kv;
+mod node;
 
 #[cfg(feature = "state-merkle-leaf-reader")]
 use crate::state::Read;

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -21,6 +21,8 @@
 mod error;
 pub mod kv;
 mod node;
+#[cfg(feature = "state-merkle-sql")]
+pub mod sql;
 
 #[cfg(feature = "state-merkle-leaf-reader")]
 use crate::state::Read;

--- a/libtransact/src/state/merkle/node.rs
+++ b/libtransact/src/state/merkle/node.rs
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2019-2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+
+use cbor::decoder::GenericDecoder;
+use cbor::encoder::GenericEncoder;
+use cbor::value::{Bytes, Key, Text, Value};
+
+use crate::error::InternalError;
+
+impl From<cbor::EncodeError> for InternalError {
+    fn from(e: cbor::EncodeError) -> Self {
+        InternalError::from_source(Box::new(e))
+    }
+}
+
+impl From<cbor::DecodeError> for InternalError {
+    fn from(e: cbor::DecodeError) -> Self {
+        InternalError::from_source(Box::new(e))
+    }
+}
+
+/// Internal Node structure of the Radix tree
+#[derive(Default, Clone)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct Node {
+    pub value: Option<Vec<u8>>,
+    pub children: BTreeMap<String, String>,
+}
+
+impl Node {
+    /// Consumes this node and serializes it to bytes
+    pub fn into_bytes(self) -> Result<Vec<u8>, InternalError> {
+        let mut e = GenericEncoder::new(Cursor::new(Vec::new()));
+
+        let mut map = BTreeMap::new();
+        map.insert(
+            Key::Text(Text::Text("v".to_string())),
+            match self.value {
+                Some(bytes) => Value::Bytes(Bytes::Bytes(bytes)),
+                None => Value::Null,
+            },
+        );
+
+        let children = self
+            .children
+            .into_iter()
+            .map(|(k, v)| (Key::Text(Text::Text(k)), Value::Text(Text::Text(v))))
+            .collect();
+
+        map.insert(Key::Text(Text::Text("c".to_string())), Value::Map(children));
+
+        e.value(&Value::Map(map))?;
+
+        Ok(e.into_inner().into_writer().into_inner())
+    }
+
+    /// Deserializes the given bytes to a Node
+    pub fn from_bytes(bytes: &[u8]) -> Result<Node, InternalError> {
+        let input = Cursor::new(bytes);
+        let mut decoder = GenericDecoder::new(cbor::Config::default(), input);
+        let decoder_value = decoder.value()?;
+        let (val, children_raw) = match decoder_value {
+            Value::Map(mut root_map) => (
+                root_map.remove(&Key::Text(Text::Text("v".to_string()))),
+                root_map.remove(&Key::Text(Text::Text("c".to_string()))),
+            ),
+            _ => {
+                return Err(InternalError::with_message(
+                    "Invalid node record: is not a map".into(),
+                ))
+            }
+        };
+
+        let value = match val {
+            Some(Value::Bytes(Bytes::Bytes(bytes))) => Some(bytes),
+            Some(Value::Null) => None,
+            _ => {
+                return Err(InternalError::with_message(
+                    "Invalid node record: incorrect value type".into(),
+                ))
+            }
+        };
+
+        let children = match children_raw {
+            Some(Value::Map(child_map)) => {
+                let mut result = BTreeMap::new();
+                for (k, v) in child_map {
+                    result.insert(key_to_string(k)?, text_to_string(v)?);
+                }
+                result
+            }
+            None => BTreeMap::new(),
+            _ => {
+                return Err(InternalError::with_message(
+                    "Invalid node record: incorrect child map type".into(),
+                ))
+            }
+        };
+
+        Ok(Node { value, children })
+    }
+}
+
+/// Converts a CBOR Key to its String content
+fn key_to_string(key_val: Key) -> Result<String, InternalError> {
+    match key_val {
+        Key::Text(Text::Text(s)) => Ok(s),
+        _ => Err(InternalError::with_message(
+            "Invalid node record: invalid key type".into(),
+        )),
+    }
+}
+
+/// Converts a CBOR Text Value to its String content
+fn text_to_string(text_val: Value) -> Result<String, InternalError> {
+    match text_val {
+        Value::Text(Text::Text(s)) => Ok(s),
+        _ => Err(InternalError::with_message(
+            "Invalid node record: invalid value type".into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_serialize() {
+        let n = Node {
+            value: Some(b"hello".to_vec()),
+            children: vec![("ab".to_string(), "123".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let packed = n
+            .into_bytes()
+            .unwrap()
+            .iter()
+            .map(|b| format!("{:x}", b))
+            .collect::<Vec<_>>()
+            .join("");
+        // This expected output was generated using the python structures
+        let output = "a26163a16261626331323361764568656c6c6f";
+
+        assert_eq!(output, packed);
+    }
+
+    #[test]
+    fn node_deserialize() {
+        let packed =
+            ::hex::decode("a26163a162303063616263617647676f6f64627965").expect("improper hex");
+
+        let unpacked = Node::from_bytes(&packed).unwrap();
+        assert_eq!(
+            Node {
+                value: Some(b"goodbye".to_vec()),
+                children: vec![("00".to_string(), "abc".to_string())]
+                    .into_iter()
+                    .collect(),
+            },
+            unpacked
+        );
+    }
+
+    #[test]
+    fn node_roundtrip() {
+        let n = Node {
+            value: Some(b"hello".to_vec()),
+            children: vec![("ab".to_string(), "123".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let packed = n.into_bytes().unwrap();
+        let unpacked = Node::from_bytes(&packed).unwrap();
+
+        assert_eq!(
+            Node {
+                value: Some(b"hello".to_vec()),
+                children: vec![("ab".to_string(), "123".to_string())]
+                    .into_iter()
+                    .collect(),
+            },
+            unpacked
+        )
+    }
+}

--- a/libtransact/src/state/merkle/sql/migration/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+#[cfg(feature = "sqlite")]
+#[allow(dead_code)]
+pub mod sqlite;

--- a/libtransact/src/state/merkle/sql/migration/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/migration/sqlite.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+
+const CREATE_LEAF_TABLE: &str = r#"
+    CREATE TABLE IF NOT EXISTS merkle_radix_leaf (
+        id INTEGER PRIMARY KEY,
+        address STRING NOT NULL,
+        data BLOB
+    )
+    "#;
+
+const CREATE_TREE_TABLE: &str = r#"
+    CREATE TABLE IF NOT EXISTS merkle_radix_tree_node (
+        hash STRING PRIMARY KEY,
+        leaf_id INTEGER,
+        children TEXT,
+        FOREIGN KEY(leaf_id) REFERENCES merkle_radix_leaf(id)
+    )
+    "#;
+const CREATE_STATE_ROOT_TABLE: &str = r#"
+    CREATE TABLE IF NOT EXISTS merkle_radix_state_root (
+        id INTEGER PRIMARY KEY,
+        state_root STRING NOT NULL,
+        parent_state_root STRING NOT NULL,
+        FOREIGN KEY(state_root) REFERENCES merkle_radix_tree_node (hash)
+    )
+    "#;
+
+const CREATE_STATE_ROOT_LEAF_INDEX_TABLE: &str = r#"
+    CREATE TABLE IF NOT EXISTS merkle_radix_state_root_leaf_index (
+        id INTEGER PRIMARY KEY,
+        leaf_id INTEGER NOT NULL,
+        from_state_root_id INTEGER NOT NULL,
+        to_state_root_id INTEGER,
+        FOREIGN KEY(from_state_root_id) REFERENCES merkle_radix_state_root(id),
+        FOREIGN KEY(leaf_id) REFERENCES merkle_radix_leaf (id)
+    )
+    "#;
+
+pub fn run_migrations(conn: &SqliteConnection) -> Result<(), InternalError> {
+    conn.transaction::<_, diesel::result::Error, _>(|| {
+        conn.execute(CREATE_LEAF_TABLE)?;
+        conn.execute(CREATE_TREE_TABLE)?;
+        conn.execute(CREATE_STATE_ROOT_TABLE)?;
+        conn.execute(CREATE_STATE_ROOT_LEAF_INDEX_TABLE)?;
+
+        Ok(())
+    })
+    .map_err(|err| InternalError::from_source(Box::new(err)))
+}

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+mod migration;
+mod models;
+mod schema;

--- a/libtransact/src/state/merkle/sql/models/mod.rs
+++ b/libtransact/src/state/merkle/sql/models/mod.rs
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+#[cfg(feature = "sqlite")]
+mod sqlite;
+
+use super::schema::*;
+
+#[derive(Insertable, Queryable, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_leaf"]
+#[primary_key(id)]
+pub struct MerkleRadixLeaf {
+    pub id: i64,
+    pub address: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Insertable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_leaf"]
+pub struct NewMerkleRadixLeaf<'a> {
+    pub id: i64,
+    pub address: &'a str,
+    pub data: &'a [u8],
+}
+
+#[derive(Insertable, Queryable, QueryableByName, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_tree_node"]
+#[primary_key(hash)]
+pub struct MerkleRadixTreeNode {
+    pub hash: String,
+    pub leaf_id: Option<i64>,
+    pub children: Children,
+}
+
+#[derive(AsExpression, Debug, FromSqlRow)]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(feature = "sqlite", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "sqlite", sql_type = "diesel::sql_types::Text")]
+pub struct Children(pub Vec<Option<String>>);
+
+#[derive(Insertable, Queryable, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_state_root"]
+#[primary_key(id)]
+pub struct MerkleRadixStateRoot {
+    pub id: i64,
+    pub state_root: String,
+    pub parent_state_root: String,
+}
+
+#[derive(Insertable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_state_root"]
+pub struct NewMerkleRadixStateRoot<'a> {
+    pub state_root: &'a str,
+    pub parent_state_root: &'a str,
+}
+
+#[derive(Insertable, Queryable, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_state_root_leaf_index"]
+#[primary_key(id)]
+pub struct MerkleRadixStateRootLeafIndexEntry {
+    pub id: i64,
+    pub leaf_id: i64,
+    pub from_state_root_id: i64,
+    pub to_state_root_id: Option<i64>,
+}

--- a/libtransact/src/state/merkle/sql/models/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/models/sqlite.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::io::Write;
+
+use super::Children;
+
+use diesel::{
+    backend::Backend,
+    deserialize::{self, FromSql},
+    serialize::{self, Output, ToSql},
+    sql_types::Text,
+    sqlite::Sqlite,
+};
+
+impl FromSql<Text, Sqlite> for Children {
+    fn from_sql(bytes: Option<&<Sqlite as Backend>::RawValue>) -> deserialize::Result<Self> {
+        let t = <String as FromSql<Text, Sqlite>>::from_sql(bytes)?;
+        Ok(serde_json::from_str(&t)?)
+    }
+}
+
+impl ToSql<Text, Sqlite> for Children {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Sqlite>) -> serialize::Result {
+        let s = serde_json::to_string(&self.0)?;
+        <String as ToSql<Text, Sqlite>>::to_sql(&s, out)
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/get_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_leaves.rs
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+
+use crate::state::merkle::sql::schema::{
+    merkle_radix_leaf, merkle_radix_state_root, merkle_radix_state_root_leaf_index,
+};
+
+use super::MerkleRadixOperations;
+
+pub trait MerkleRadixGetLeavesOperation {
+    fn get_leaves(
+        &self,
+        state_root_hash: &str,
+        addresses: Vec<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
+}
+
+impl<'a, C> MerkleRadixGetLeavesOperation for MerkleRadixOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Blob, C::Backend>,
+{
+    fn get_leaves(
+        &self,
+        state_root_hash: &str,
+        addresses: Vec<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
+        self.conn
+            .transaction::<_, diesel::result::Error, _>(|| {
+                let mut results = vec![];
+                let state_root_id = merkle_radix_state_root::table
+                    .filter(merkle_radix_state_root::state_root.eq(state_root_hash))
+                    .select(merkle_radix_state_root::id)
+                    .get_result::<i64>(self.conn)?;
+
+                for address in addresses {
+                    let query = merkle_radix_leaf::table
+                        .inner_join(merkle_radix_state_root_leaf_index::table)
+                        .filter(
+                            merkle_radix_leaf::address
+                                .eq(address)
+                                .and(
+                                    merkle_radix_state_root_leaf_index::from_state_root_id
+                                        .le(state_root_id),
+                                )
+                                .and(
+                                    merkle_radix_state_root_leaf_index::to_state_root_id
+                                        .is_null()
+                                        .or(merkle_radix_state_root_leaf_index::to_state_root_id
+                                            .gt(state_root_id)),
+                                ),
+                        )
+                        .select((
+                            merkle_radix_leaf::id,
+                            merkle_radix_leaf::address,
+                            merkle_radix_leaf::data,
+                            merkle_radix_state_root_leaf_index::to_state_root_id,
+                        ))
+                        .order(merkle_radix_leaf::address.asc())
+                        .then_order_by(merkle_radix_state_root_leaf_index::to_state_root_id.desc());
+
+                    let leaf = query
+                        .get_result::<(i64, String, Vec<u8>, Option<i64>)>(self.conn)
+                        .optional()?;
+
+                    if let Some((_, address, data, _)) = leaf {
+                        results.push((address, data));
+                    }
+                }
+
+                Ok(results)
+            })
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use diesel::dsl::insert_into;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::MerkleRadixLeaf;
+    use crate::state::merkle::sql::operations::update_index::{
+        ChangedLeaf, MerkleRadixUpdateIndexOperation,
+    };
+
+    /// This tests that a leaf changed across several state root hashes is returned when requested
+    /// at the given state root hash. It verifies that:
+    /// 1. No leaves are returned for the initial state root hash
+    /// 2. The first leaf change is returned for first state root.
+    /// 3. The second leaf change is returned for the second state root.
+    #[test]
+    fn test_get_leaves_at_state_root() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        // insert the initial root:
+        insert_into(merkle_radix_state_root::table)
+            .values((
+                merkle_radix_state_root::state_root.eq("initial-state-root"),
+                merkle_radix_state_root::parent_state_root.eq(""),
+            ))
+            .execute(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        operations.update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        // insert the changed leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 2,
+                address: "aabbcc".into(),
+                data: b"goodbye".to_vec(),
+            })
+            .execute(&conn)?;
+
+        operations.update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 2,
+            }],
+        )?;
+
+        let leaves = operations.get_leaves("initial-state-root", vec!["aabbcc"])?;
+        assert!(leaves.is_empty());
+
+        let leaves = operations.get_leaves("first-state-root", vec!["aabbcc"])?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        let leaves = operations.get_leaves("second-state-root", vec!["aabbcc"])?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"goodbye");
+
+        Ok(())
+    }
+
+    /// This tests that a leaf inserted then deleted across several state root hashes is returned
+    /// only on the state root hash where it exists.  It verifies that:
+    /// 1. No leaves are returned for the initial state root hash
+    /// 2. The leaf is returned for first state root.
+    /// 3. The leaf is no longer returned for the second state root.
+    #[test]
+    fn test_get_leaves_with_deletion() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        // insert the initial root:
+        insert_into(merkle_radix_state_root::table)
+            .values((
+                merkle_radix_state_root::state_root.eq("initial-state-root"),
+                merkle_radix_state_root::parent_state_root.eq(""),
+            ))
+            .execute(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        operations.update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        // insert the changed leaf
+        operations.update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::Deleted("aabbcc")],
+        )?;
+
+        let leaves = operations.get_leaves("initial-state-root", vec!["aabbcc"])?;
+        assert!(leaves.is_empty());
+
+        let leaves = operations.get_leaves("first-state-root", vec!["aabbcc"])?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        let leaves = operations.get_leaves("second-state-root", vec!["aabbcc"])?;
+        assert!(leaves.is_empty());
+
+        Ok(())
+    }
+
+    /// This tests that several leaves, added against successive state root hashes.
+    /// 1. Add a leaf and nodes to the tree at state root 1
+    /// 2. Add a second leaf and nodes to the tree at state root 2
+    /// 3. Verify that only the first leaf is returned with state root 1
+    /// 4. Verify that both leaves are returned with state root 2
+    #[test]
+    fn test_get_leaves_at_state_root_larger_tree() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        // insert the initial root:
+        insert_into(merkle_radix_state_root::table)
+            .values((
+                merkle_radix_state_root::state_root.eq("initial-state-root"),
+                merkle_radix_state_root::parent_state_root.eq(""),
+            ))
+            .execute(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        operations.update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        // insert a new leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 2,
+                address: "112233".into(),
+                data: b"goodbye".to_vec(),
+            })
+            .execute(&conn)?;
+
+        operations.update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "112233",
+                leaf_id: 2,
+            }],
+        )?;
+
+        let leaves = operations.get_leaves("initial-state-root", vec!["aabbcc"])?;
+        assert!(leaves.is_empty());
+
+        let leaves = operations.get_leaves("first-state-root", vec!["aabbcc"])?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        let leaves = operations.get_leaves("second-state-root", vec!["112233", "aabbcc"])?;
+        assert_eq!(leaves.len(), 2);
+        assert_eq!(leaves[0].0, "112233");
+        assert_eq!(leaves[0].1, b"goodbye");
+        assert_eq!(leaves[1].0, "aabbcc");
+        assert_eq!(leaves[1].1, b"hello");
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/get_path.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_path.rs
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::BTreeMap;
+
+use diesel::prelude::*;
+use diesel::sql_query;
+#[cfg(feature = "sqlite")]
+use diesel::sql_types::{BigInt, Blob, Nullable, Text};
+
+use crate::error::InternalError;
+use crate::state::merkle::node::Node;
+use crate::state::merkle::sql::models::Children;
+
+use super::MerkleRadixOperations;
+
+#[cfg(feature = "sqlite")]
+#[derive(QueryableByName)]
+struct ExtendedMerkleRadixTreeNode {
+    #[column_name = "hash"]
+    #[sql_type = "Text"]
+    pub hash: String,
+
+    #[column_name = "leaf_id"]
+    #[sql_type = "Nullable<BigInt>"]
+    pub leaf_id: Option<i64>,
+
+    #[column_name = "children"]
+    #[sql_type = "Text"]
+    pub children: Children,
+
+    #[column_name = "data"]
+    #[sql_type = "Nullable<Blob>"]
+    pub data: Option<Vec<u8>>,
+}
+
+pub trait MerkleRadixGetPathOperation {
+    fn get_path(
+        &self,
+        state_root_hash: &str,
+        address: &str,
+    ) -> Result<Vec<(String, Node)>, InternalError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> MerkleRadixGetPathOperation for MerkleRadixOperations<'a, SqliteConnection> {
+    fn get_path(
+        &self,
+        state_root_hash: &str,
+        address: &str,
+    ) -> Result<Vec<(String, Node)>, InternalError> {
+        let address_bytes =
+            hex::decode(address).map_err(|e| InternalError::from_source(Box::new(e)))?;
+        let path = sql_query(
+            r#"
+            WITH RECURSIVE tree_path AS
+            (
+                -- This is the initial node
+                SELECT hash, leaf_id, children, 0 as depth
+                FROM merkle_radix_tree_node
+                WHERE hash = ?
+
+                UNION ALL
+
+                -- Recurse through the tree
+                SELECT c.hash, c.leaf_id, c.children, p.depth + 1
+                FROM merkle_radix_tree_node c, tree_path p
+                WHERE c.hash = json_extract(
+                  p.children,
+                  '$[' || json_extract(?, '$[' || p.depth || ']') || ']'
+                )
+            )
+            SELECT t.hash, t.leaf_id, t.children, l.data FROM tree_path t
+            LEFT OUTER JOIN merkle_radix_leaf l ON t.leaf_id = l.id
+            "#,
+        )
+        .bind::<Text, _>(state_root_hash)
+        .bind::<Text, _>(
+            serde_json::to_string(&address_bytes)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?,
+        )
+        .load::<ExtendedMerkleRadixTreeNode>(self.conn)
+        .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        Ok(path
+            .into_iter()
+            .map(|extended_node| {
+                (
+                    extended_node.hash,
+                    Node {
+                        value: extended_node.data,
+                        children: extended_node.children.into(),
+                    },
+                )
+            })
+            .collect())
+    }
+}
+
+impl From<Children> for BTreeMap<String, String> {
+    fn from(children: Children) -> Self {
+        let mut btree = BTreeMap::new();
+
+        for (i, hash_opt) in children
+            .0
+            .into_iter()
+            .enumerate()
+            .filter(|(_, opt)| opt.is_some())
+        {
+            if let Some(hash) = hash_opt {
+                btree.insert(format!("{:02x}", i), hash);
+            }
+        }
+        btree
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[cfg(test)]
+mod sqlite_tests {
+    use super::*;
+
+    use diesel::dsl::{insert_into, select};
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::{Children, MerkleRadixTreeNode, NewMerkleRadixLeaf};
+    use crate::state::merkle::sql::operations::last_insert_rowid;
+    use crate::state::merkle::sql::schema::{merkle_radix_leaf, merkle_radix_tree_node};
+
+    /// Test that the get path on a non-existent root returns an empty path.
+    #[test]
+    fn test_get_path_empty_tree() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let path = MerkleRadixOperations::new(&conn).get_path("state-root", "aabbcc")?;
+
+        assert!(path.is_empty());
+
+        Ok(())
+    }
+
+    /// Test that a single leaf, with intermediate nodes will return the correct path, transformed
+    /// into the merkle Node representation. Additionally, verify that partial paths are returned
+    /// for addresses that do not have leaves in the tree.
+    #[test]
+    fn test_get_path_single_entry() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        insert_into(merkle_radix_leaf::table)
+            .values(NewMerkleRadixLeaf {
+                id: 1,
+                address: "000000",
+                data: b"hello",
+            })
+            .execute(&conn)?;
+
+        let inserted_id = select(last_insert_rowid).get_result::<i64>(&conn)?;
+
+        insert_into(merkle_radix_tree_node::table)
+            .values(vec![
+                MerkleRadixTreeNode {
+                    hash: "000000-hash".into(),
+                    leaf_id: Some(inserted_id),
+                    children: Children(vec![]),
+                },
+                MerkleRadixTreeNode {
+                    hash: "0000-hash".into(),
+                    leaf_id: None,
+                    children: Children(vec![Some("000000-hash".to_string())]),
+                },
+                MerkleRadixTreeNode {
+                    hash: "00-hash".into(),
+                    leaf_id: None,
+                    children: Children(vec![Some("0000-hash".to_string())]),
+                },
+                MerkleRadixTreeNode {
+                    hash: "root-hash".into(),
+                    leaf_id: None,
+                    children: Children(vec![Some("00-hash".to_string())]),
+                },
+            ])
+            .execute(&conn)?;
+
+        let path = MerkleRadixOperations::new(&conn).get_path("root-hash", "000000")?;
+
+        assert_eq!(
+            path,
+            vec![
+                (
+                    "root-hash".to_string(),
+                    Node {
+                        value: None,
+                        children: single_child_btree("00", "00-hash"),
+                    }
+                ),
+                (
+                    "00-hash".into(),
+                    Node {
+                        value: None,
+                        children: single_child_btree("00", "0000-hash"),
+                    }
+                ),
+                (
+                    "0000-hash".into(),
+                    Node {
+                        value: None,
+                        children: single_child_btree("00", "000000-hash"),
+                    }
+                ),
+                (
+                    "000000-hash".into(),
+                    Node {
+                        value: Some(b"hello".to_vec()),
+                        children: BTreeMap::new()
+                    }
+                ),
+            ]
+        );
+
+        // verify that a path that doesn't exist returns just the intermediate nodes.
+        let path = MerkleRadixOperations::new(&conn).get_path("root-hash", "000001")?;
+
+        assert_eq!(
+            path,
+            vec![
+                (
+                    "root-hash".to_string(),
+                    Node {
+                        value: None,
+                        children: single_child_btree("00", "00-hash"),
+                    }
+                ),
+                (
+                    "00-hash".into(),
+                    Node {
+                        value: None,
+                        children: single_child_btree("00", "0000-hash"),
+                    }
+                ),
+                (
+                    "0000-hash".into(),
+                    Node {
+                        value: None,
+                        children: single_child_btree("00", "000000-hash"),
+                    }
+                ),
+            ]
+        );
+
+        // verify that a path that is completely non-existent only returns the root node.
+        let path = MerkleRadixOperations::new(&conn).get_path("root-hash", "aabbcc")?;
+
+        assert_eq!(
+            path,
+            vec![(
+                "root-hash".to_string(),
+                Node {
+                    value: None,
+                    children: single_child_btree("00", "00-hash"),
+                }
+            ),]
+        );
+
+        Ok(())
+    }
+
+    fn single_child_btree(addr_part: &str, hash: &str) -> BTreeMap<String, String> {
+        let mut children = BTreeMap::new();
+        children.insert(addr_part.to_string(), hash.to_string());
+        children
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/has_root.rs
+++ b/libtransact/src/state/merkle/sql/operations/has_root.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::prelude::*;
+
+use diesel::{dsl::exists, select};
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::schema::merkle_radix_tree_node;
+
+use super::MerkleRadixOperations;
+
+pub trait MerkleRadixHasRootOperation {
+    fn has_root(&self, state_root_hash: &str) -> Result<bool, InternalError>;
+}
+
+impl<'a, C> MerkleRadixHasRootOperation for MerkleRadixOperations<'a, C>
+where
+    C: diesel::Connection,
+    C::Backend: diesel::sql_types::HasSqlType<diesel::sql_types::Bool>,
+    bool: diesel::deserialize::FromSql<diesel::sql_types::Bool, C::Backend>,
+{
+    fn has_root(&self, state_root_hash: &str) -> Result<bool, InternalError> {
+        select(exists(merkle_radix_tree_node::table.find(state_root_hash)))
+            .get_result::<bool>(self.conn)
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use diesel::dsl::insert_into;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::{Children, MerkleRadixTreeNode};
+
+    /// Test that has_node succeeds if the root hash is in the tree table.
+    #[test]
+    fn test_has_root_from_tree_node() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        // Does not exist
+        assert!(!MerkleRadixOperations::new(&conn).has_root("initial-state-root")?);
+
+        // insert the root only into the tree:
+        insert_into(merkle_radix_tree_node::table)
+            .values(MerkleRadixTreeNode {
+                hash: "initial-state-root".into(),
+                leaf_id: None,
+                children: Children(vec![]),
+            })
+            .execute(&conn)?;
+
+        assert!(MerkleRadixOperations::new(&conn).has_root("initial-state-root")?);
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
+++ b/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+
+use diesel::dsl::{insert_into, insert_or_ignore_into, max};
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+use crate::state::merkle::node::Node;
+use crate::state::merkle::sql::models::{Children, MerkleRadixTreeNode, NewMerkleRadixLeaf};
+use crate::state::merkle::sql::schema::{merkle_radix_leaf, merkle_radix_tree_node};
+
+use super::MerkleRadixOperations;
+
+pub struct InsertableNode {
+    pub hash: String,
+    pub node: Node,
+    pub address: String,
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct IndexableLeafInfo {
+    pub address: String,
+    pub leaf_id: i64,
+}
+
+pub trait MerkleRadixInsertNodesOperation {
+    fn insert_nodes(
+        &self,
+        nodes: &[InsertableNode],
+    ) -> Result<Vec<IndexableLeafInfo>, InternalError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, SqliteConnection> {
+    fn insert_nodes(
+        &self,
+        nodes: &[InsertableNode],
+    ) -> Result<Vec<IndexableLeafInfo>, InternalError> {
+        self.conn.transaction::<_, InternalError, _>(|| {
+            // We manually increment the id, so we don't have to insert one at a time and fetch
+            // back the resulting id.
+            let initial_id: i64 = merkle_radix_leaf::table
+                .select(max(merkle_radix_leaf::id))
+                .first::<Option<i64>>(self.conn)?
+                .unwrap_or(1);
+
+            let leaves = nodes
+                .iter()
+                .filter(|insertable_node| insertable_node.node.value.is_some())
+                .enumerate()
+                .map(|(i, insertable_node)| {
+                    if let Some(data) = insertable_node.node.value.as_deref() {
+                        Ok(NewMerkleRadixLeaf {
+                            id: initial_id.checked_add(1 + i as i64).ok_or_else(|| {
+                                InternalError::with_message("exceeded id space".into())
+                            })?,
+                            address: &insertable_node.address,
+                            data,
+                        })
+                    } else {
+                        // we already filtered out the None values
+                        unreachable!()
+                    }
+                })
+                .collect::<Result<Vec<NewMerkleRadixLeaf>, InternalError>>()?;
+
+            let leaf_ids: HashMap<&str, i64> = leaves
+                .iter()
+                .map(|new_leaf| (new_leaf.address, new_leaf.id))
+                .collect();
+
+            insert_into(merkle_radix_leaf::table)
+                .values(leaves)
+                .execute(self.conn)?;
+
+            let node_models = nodes
+                .iter()
+                .map::<Result<MerkleRadixTreeNode, InternalError>, _>(|insertable_node| {
+                    Ok(MerkleRadixTreeNode {
+                        hash: insertable_node.hash.clone(),
+                        leaf_id: leaf_ids.get(insertable_node.address.as_str()).copied(),
+                        children: node_to_children(&insertable_node.node)?,
+                    })
+                })
+                .collect::<Result<Vec<MerkleRadixTreeNode>, _>>()?;
+
+            insert_or_ignore_into(merkle_radix_tree_node::table)
+                .values(node_models)
+                .execute(self.conn)?;
+
+            Ok(leaf_ids
+                .into_iter()
+                .map(|(address, leaf_id)| IndexableLeafInfo {
+                    address: address.into(),
+                    leaf_id,
+                })
+                .collect())
+        })
+    }
+}
+
+fn node_to_children(node: &Node) -> Result<Children, InternalError> {
+    let mut children = vec![None; 256];
+    for (location, hash) in node.children.iter() {
+        let pos = u8::from_str_radix(&location, 16)
+            .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+        children[pos as usize] = Some(hash.to_string());
+    }
+    Ok(Children(children))
+}
+
+impl From<diesel::result::Error> for InternalError {
+    fn from(err: diesel::result::Error) -> Self {
+        InternalError::from_source(Box::new(err))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    use diesel::dsl::count;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::MerkleRadixLeaf;
+
+    /// This test inserts a single node (that of the initial state root) and verifies that it is
+    /// correctly inserted into the node table.
+    #[test]
+    fn test_insert_single_node() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        let indexable_info = operations.insert_nodes(&vec![InsertableNode {
+            hash: "initial-state-root".into(),
+            node: Node {
+                value: None,
+                children: Default::default(),
+            },
+            address: String::new(),
+        }])?;
+
+        assert!(
+            indexable_info.is_empty(),
+            "Expected no indexable information, but received some"
+        );
+
+        assert_eq!(
+            merkle_radix_leaf::table
+                .select(count(merkle_radix_leaf::id))
+                .get_result::<i64>(&conn)?,
+            0
+        );
+
+        let nodes = merkle_radix_tree_node::table.get_results::<MerkleRadixTreeNode>(&conn)?;
+
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(
+            nodes[0],
+            MerkleRadixTreeNode {
+                hash: "initial-state-root".into(),
+                leaf_id: None,
+                children: Children(vec![None; 256]),
+            }
+        );
+
+        Ok(())
+    }
+
+    /// This test inserts a set of nodes where the deepest node references a leaf.  It verifies
+    /// that the nodes have been inserted into the node table, and the leave has been inserted into
+    /// the leaf table.
+    #[test]
+    fn test_insert_nodes_with_leaf() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        let nodes = vec![
+            InsertableNode {
+                hash: "state-root".into(),
+                node: Node {
+                    value: None,
+                    children: single_child_btree("0a", "first-node-hash"),
+                },
+                address: String::new(),
+            },
+            InsertableNode {
+                hash: "first-node-hash".into(),
+                node: Node {
+                    value: None,
+                    children: single_child_btree("01", "second-node-hash"),
+                },
+                address: "0a".into(),
+            },
+            InsertableNode {
+                hash: "second-node-hash".into(),
+                node: Node {
+                    value: None,
+                    children: single_child_btree("ff", "leaf-node-hash"),
+                },
+                address: "0a01".into(),
+            },
+            InsertableNode {
+                hash: "leaf-node-hash".into(),
+                node: Node {
+                    value: Some(b"hello".to_vec()),
+                    children: BTreeMap::default(),
+                },
+                address: "0a01ff".into(),
+            },
+        ];
+
+        let indexable_info = operations.insert_nodes(&nodes)?;
+
+        let leaves = merkle_radix_leaf::table.get_results::<MerkleRadixLeaf>(&conn)?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].address, "0a01ff");
+        assert_eq!(leaves[0].data, b"hello");
+
+        assert_eq!(
+            indexable_info,
+            vec![IndexableLeafInfo {
+                address: "0a01ff".into(),
+                leaf_id: leaves[0].id
+            }]
+        );
+
+        let nodes = merkle_radix_tree_node::table.get_results::<MerkleRadixTreeNode>(&conn)?;
+
+        assert_eq!(
+            nodes,
+            vec![
+                MerkleRadixTreeNode {
+                    hash: "state-root".into(),
+                    leaf_id: None,
+                    children: single_child(10, "first-node-hash"),
+                },
+                MerkleRadixTreeNode {
+                    hash: "first-node-hash".into(),
+                    leaf_id: None,
+                    children: single_child(1, "second-node-hash"),
+                },
+                MerkleRadixTreeNode {
+                    hash: "second-node-hash".into(),
+                    leaf_id: None,
+                    children: single_child(255, "leaf-node-hash"),
+                },
+                MerkleRadixTreeNode {
+                    hash: "leaf-node-hash".into(),
+                    leaf_id: Some(leaves[0].id),
+                    children: Children(vec![None; 256])
+                },
+            ]
+        );
+
+        Ok(())
+    }
+
+    fn single_child(pos: usize, hash: &str) -> Children {
+        let mut children = vec![None; 256];
+
+        children[pos] = Some(hash.into());
+
+        Children(children)
+    }
+
+    fn single_child_btree(addr_part: &str, hash: &str) -> BTreeMap<String, String> {
+        let mut children = BTreeMap::new();
+        children.insert(addr_part.to_string(), hash.to_string());
+        children
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/list_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/list_leaves.rs
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+
+use crate::state::merkle::sql::schema::{
+    merkle_radix_leaf, merkle_radix_state_root, merkle_radix_state_root_leaf_index,
+};
+
+use super::MerkleRadixOperations;
+
+pub trait MerkleRadixListLeavesOperation {
+    fn list_leaves(
+        &self,
+        state_root_hash: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
+}
+
+impl<'a, C> MerkleRadixListLeavesOperation for MerkleRadixOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+    Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Blob, C::Backend>,
+{
+    fn list_leaves(
+        &self,
+        state_root_hash: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
+        self.conn
+            .transaction::<_, diesel::result::Error, _>(|| {
+                let state_root_id = merkle_radix_state_root::table
+                    .filter(merkle_radix_state_root::state_root.eq(state_root_hash))
+                    .select(merkle_radix_state_root::id)
+                    .get_result::<i64>(self.conn)?;
+
+                let mut query = merkle_radix_leaf::table
+                    .inner_join(merkle_radix_state_root_leaf_index::table)
+                    .filter(
+                        merkle_radix_state_root_leaf_index::from_state_root_id
+                            .le(state_root_id)
+                            .and(
+                                merkle_radix_state_root_leaf_index::to_state_root_id
+                                    .is_null()
+                                    .or(merkle_radix_state_root_leaf_index::to_state_root_id
+                                        .gt(state_root_id)),
+                            ),
+                    )
+                    .select((
+                        merkle_radix_leaf::id,
+                        merkle_radix_leaf::address,
+                        merkle_radix_leaf::data,
+                        merkle_radix_state_root_leaf_index::to_state_root_id,
+                    ))
+                    .into_boxed();
+
+                if let Some(prefix) = prefix {
+                    query = query.filter(merkle_radix_leaf::address.like(format!("{}%", prefix)));
+                }
+
+                query = query
+                    .order(merkle_radix_leaf::address.asc())
+                    .then_order_by(merkle_radix_state_root_leaf_index::to_state_root_id.desc());
+
+                let leaves = query
+                    .get_results::<(i64, String, Vec<u8>, Option<i64>)>(self.conn)?
+                    .into_iter()
+                    .map(|(_, addr, data, _)| (addr, data))
+                    .collect();
+
+                Ok(leaves)
+            })
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use diesel::dsl::insert_into;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::MerkleRadixLeaf;
+    use crate::state::merkle::sql::operations::update_index::{
+        ChangedLeaf, MerkleRadixUpdateIndexOperation,
+    };
+
+    /// This tests that a leaf changed across several state root hashes is included in the list
+    /// at the given state root hash. It verifies that:
+    /// 1. No leaves are returned for the initial state root hash
+    /// 2. The first leaf change is returned for first state root.
+    /// 3. The second leaf change is returned for the second state root.
+    #[test]
+    fn test_list_leaves_at_state_root() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        // insert the initial root:
+        insert_into(merkle_radix_state_root::table)
+            .values((
+                merkle_radix_state_root::state_root.eq("initial-state-root"),
+                merkle_radix_state_root::parent_state_root.eq(""),
+            ))
+            .execute(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        operations.update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        // insert the changed leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 2,
+                address: "aabbcc".into(),
+                data: b"goodbye".to_vec(),
+            })
+            .execute(&conn)?;
+
+        operations.update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 2,
+            }],
+        )?;
+
+        let leaves = operations.list_leaves("initial-state-root", None)?;
+        assert!(leaves.is_empty());
+
+        let leaves = operations.list_leaves("first-state-root", None)?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        let leaves = operations.list_leaves("second-state-root", None)?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"goodbye");
+
+        Ok(())
+    }
+
+    /// This tests that a leaf inserted then deleted across several state root hashes is included
+    /// in the list only on the state root hash where it exists.  It verifies that:
+    /// 1. No leaves are returned for the initial state root hash
+    /// 2. The leaf is returned for first state root.
+    /// 3. The leaf is no longer returned for the second state root.
+    #[test]
+    fn test_list_leaves_with_deletion() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        // insert the initial root:
+        insert_into(merkle_radix_state_root::table)
+            .values((
+                merkle_radix_state_root::state_root.eq("initial-state-root"),
+                merkle_radix_state_root::parent_state_root.eq(""),
+            ))
+            .execute(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        operations.update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        // insert the changed leaf
+        operations.update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::Deleted("aabbcc")],
+        )?;
+
+        let leaves = operations.list_leaves("initial-state-root", None)?;
+        assert!(leaves.is_empty());
+
+        let leaves = operations.list_leaves("first-state-root", None)?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        let leaves = operations.list_leaves("second-state-root", None)?;
+        assert!(leaves.is_empty());
+
+        Ok(())
+    }
+
+    /// This tests that several leaves, added against successive state root hashes.
+    /// 1. Add a leaf and nodes to the tree at state root 1
+    /// 2. Add a second leaf and nodes to the tree at state root 2
+    /// 3. Verify that only the first leaf is returned with state root 1
+    /// 4. Verify that both leaves are returned with state root 2
+    /// 5. Verify that only one of the leaves is included in the list when a subtree is specified
+    #[test]
+    fn test_list_leaves_at_state_root_larger_tree() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        // insert the initial root:
+        insert_into(merkle_radix_state_root::table)
+            .values((
+                merkle_radix_state_root::state_root.eq("initial-state-root"),
+                merkle_radix_state_root::parent_state_root.eq(""),
+            ))
+            .execute(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        operations.update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        // insert a new leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 2,
+                address: "112233".into(),
+                data: b"goodbye".to_vec(),
+            })
+            .execute(&conn)?;
+
+        operations.update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "112233",
+                leaf_id: 2,
+            }],
+        )?;
+
+        let leaves = operations.list_leaves("initial-state-root", None)?;
+        assert!(leaves.is_empty());
+
+        let leaves = operations.list_leaves("first-state-root", None)?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        let leaves = operations.list_leaves("second-state-root", None)?;
+        assert_eq!(leaves.len(), 2);
+        assert_eq!(leaves[0].0, "112233");
+        assert_eq!(leaves[0].1, b"goodbye");
+        assert_eq!(leaves[1].0, "aabbcc");
+        assert_eq!(leaves[1].1, b"hello");
+
+        // Test with a prefix
+        let leaves = operations.list_leaves("second-state-root", Some("aa"))?;
+        assert_eq!(leaves.len(), 1);
+        assert_eq!(leaves[0].0, "aabbcc");
+        assert_eq!(leaves[0].1, b"hello");
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -15,6 +15,13 @@
  * -----------------------------------------------------------------------------
  */
 
+#[cfg(feature = "sqlite")]
+no_arg_sql_function!(
+    last_insert_rowid,
+    diesel::sql_types::BigInt,
+    "Represents the SQLite last_insert_rowid() function"
+);
+
 pub struct MerkleRadixOperations<'a, C>
 where
     C: diesel::Connection,

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -15,7 +15,19 @@
  * -----------------------------------------------------------------------------
  */
 
-mod migration;
-mod models;
-mod operations;
-mod schema;
+pub struct MerkleRadixOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    conn: &'a C,
+}
+
+impl<'a, C> MerkleRadixOperations<'a, C>
+where
+    C: diesel::Connection,
+{
+    #[allow(dead_code)]
+    pub fn new(conn: &'a C) -> Self {
+        MerkleRadixOperations { conn }
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -17,6 +17,7 @@
 
 pub(super) mod get_leaves;
 pub(super) mod get_path;
+pub(super) mod has_root;
 pub(super) mod insert_nodes;
 pub(super) mod list_leaves;
 pub(super) mod update_index;

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub(super) mod get_leaves;
+pub(super) mod get_path;
 pub(super) mod insert_nodes;
 pub(super) mod list_leaves;
 pub(super) mod update_index;

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub(super) mod get_leaves;
+pub(super) mod list_leaves;
 pub(super) mod update_index;
 
 #[cfg(feature = "sqlite")]

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -15,6 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
+pub(super) mod get_leaves;
 pub(super) mod update_index;
 
 #[cfg(feature = "sqlite")]

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -16,6 +16,7 @@
  */
 
 pub(super) mod get_leaves;
+pub(super) mod insert_nodes;
 pub(super) mod list_leaves;
 pub(super) mod update_index;
 

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -15,6 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+pub(super) mod update_index;
+
 #[cfg(feature = "sqlite")]
 no_arg_sql_function!(
     last_insert_rowid,

--- a/libtransact/src/state/merkle/sql/operations/update_index.rs
+++ b/libtransact/src/state/merkle/sql/operations/update_index.rs
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::dsl::{delete, insert_into, select, update};
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::models::{MerkleRadixStateRoot, NewMerkleRadixStateRoot};
+use crate::state::merkle::sql::schema::{
+    merkle_radix_leaf, merkle_radix_state_root, merkle_radix_state_root_leaf_index,
+};
+
+#[cfg(feature = "sqlite")]
+use super::last_insert_rowid;
+use super::MerkleRadixOperations;
+
+pub enum ChangedLeaf<'data> {
+    #[allow(dead_code)]
+    AddedOrUpdated { address: &'data str, leaf_id: i64 },
+    #[allow(dead_code)]
+    Deleted(&'data str),
+}
+
+impl<'data> ChangedLeaf<'data> {
+    fn address(&self) -> &'data str {
+        match self {
+            ChangedLeaf::AddedOrUpdated { address, .. } => address,
+            ChangedLeaf::Deleted(addr) => addr,
+        }
+    }
+}
+
+pub trait MerkleRadixUpdateIndexOperation {
+    fn update_index(
+        &self,
+        state_root: &str,
+        parent_state_root: &str,
+        changed_addresses: Vec<ChangedLeaf>,
+    ) -> Result<(), InternalError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> MerkleRadixUpdateIndexOperation for MerkleRadixOperations<'a, SqliteConnection> {
+    fn update_index(
+        &self,
+        state_root: &str,
+        parent_state_root: &str,
+        changed_addresses: Vec<ChangedLeaf>,
+    ) -> Result<(), InternalError> {
+        self.conn
+            .transaction::<_, diesel::result::Error, _>(|| {
+                let fork = merkle_radix_state_root::table
+                    .filter(merkle_radix_state_root::parent_state_root.eq(parent_state_root))
+                    .first::<MerkleRadixStateRoot>(self.conn)
+                    .optional()?;
+
+                if let Some(fork_state_root_id) = fork.map(|state_root| state_root.id) {
+                    let null_id: Option<i64> = None;
+                    // remove the fork changes from the index
+                    update(merkle_radix_state_root_leaf_index::table.filter(
+                        merkle_radix_state_root_leaf_index::to_state_root_id.ge(fork_state_root_id),
+                    ))
+                    .set(merkle_radix_state_root_leaf_index::to_state_root_id.eq(null_id))
+                    .execute(self.conn)?;
+
+                    delete(
+                        merkle_radix_state_root_leaf_index::table.filter(
+                            merkle_radix_state_root_leaf_index::from_state_root_id
+                                .eq(fork_state_root_id),
+                        ),
+                    )
+                    .execute(self.conn)?;
+
+                    delete(merkle_radix_state_root::table.find(fork_state_root_id))
+                        .execute(self.conn)?;
+                }
+
+                insert_into(merkle_radix_state_root::table)
+                    .values(NewMerkleRadixStateRoot {
+                        state_root,
+                        parent_state_root,
+                    })
+                    .execute(self.conn)?;
+
+                let state_root_id = select(last_insert_rowid).get_result::<i64>(self.conn)?;
+
+                for change in changed_addresses.iter() {
+                    update(
+                        merkle_radix_state_root_leaf_index::table.filter(
+                            merkle_radix_state_root_leaf_index::to_state_root_id
+                                .is_null()
+                                .and(
+                                    merkle_radix_state_root_leaf_index::leaf_id.eq_any(
+                                        merkle_radix_leaf::table
+                                            .select(merkle_radix_leaf::id)
+                                            .filter(
+                                                merkle_radix_leaf::address.eq(change.address()),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                    )
+                    .set(merkle_radix_state_root_leaf_index::to_state_root_id.eq(state_root_id))
+                    .execute(self.conn)?;
+                }
+
+                // insert index records for all added or updated leaves.
+                insert_into(merkle_radix_state_root_leaf_index::table)
+                    .values(
+                        changed_addresses
+                            .iter()
+                            .filter(|change| matches!(change, ChangedLeaf::AddedOrUpdated { .. }))
+                            .map(|change| match change {
+                                ChangedLeaf::AddedOrUpdated { leaf_id, .. } => (
+                                    merkle_radix_state_root_leaf_index::leaf_id.eq(leaf_id),
+                                    merkle_radix_state_root_leaf_index::from_state_root_id
+                                        .eq(state_root_id),
+                                ),
+                                // we filtered only on AddedOrUpdated, so everything else is
+                                // unreachable.
+                                _ => unreachable!(),
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .execute(self.conn)?;
+
+                Ok(())
+            })
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+#[cfg(test)]
+mod sqlite_tests {
+    use super::*;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::{MerkleRadixLeaf, MerkleRadixStateRootLeafIndexEntry};
+    use crate::state::merkle::sql::schema::merkle_radix_leaf;
+
+    /// This test indexes a leaf and its tree nodes into the index as in an initial entry into the
+    /// merkle tree.  That is, there was no prior entry at that address. It
+    /// 1. Verifies that the new state root hash specified is inserted into the state root table
+    /// 2. Verifies that the leaf-state-root relationship is added to the index, with a null
+    ///    to_state_root_id
+    #[test]
+    fn test_update_index_initial_change() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        // insert the leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        MerkleRadixOperations::new(&conn).update_index(
+            "new-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+
+        let state_root_ord = merkle_radix_state_root::table
+            .filter(merkle_radix_state_root::state_root.eq("new-state-root"))
+            .first::<MerkleRadixStateRoot>(&conn)?;
+
+        assert_eq!("initial-state-root", &state_root_ord.parent_state_root);
+
+        let leaves = merkle_radix_state_root_leaf_index::table
+            .filter(merkle_radix_state_root_leaf_index::leaf_id.eq(1))
+            .get_results::<MerkleRadixStateRootLeafIndexEntry>(&conn)?;
+
+        assert_eq!(leaves.len(), 1);
+
+        assert_eq!(leaves[0].leaf_id, 1);
+        assert_eq!(leaves[0].from_state_root_id, state_root_ord.id);
+        assert_eq!(leaves[0].to_state_root_id, None);
+
+        Ok(())
+    }
+
+    /// This test indexes an initial leaf and set of nodes, then updates the leaf at the same
+    /// address.  It verifies that
+    /// 1. Both state roots are in the state root table, with the correct parents
+    /// 2. Verifies that the index contains two entries for the leaf, one that is valid only for
+    ///    the first state root, and one that is valid for the current root, with a null
+    ///    to_state_root_id (i.e. has not been changed yet).
+    #[test]
+    fn test_update_index_single_change() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        MerkleRadixOperations::new(&conn).update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+        let first_state_root_ord = merkle_radix_state_root::table
+            .filter(merkle_radix_state_root::state_root.eq("first-state-root"))
+            .first::<MerkleRadixStateRoot>(&conn)?;
+
+        // insert the changed leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 2,
+                address: "aabbcc".into(),
+                data: b"goodbye".to_vec(),
+            })
+            .execute(&conn)?;
+
+        MerkleRadixOperations::new(&conn).update_index(
+            "second-state-root",
+            "first-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 2,
+            }],
+        )?;
+
+        let second_state_root_ord = merkle_radix_state_root::table
+            .filter(merkle_radix_state_root::state_root.eq("second-state-root"))
+            .first::<MerkleRadixStateRoot>(&conn)?;
+
+        assert_eq!(second_state_root_ord.parent_state_root, "first-state-root");
+
+        let leaves = merkle_radix_state_root_leaf_index::table
+            .filter(
+                merkle_radix_state_root_leaf_index::leaf_id.eq_any(
+                    merkle_radix_leaf::table
+                        .select(merkle_radix_leaf::id)
+                        .filter(merkle_radix_leaf::address.eq("aabbcc")),
+                ),
+            )
+            .get_results::<MerkleRadixStateRootLeafIndexEntry>(&conn)?;
+
+        assert_eq!(leaves.len(), 2);
+
+        assert_eq!(leaves[0].leaf_id, 1);
+        assert_eq!(leaves[0].from_state_root_id, first_state_root_ord.id);
+        assert_eq!(leaves[0].to_state_root_id, Some(second_state_root_ord.id));
+
+        assert_eq!(leaves[1].leaf_id, 2);
+        assert_eq!(leaves[1].from_state_root_id, second_state_root_ord.id);
+        assert_eq!(leaves[1].to_state_root_id, None);
+
+        Ok(())
+    }
+
+    /// This test indexes a leaf starting from the initial root, then indexes a second value at
+    /// that address starting also starting from the initial root.  It will treat this as a fork in
+    /// the tree's history, and remove the old branch in favor of the new one.  It should
+    /// 1. Verify that the state root table only has one entry where the parent hash is the initial
+    ///    state root hash.
+    /// 2. Verify that there is only one index entry for the leaf with the second state root hash
+    ///    as its from_state_root_id and null for its to_state_root_id
+    #[test]
+    fn test_update_index_single_change_fork() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        run_migrations(&conn)?;
+
+        // insert the initial leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 1,
+                address: "aabbcc".into(),
+                data: b"hello".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index
+        MerkleRadixOperations::new(&conn).update_index(
+            "first-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 1,
+            }],
+        )?;
+        let _first_state_root_ord = merkle_radix_state_root::table
+            .filter(merkle_radix_state_root::state_root.eq("first-state-root"))
+            .first::<MerkleRadixStateRoot>(&conn)?;
+
+        // insert the changed leaf
+        insert_into(merkle_radix_leaf::table)
+            .values(MerkleRadixLeaf {
+                id: 2,
+                address: "aabbcc".into(),
+                data: b"goodbye".to_vec(),
+            })
+            .execute(&conn)?;
+
+        // update the index as if it's transition from the initial state root again (i.e.
+        // a new forked tree)
+        MerkleRadixOperations::new(&conn).update_index(
+            "second-state-root",
+            "initial-state-root",
+            vec![ChangedLeaf::AddedOrUpdated {
+                address: "aabbcc",
+                leaf_id: 2,
+            }],
+        )?;
+
+        let second_state_root_ord = merkle_radix_state_root::table
+            .filter(merkle_radix_state_root::state_root.eq("second-state-root"))
+            .first::<MerkleRadixStateRoot>(&conn)?;
+
+        assert_eq!(
+            second_state_root_ord.parent_state_root,
+            "initial-state-root"
+        );
+
+        let leaves = merkle_radix_state_root_leaf_index::table
+            .filter(
+                merkle_radix_state_root_leaf_index::leaf_id.eq_any(
+                    merkle_radix_leaf::table
+                        .select(merkle_radix_leaf::id)
+                        .filter(merkle_radix_leaf::address.eq("aabbcc")),
+                ),
+            )
+            .get_results::<MerkleRadixStateRootLeafIndexEntry>(&conn)?;
+
+        assert_eq!(leaves.len(), 1);
+
+        assert_eq!(leaves[0].leaf_id, 2);
+        assert_eq!(leaves[0].from_state_root_id, second_state_root_ord.id);
+        assert_eq!(leaves[0].to_state_root_id, None);
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/schema.rs
+++ b/libtransact/src/state/merkle/sql/schema.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+// Due to schema differences, this may have to be under a submodule specific to sqlite or postgres
+// (or other array-supporting dbs). This may only be the case with the merkle_radix_leaf table.
+
+table! {
+    merkle_radix_leaf (id) {
+        id -> Int8,
+        address -> VarChar,
+        data -> Blob,
+    }
+}
+
+table! {
+    merkle_radix_tree_node (hash) {
+        hash -> VarChar,
+        leaf_id -> Nullable<Int8>,
+        // JSON children
+        children -> Text,
+    }
+}
+
+table! {
+    merkle_radix_state_root (id) {
+        id -> Int8,
+        state_root -> VarChar,
+        parent_state_root -> VarChar,
+    }
+}
+
+table! {
+    merkle_radix_state_root_leaf_index (id) {
+        id -> Int8,
+        leaf_id -> Int8,
+        from_state_root_id -> Int8,
+        to_state_root_id -> Nullable<Int8>,
+    }
+}
+
+joinable!(merkle_radix_state_root_leaf_index -> merkle_radix_leaf (leaf_id));
+
+allow_tables_to_appear_in_same_query!(
+    merkle_radix_leaf,
+    merkle_radix_tree_node,
+    merkle_radix_state_root,
+    merkle_radix_state_root_leaf_index,
+);


### PR DESCRIPTION
This PR adds a set of operations that will support the SQL-backed merkle radix state implementation.  

A future PR will implement the radix tree over a sqlite db using these operations.