### PR TITLE
Generic Merkle State Tests

### DIFF
--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -71,11 +71,8 @@ impl Write for MerkleState {
         state_id: &Self::StateId,
         state_changes: &[StateChange],
     ) -> Result<Self::StateId, StateWriteError> {
-        let mut merkle_tree = MerkleRadixTree::new(self.db.clone(), Some(state_id))
-            .map_err(|err| StateWriteError::StorageError(Box::new(err)))?;
-        merkle_tree
-            .set_merkle_root(state_id.to_string())
-            .map_err(|err| match err {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
                 StateDatabaseError::NotFound(msg) => StateWriteError::InvalidStateId(msg),
                 _ => StateWriteError::StorageError(Box::new(err)),
             })?;
@@ -89,15 +86,12 @@ impl Write for MerkleState {
         state_id: &Self::StateId,
         state_changes: &[StateChange],
     ) -> Result<Self::StateId, StateWriteError> {
-        let mut merkle_tree = MerkleRadixTree::new(self.db.clone(), Some(state_id))
-            .map_err(|err| StateWriteError::StorageError(Box::new(err)))?;
-
-        merkle_tree
-            .set_merkle_root(state_id.to_string())
-            .map_err(|err| match err {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
                 StateDatabaseError::NotFound(msg) => StateWriteError::InvalidStateId(msg),
                 _ => StateWriteError::StorageError(Box::new(err)),
             })?;
+
         merkle_tree
             .update(state_changes, true)
             .map_err(|err| StateWriteError::StorageError(Box::new(err)))
@@ -114,15 +108,12 @@ impl Read for MerkleState {
         state_id: &Self::StateId,
         keys: &[Self::Key],
     ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
-        let mut merkle_tree = MerkleRadixTree::new(self.db.clone(), Some(state_id))
-            .map_err(|err| StateReadError::StorageError(Box::new(err)))?;
-
-        merkle_tree
-            .set_merkle_root(state_id.to_string())
-            .map_err(|err| match err {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
                 StateDatabaseError::NotFound(msg) => StateReadError::InvalidStateId(msg),
                 _ => StateReadError::StorageError(Box::new(err)),
             })?;
+
         keys.iter().try_fold(HashMap::new(), |mut result, key| {
             let value = match merkle_tree.get_by_address(key) {
                 Ok(value) => Ok(value.value),
@@ -159,14 +150,8 @@ impl MerkleRadixLeafReader for MerkleState {
         state_id: &Self::StateId,
         subtree: Option<&str>,
     ) -> IterResult<LeafIter<(Self::Key, Self::Value)>> {
-        let mut merkle_tree =
-            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| {
-                MerkleRadixLeafReadError::InternalError(InternalError::from_source(Box::new(err)))
-            })?;
-
-        merkle_tree
-            .set_merkle_root(state_id.to_string())
-            .map_err(|err| match err {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
                 StateDatabaseError::NotFound(msg) => MerkleRadixLeafReadError::InvalidStateError(
                     InvalidStateError::with_message(msg),
                 ),

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -53,6 +53,15 @@ impl Clone for StateChange {
     }
 }
 
+impl StateChange {
+    pub fn key(&self) -> &str {
+        match self {
+            StateChange::Set { key, .. } => &key,
+            StateChange::Delete { key } => &key,
+        }
+    }
+}
+
 /// `state::Write` provides a way to write to a particular state storage system.
 ///
 /// It provides the ability for the caller to either compute the next `StateId` -

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -18,30 +18,29 @@ use std::str::from_utf8;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 
+#[cfg(feature = "state-merkle-leaf-reader")]
+use transact::state::merkle::MerkleRadixLeafReader;
 use transact::{
     database::{error::DatabaseError, Database},
     protos::merkle::ChangeLogEntry,
     state::{
         merkle::{MerkleRadixTree, MerkleState, CHANGE_LOG_INDEX},
-        Prune, StateChange, Write,
+        Prune, Read, StateChange, StateReadError, Write,
     },
 };
 
-/// 1. Layer a MerkleRadixTree over the given database
-/// 2. Compute the state root hash for an empty change list to the original root
-/// 3. Validate the computed root is the same as the original root
-fn test_merkle_trie_empty_changes(db: Box<dyn Database>) {
-    let merkle_state = MerkleState::new(db.clone());
-    let merkle_db = MerkleRadixTree::new(db.clone(), None)
-        .expect("Could not overlay the merkle tree on the database");
-
-    let orig_root = merkle_db.get_merkle_root();
-
+/// 1. Compute the state root hash for an empty change list to the original root
+/// 2. Validate the computed root is the same as the original root
+fn test_merkle_trie_empty_changes<M>(initial_state_root: String, merkle_state: M)
+where
+    M: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+{
     let new_state_id = merkle_state
-        .compute_state_id(&orig_root, &[])
+        .compute_state_id(&initial_state_root, &[])
         .expect("Did not supply a state id");
 
-    assert_eq!(orig_root, new_state_id);
+    assert_eq!(initial_state_root, new_state_id);
 }
 
 /// 1. Layer a MerkleRadixTree over the given database
@@ -103,20 +102,20 @@ fn test_merkle_trie_root_advance(db: Box<dyn Database>) {
 /// 4. Commit a Delete state change against the previous state root
 /// 5. Check that the value still exists under the previous state root
 /// 6. Set the merkle root to the committed root and validate that the value has been deleted
-fn test_merkle_trie_delete(db: Box<dyn Database>) {
-    let merkle_state = MerkleState::new(db.clone());
-    let mut merkle_db = MerkleRadixTree::new(db.clone(), None).unwrap();
-
+fn test_merkle_trie_delete<M>(initial_state_root: String, merkle_state: M)
+where
+    M: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+{
     let state_change_set = StateChange::Set {
         key: "1234".to_string(),
         value: "deletable".as_bytes().to_vec(),
     };
 
     let new_root = merkle_state
-        .commit(&merkle_db.get_merkle_root(), &[state_change_set])
+        .commit(&initial_state_root, &[state_change_set])
         .unwrap();
-    merkle_db.set_merkle_root(new_root.clone()).unwrap();
-    assert_value_at_address(&merkle_db, "1234", "deletable");
+    assert_read_value_at_address(&merkle_state, &new_root, "1234", Some("deletable"));
 
     let state_change_del_1 = StateChange::Delete {
         key: "barf".to_string(),
@@ -135,18 +134,15 @@ fn test_merkle_trie_delete(db: Box<dyn Database>) {
         .commit(&new_root, &[state_change_del_2])
         .unwrap();
 
-    // del_root hasn't been set yet, so address should still have value
-    assert_value_at_address(&merkle_db, "1234", "deletable");
-    merkle_db.set_merkle_root(del_root).unwrap();
-    assert!(!merkle_db.contains("1234").unwrap());
+    assert_read_value_at_address(&merkle_state, &new_root, "1234", Some("deletable"));
+    assert_read_value_at_address(&merkle_state, &del_root, "1234", None);
 }
 
-fn test_merkle_trie_update(db: Box<dyn Database>) {
-    let merkle_state = MerkleState::new(db.clone());
-    let mut merkle_db = MerkleRadixTree::new(db.clone(), None).unwrap();
-
-    let init_root = merkle_db.get_merkle_root();
-
+fn test_merkle_trie_update<M>(initial_state_root: String, merkle_state: M)
+where
+    M: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+{
     let key_hashes = (0..1000)
         .map(|i| {
             let key = format!("{:016x}", i);
@@ -156,7 +152,7 @@ fn test_merkle_trie_update(db: Box<dyn Database>) {
         .collect::<Vec<_>>();
 
     let mut values = HashMap::new();
-    let mut new_root = init_root.clone();
+    let mut new_root = initial_state_root.clone();
     for &(ref key, ref hashed) in key_hashes.iter() {
         let state_change_set = StateChange::Set {
             key: hashed.to_string(),
@@ -165,9 +161,6 @@ fn test_merkle_trie_update(db: Box<dyn Database>) {
         new_root = merkle_state.commit(&new_root, &[state_change_set]).unwrap();
         values.insert(hashed.clone(), key.to_string());
     }
-
-    merkle_db.set_merkle_root(new_root.clone()).unwrap();
-    assert_ne!(init_root, merkle_db.get_merkle_root());
 
     let mut rng = thread_rng();
     let mut state_changes = vec![];
@@ -192,32 +185,29 @@ fn test_merkle_trie_update(db: Box<dyn Database>) {
     state_changes.extend_from_slice(&delete_items);
 
     let virtual_root = merkle_state
-        .compute_state_id(&merkle_db.get_merkle_root(), &state_changes)
+        .compute_state_id(&new_root, &state_changes)
         .unwrap();
 
     // virtual root shouldn't match actual contents of tree
-    assert!(merkle_db.set_merkle_root(virtual_root.clone()).is_err());
+    let res = merkle_state.get(&virtual_root, &[state_changes[0].key().to_string()]);
+    assert!(
+        matches!(res, Err(StateReadError::InvalidStateId(_))),
+        "expected {:?} but was {:?}",
+        StateReadError::InvalidStateId(virtual_root.clone()),
+        res
+    );
 
-    let actual_root = merkle_state
-        .commit(&merkle_db.get_merkle_root(), &state_changes)
-        .unwrap();
+    let actual_root = merkle_state.commit(&new_root, &state_changes).unwrap();
+
     // the virtual root should be the same as the actual root
     assert_eq!(virtual_root, actual_root);
-    assert_ne!(actual_root, merkle_db.get_merkle_root());
-
-    merkle_db.set_merkle_root(actual_root).unwrap();
 
     for (address, value) in values {
-        assert_value_at_address(&merkle_db, &address, &value);
+        assert_read_value_at_address(&merkle_state, &actual_root, &address, Some(&value));
     }
 
     for delete_change in delete_items {
-        match delete_change {
-            StateChange::Delete { key } => {
-                assert!(merkle_db.get_value(&key.clone()).unwrap().is_none());
-            }
-            _ => (),
-        }
+        assert_read_value_at_address(&merkle_state, &actual_root, delete_change.key(), None);
     }
 }
 
@@ -228,11 +218,11 @@ fn test_merkle_trie_update(db: Box<dyn Database>) {
 ///
 /// A Merkle trie is created with some initial values which is then updated
 /// (set & delete).
-fn test_merkle_trie_update_same_address_space(db: Box<dyn Database>) {
-    let merkle_state = MerkleState::new(db.clone());
-    let mut merkle_db = MerkleRadixTree::new(db.clone(), None).unwrap();
-
-    let init_root = merkle_db.get_merkle_root();
+fn test_merkle_trie_update_same_address_space<M>(initial_state_root: String, merkle_state: M)
+where
+    M: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+{
     let key_hashes = vec![
         // matching prefix e55420
         (
@@ -262,7 +252,7 @@ fn test_merkle_trie_update_same_address_space(db: Box<dyn Database>) {
         ),
     ];
     let mut values = HashMap::new();
-    let mut new_root = init_root.clone();
+    let mut new_root = initial_state_root.clone();
     for &(ref key, ref hashed) in key_hashes.iter() {
         let state_change_set = StateChange::Set {
             key: hashed.to_string(),
@@ -272,8 +262,7 @@ fn test_merkle_trie_update_same_address_space(db: Box<dyn Database>) {
         values.insert(hashed.to_string(), key.to_string());
     }
 
-    merkle_db.set_merkle_root(new_root.clone()).unwrap();
-    assert_ne!(init_root, merkle_db.get_merkle_root());
+    assert_ne!(initial_state_root, new_root);
     let mut state_changes = vec![];
     // Perform some updates on the lower keys
     for &(_, ref key_hash) in key_hashes.iter() {
@@ -316,24 +305,24 @@ fn test_merkle_trie_update_same_address_space(db: Box<dyn Database>) {
         .compute_state_id(&new_root, &state_changes)
         .unwrap();
     // virtual root shouldn't match actual contents of tree
-    assert!(merkle_db.set_merkle_root(virtual_root.clone()).is_err());
+    let res = merkle_state.get(&virtual_root, &[state_changes[0].key().to_string()]);
+    assert!(
+        matches!(res, Err(StateReadError::InvalidStateId(_))),
+        "expected {:?} but was {:?}",
+        StateReadError::InvalidStateId(virtual_root.clone()),
+        res
+    );
 
     let actual_root = merkle_state.commit(&new_root, &state_changes).unwrap();
     // the virtual root should be the same as the actual root
     assert_eq!(virtual_root, actual_root);
-    assert_ne!(actual_root, merkle_db.get_merkle_root());
-
-    merkle_db.set_merkle_root(actual_root).unwrap();
 
     for (address, value) in values {
-        assert_value_at_address(&merkle_db, &address, &value);
+        assert_read_value_at_address(&merkle_state, &actual_root, &address, Some(&value));
     }
 
     for delete_change in delete_items {
-        match delete_change {
-            StateChange::Delete { key } => assert!(merkle_db.get_value(&key).unwrap().is_none()),
-            _ => (),
-        }
+        assert_read_value_at_address(&merkle_state, &actual_root, delete_change.key(), None);
     }
 }
 
@@ -344,11 +333,13 @@ fn test_merkle_trie_update_same_address_space(db: Box<dyn Database>) {
 ///
 /// A Merkle trie is created with some initial values which is then updated
 /// (set & delete).
-fn test_merkle_trie_update_same_address_space_with_no_children(db: Box<dyn Database>) {
-    let merkle_state = MerkleState::new(db.clone());
-    let mut merkle_db = MerkleRadixTree::new(db.clone(), None).unwrap();
-
-    let init_root = merkle_db.get_merkle_root();
+fn test_merkle_trie_update_same_address_space_with_no_children<M>(
+    initial_state_root: String,
+    merkle_state: M,
+) where
+    M: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+{
     let key_hashes = vec![
         (
             "qwert",
@@ -373,7 +364,7 @@ fn test_merkle_trie_update_same_address_space_with_no_children(db: Box<dyn Datab
         ),
     ];
     let mut values = HashMap::new();
-    let mut new_root = init_root.clone();
+    let mut new_root = initial_state_root.clone();
     for &(ref key, ref hashed) in key_hashes.iter() {
         let state_change_set = StateChange::Set {
             key: hashed.to_string(),
@@ -383,8 +374,7 @@ fn test_merkle_trie_update_same_address_space_with_no_children(db: Box<dyn Datab
         values.insert(hashed.to_string(), key.to_string());
     }
 
-    merkle_db.set_merkle_root(new_root.clone()).unwrap();
-    assert_ne!(init_root, merkle_db.get_merkle_root());
+    assert_ne!(initial_state_root, new_root);
 
     // matching prefix e55420, however this will be newly added and not set already in trie
     let key_hash_to_be_inserted = vec![(
@@ -435,27 +425,25 @@ fn test_merkle_trie_update_same_address_space_with_no_children(db: Box<dyn Datab
         .unwrap();
 
     // virtual root shouldn't match actual contents of tree
-    assert!(merkle_db.set_merkle_root(virtual_root.clone()).is_err());
+    let res = merkle_state.get(&virtual_root, &[state_changes[0].key().to_string()]);
+    assert!(
+        matches!(res, Err(StateReadError::InvalidStateId(_))),
+        "expected {:?} but was {:?}",
+        StateReadError::InvalidStateId(virtual_root.clone()),
+        res
+    );
 
     let actual_root = merkle_state.commit(&new_root, &state_changes).unwrap();
 
     // the virtual root should be the same as the actual root
     assert_eq!(virtual_root, actual_root);
-    assert_ne!(actual_root, merkle_db.get_merkle_root());
-
-    merkle_db.set_merkle_root(actual_root).unwrap();
 
     for (address, value) in values {
-        assert_value_at_address(&merkle_db, &address, &value);
+        assert_read_value_at_address(&merkle_state, &actual_root, &address, Some(&value));
     }
 
     for delete_change in delete_items {
-        match delete_change {
-            StateChange::Delete { key } => {
-                assert!(merkle_db.get_value(&key).unwrap().is_none());
-            }
-            _ => (),
-        }
+        assert_read_value_at_address(&merkle_state, &actual_root, delete_change.key(), None);
     }
 }
 
@@ -780,11 +768,14 @@ fn test_merkle_trie_pruning_successor_duplicate_leaves(db: Box<dyn Database>) {
     assert_value_at_address(&merkle_db, "ab0000", "0001");
 }
 
+#[cfg(feature = "state-merkle-leaf-reader")]
 /// Test iteration over leaves.
-fn test_leaf_iteration(db: Box<dyn Database>) {
-    let mut merkle_db = MerkleRadixTree::new(db, None).unwrap();
+fn test_leaf_iteration<M>(initial_state_root: String, merkle_state: M)
+where
+    M: Write<StateId = String, Key = String, Value = Vec<u8>> + MerkleRadixLeafReader,
+{
     {
-        let mut leaf_iter = merkle_db.leaves(None).unwrap();
+        let mut leaf_iter = merkle_state.leaves(&initial_state_root, None).unwrap();
         assert!(
             leaf_iter.next().is_none(),
             "Empty tree should return no leaves"
@@ -792,19 +783,20 @@ fn test_leaf_iteration(db: Box<dyn Database>) {
     }
 
     let addresses = vec!["ab0000", "aba001", "abff02"];
+    let mut new_root = initial_state_root.clone();
     for (i, key) in addresses.iter().enumerate() {
         let state_change_set = StateChange::Set {
             key: key.to_string(),
             value: format!("{:04x}", i * 10).as_bytes().to_vec(),
         };
-        let new_root = merkle_db.update(&[state_change_set], false).unwrap();
-        merkle_db.set_merkle_root(new_root).unwrap();
+        new_root = merkle_state.commit(&new_root, &[state_change_set]).unwrap();
     }
-    assert_value_at_address(&merkle_db, "ab0000", "0000");
-    assert_value_at_address(&merkle_db, "aba001", "000a");
-    assert_value_at_address(&merkle_db, "abff02", "0014");
 
-    let mut leaf_iter = merkle_db.leaves(None).unwrap();
+    assert_read_value_at_address(&merkle_state, &new_root, "ab0000", Some("0000"));
+    assert_read_value_at_address(&merkle_state, &new_root, "aba001", Some("000a"));
+    assert_read_value_at_address(&merkle_state, &new_root, "abff02", Some("0014"));
+
+    let mut leaf_iter = merkle_state.leaves(&new_root, None).unwrap();
 
     assert_eq!(
         ("ab0000".into(), "0000".as_bytes().to_vec()),
@@ -821,7 +813,7 @@ fn test_leaf_iteration(db: Box<dyn Database>) {
     assert!(leaf_iter.next().is_none(), "Iterator should be Exhausted");
 
     // test that we can start from an prefix:
-    let mut leaf_iter = merkle_db.leaves(Some("abff")).unwrap();
+    let mut leaf_iter = merkle_state.leaves(&new_root, Some("abff")).unwrap();
     assert_eq!(
         ("abff02".into(), "0014".as_bytes().to_vec()),
         leaf_iter.next().unwrap().unwrap()
@@ -907,6 +899,28 @@ fn assert_value_at_address(merkle_db: &MerkleRadixTree, address: &str, expected_
     }
 }
 
+fn assert_read_value_at_address<R>(
+    merkle_read: &R,
+    root_hash: &str,
+    address: &str,
+    expected_value: Option<&str>,
+) where
+    R: Read<StateId = String, Key = String, Value = Vec<u8>>,
+{
+    let value = merkle_read
+        .get(&root_hash.to_string(), &[address.to_string()])
+        .and_then(|mut values| {
+            Ok(values
+                .remove(address)
+                .map(|value| String::from_utf8(value).expect("could not convert bytes to string")))
+        });
+
+    match value {
+        Ok(value) => assert_eq!(expected_value, value.as_deref()),
+        Err(err) => panic!("value at address {} produced an error: {}", address, err),
+    }
+}
+
 fn expect_change_log(db: &dyn Database, root_hash: &[u8]) -> ChangeLogEntry {
     let reader = db.get_reader().unwrap();
     protobuf::Message::parse_from_bytes(
@@ -952,10 +966,22 @@ mod btree {
 
     use super::*;
 
+    fn new_btree_state_and_root() -> (MerkleState, String) {
+        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
+        let merkle_state = MerkleState::new(btree_db.clone());
+
+        let merkle_db = MerkleRadixTree::new(btree_db, None)
+            .expect("Could not overlay the merkle tree on the database");
+
+        let orig_root = merkle_db.get_merkle_root();
+
+        (merkle_state, orig_root)
+    }
+
     #[test]
     fn merkle_trie_empty_changes() {
-        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
-        test_merkle_trie_empty_changes(btree_db);
+        let (state, orig_root) = new_btree_state_and_root();
+        test_merkle_trie_empty_changes(orig_root, state);
     }
 
     #[test]
@@ -966,26 +992,26 @@ mod btree {
 
     #[test]
     fn merkle_trie_delete() {
-        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
-        test_merkle_trie_delete(btree_db);
+        let (state, orig_root) = new_btree_state_and_root();
+        test_merkle_trie_delete(orig_root, state);
     }
 
     #[test]
     fn merkle_trie_update() {
-        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
-        test_merkle_trie_update(btree_db);
+        let (state, orig_root) = new_btree_state_and_root();
+        test_merkle_trie_update(orig_root, state);
     }
 
     #[test]
     fn merkle_trie_update_same_address_space() {
-        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
-        test_merkle_trie_update_same_address_space(btree_db);
+        let (state, orig_root) = new_btree_state_and_root();
+        test_merkle_trie_update_same_address_space(orig_root, state);
     }
 
     #[test]
     fn merkle_trie_update_same_address_space_with_no_children() {
-        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
-        test_merkle_trie_update_same_address_space_with_no_children(btree_db);
+        let (state, orig_root) = new_btree_state_and_root();
+        test_merkle_trie_update_same_address_space_with_no_children(orig_root, state);
     }
 
     #[test]
@@ -1012,10 +1038,11 @@ mod btree {
         test_merkle_trie_pruning_successor_duplicate_leaves(btree_db);
     }
 
+    #[cfg(feature = "state-merkle-leaf-reader")]
     #[test]
     fn leaf_iteration() {
-        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
-        test_leaf_iteration(btree_db);
+        let (state, orig_root) = new_btree_state_and_root();
+        test_leaf_iteration(orig_root, state);
     }
 }
 
@@ -1039,11 +1066,23 @@ mod lmdb {
 
     use super::*;
 
+    fn new_lmdb_state_and_root(lmdb_path: &str) -> (MerkleState, String) {
+        let lmdb_db = make_lmdb(lmdb_path);
+        let merkle_state = MerkleState::new(lmdb_db.clone());
+
+        let merkle_db = MerkleRadixTree::new(lmdb_db, None)
+            .expect("Could not overlay the merkle tree on the database");
+
+        let orig_root = merkle_db.get_merkle_root();
+
+        (merkle_state, orig_root)
+    }
+
     #[test]
     fn merkle_trie_empty_changes() {
         run_test(|merkle_path| {
-            let db = make_lmdb(&merkle_path);
-            test_merkle_trie_empty_changes(db);
+            let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+            test_merkle_trie_empty_changes(orig_root, state);
         })
     }
 
@@ -1058,32 +1097,32 @@ mod lmdb {
     #[test]
     fn merkle_trie_delete() {
         run_test(|merkle_path| {
-            let db = make_lmdb(&merkle_path);
-            test_merkle_trie_delete(db);
+            let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+            test_merkle_trie_delete(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update_multiple_entries() {
         run_test(|merkle_path| {
-            let db = make_lmdb(&merkle_path);
-            test_merkle_trie_update(db);
+            let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+            test_merkle_trie_update(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update_same_address_space() {
         run_test(|merkle_path| {
-            let db = make_lmdb(&merkle_path);
-            test_merkle_trie_update_same_address_space(db);
+            let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+            test_merkle_trie_update_same_address_space(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update_same_address_space_with_no_children() {
         run_test(|merkle_path| {
-            let db = make_lmdb(&merkle_path);
-            test_merkle_trie_update_same_address_space_with_no_children(db);
+            let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+            test_merkle_trie_update_same_address_space_with_no_children(orig_root, state);
         })
     }
 
@@ -1119,11 +1158,12 @@ mod lmdb {
         })
     }
 
+    #[cfg(feature = "state-merkle-leaf-reader")]
     #[test]
     fn leaf_iteration() {
         run_test(|merkle_path| {
-            let lmdb_db = make_lmdb(merkle_path);
-            test_leaf_iteration(lmdb_db);
+            let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+            test_leaf_iteration(orig_root, state);
         })
     }
 
@@ -1164,7 +1204,7 @@ mod lmdb {
         }
     }
 
-    fn make_lmdb(merkle_path: &str) -> Box<LmdbDatabase> {
+    fn make_lmdb(merkle_path: &str) -> Box<dyn Database> {
         let ctx = LmdbContext::new(
             Path::new(merkle_path),
             INDEXES.len(),
@@ -1206,14 +1246,26 @@ mod redisdb {
 
     const DEFAULT_REDIS_URL: &str = "redis://localhost:6379/";
 
+    fn new_redis_state_and_root(redis_url: &str, primary: &str) -> (MerkleState, String) {
+        let db = Box::new(
+            RedisDatabase::new(redis_url, primary.to_string(), &INDEXES)
+                .expect("Unable to create redis database"),
+        );
+        let merkle_state = MerkleState::new(db.clone());
+
+        let merkle_db = MerkleRadixTree::new(db, None)
+            .expect("Could not overlay the merkle tree on the database");
+
+        let orig_root = merkle_db.get_merkle_root();
+
+        (merkle_state, orig_root)
+    }
+
     #[test]
     fn merkle_trie_empty_changes() {
         run_test(|redis_url, primary| {
-            let db = Box::new(
-                RedisDatabase::new(redis_url, primary.to_string(), &INDEXES)
-                    .expect("Unable to create redis database"),
-            );
-            test_merkle_trie_empty_changes(db);
+            let (state, orig_root) = new_redis_state_and_root(redis_url, primary);
+            test_merkle_trie_empty_changes(orig_root, state);
         })
     }
 
@@ -1231,44 +1283,32 @@ mod redisdb {
     #[test]
     fn merkle_trie_delete() {
         run_test(|redis_url, primary| {
-            let db = Box::new(
-                RedisDatabase::new(redis_url, primary.to_string(), &INDEXES)
-                    .expect("Unable to create redis database"),
-            );
-            test_merkle_trie_delete(db);
+            let (state, orig_root) = new_redis_state_and_root(redis_url, primary);
+            test_merkle_trie_delete(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update() {
         run_test(|redis_url, primary| {
-            let db = Box::new(
-                RedisDatabase::new(redis_url, primary.to_string(), &INDEXES)
-                    .expect("Unable to create redis database"),
-            );
-            test_merkle_trie_update(db);
+            let (state, orig_root) = new_redis_state_and_root(redis_url, primary);
+            test_merkle_trie_update(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update_same_address_space() {
         run_test(|redis_url, primary| {
-            let db = Box::new(
-                RedisDatabase::new(redis_url, primary.to_string(), &INDEXES)
-                    .expect("Unable to create redis database"),
-            );
-            test_merkle_trie_update_same_address_space(db);
+            let (state, orig_root) = new_redis_state_and_root(redis_url, primary);
+            test_merkle_trie_update_same_address_space(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update_same_address_space_with_no_children() {
         run_test(|redis_url, primary| {
-            let db = Box::new(
-                RedisDatabase::new(redis_url, primary.to_string(), &INDEXES)
-                    .expect("Unable to create redis database"),
-            );
-            test_merkle_trie_update_same_address_space_with_no_children(db);
+            let (state, orig_root) = new_redis_state_and_root(redis_url, primary);
+            test_merkle_trie_update_same_address_space_with_no_children(orig_root, state);
         })
     }
 
@@ -1394,13 +1434,25 @@ mod sqlitedb {
 
     use super::*;
 
+    fn new_sqlite_state_and_root(db_path: &str) -> (MerkleState, String) {
+        let db = Box::new(
+            SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
+        );
+        let merkle_state = MerkleState::new(db.clone());
+
+        let merkle_db = MerkleRadixTree::new(db, None)
+            .expect("Could not overlay the merkle tree on the database");
+
+        let orig_root = merkle_db.get_merkle_root();
+
+        (merkle_state, orig_root)
+    }
+
     #[test]
     fn merkle_trie_empty_changes() {
         run_test(|db_path| {
-            let db = Box::new(
-                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
-            );
-            test_merkle_trie_empty_changes(db);
+            let (state, orig_root) = new_sqlite_state_and_root(db_path);
+            test_merkle_trie_empty_changes(orig_root, state);
         })
     }
 
@@ -1417,10 +1469,8 @@ mod sqlitedb {
     #[test]
     fn merkle_trie_delete() {
         run_test(|db_path| {
-            let db = Box::new(
-                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
-            );
-            test_merkle_trie_delete(db);
+            let (state, orig_root) = new_sqlite_state_and_root(db_path);
+            test_merkle_trie_delete(orig_root, state);
         })
     }
 
@@ -1428,10 +1478,8 @@ mod sqlitedb {
     #[test]
     fn merkle_trie_update_atomic_commit_rollback() {
         run_test(|db_path| {
-            let db = Box::new(
-                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
-            );
-            test_merkle_trie_update(db);
+            let (state, orig_root) = new_sqlite_state_and_root(db_path);
+            test_merkle_trie_update(orig_root, state);
         })
     }
 
@@ -1446,7 +1494,13 @@ mod sqlitedb {
                     .build()
                     .expect("Unable to create Sqlite database"),
             );
-            test_merkle_trie_update(db);
+            let merkle_state = MerkleState::new(db.clone());
+
+            let merkle_db = MerkleRadixTree::new(db, None)
+                .expect("Could not overlay the merkle tree on the database");
+
+            let orig_root = merkle_db.get_merkle_root();
+            test_merkle_trie_update(orig_root, merkle_state);
         })
     }
 
@@ -1462,27 +1516,29 @@ mod sqlitedb {
                     .build()
                     .expect("Unable to create Sqlite database"),
             );
-            test_merkle_trie_update(db);
+            let merkle_state = MerkleState::new(db.clone());
+
+            let merkle_db = MerkleRadixTree::new(db, None)
+                .expect("Could not overlay the merkle tree on the database");
+
+            let orig_root = merkle_db.get_merkle_root();
+            test_merkle_trie_update(orig_root, merkle_state);
         })
     }
 
     #[test]
     fn merkle_trie_update_same_address_space() {
         run_test(|db_path| {
-            let db = Box::new(
-                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
-            );
-            test_merkle_trie_update_same_address_space(db);
+            let (state, orig_root) = new_sqlite_state_and_root(db_path);
+            test_merkle_trie_update_same_address_space(orig_root, state);
         })
     }
 
     #[test]
     fn merkle_trie_update_same_address_space_with_no_children() {
         run_test(|db_path| {
-            let db = Box::new(
-                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
-            );
-            test_merkle_trie_update_same_address_space_with_no_children(db);
+            let (state, orig_root) = new_sqlite_state_and_root(db_path);
+            test_merkle_trie_update_same_address_space_with_no_children(orig_root, state);
         })
     }
 
@@ -1526,13 +1582,12 @@ mod sqlitedb {
         })
     }
 
+    #[cfg(feature = "state-merkle-leaf-reader")]
     #[test]
     fn leaf_iteration() {
         run_test(|db_path| {
-            let db = Box::new(
-                SqliteDatabase::new(&db_path, &INDEXES).expect("Unable to create Sqlite database"),
-            );
-            test_leaf_iteration(db);
+            let (state, orig_root) = new_sqlite_state_and_root(db_path);
+            test_leaf_iteration(orig_root, state);
         })
     }
 

--- a/libtransact/tests/state/merkle.rs
+++ b/libtransact/tests/state/merkle.rs
@@ -1159,7 +1159,9 @@ mod lmdb {
 
         remove_file(dbpath).unwrap();
 
-        assert!(result.is_ok())
+        if let Err(err) = result {
+            panic::resume_unwind(err);
+        }
     }
 
     fn make_lmdb(merkle_path: &str) -> Box<LmdbDatabase> {
@@ -1570,7 +1572,9 @@ mod sqlitedb {
 
         std::fs::remove_file(dbpath).unwrap();
 
-        assert!(result.is_ok())
+        if let Err(err) = result {
+            std::panic::resume_unwind(err);
+        }
     }
     static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(1);
 


### PR DESCRIPTION
This change updates the merkle state tests to use the state traits in all tests that don't involve pruning checks.  This will enable validating the SQL-backed implementation against the same tests.

Additionally, 

- Fixes a bug with error output of the trait implementations in the key-value implementation
- replaces panics with resume_unwind in the test wrappers
- Adds a `key()` accessor to `StateChange`, for convenience