### PR TITLE
Update semver dep from 0.9 to 0.11

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -45,7 +45,7 @@ rand_hc = { version = "0.1", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
 rusqlite = { version = "0.22", optional = true }
 sawtooth-sdk = { version = "0.5", optional = true }
-semver = { version = "0.9", optional = true }
+semver = { version = "1.0", optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8", optional = true }


### PR DESCRIPTION
The VersionReq object in 0.11 can parse more complex requirements, like
specifiying different version ranges. This will improve the robustness
of the find_scar function, and allow us to describe both minor version ranges
and pre-release version ranges.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>