### PR TITLE
Fix 0-3 merge builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     }
 
     triggers {
-        cron(env.BRANCH_NAME == 'master' ? 'H 2 * * *' : '')
+        cron(env.BRANCH_NAME == '0-3' ? 'H 2 * * *' : '')
     }
 
     options {
@@ -45,7 +45,7 @@ pipeline {
             }
             when {
                 not {
-                    branch 'master'
+                    branch '0-3'
                 }
             }
         }


### PR DESCRIPTION
The authorized builders check is triggered erroneously and fails
because merge builds do not have a CHANGE_AUTHOR.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>