### PR TITLE
Fix bug in command workload `CommandGeneratingIter`

### DIFF
--- a/libtransact/src/families/command/workload/playlist.rs
+++ b/libtransact/src/families/command/workload/playlist.rs
@@ -39,7 +39,9 @@ impl CommandGeneratingIter {
     }
 
     pub fn add_set_address(&mut self, address: String) {
-        self.set_addresses.push(address);
+        if !self.set_addresses.contains(&address) {
+            self.set_addresses.push(address);
+        }
     }
 
     pub fn remove_set_address(&mut self, index: usize) {


### PR DESCRIPTION
Update the `add_set_address` method in `CommandGeneratingIter` to only add an address to the `set_addresses` vector if it isn't already in the vector.

Previously it was possible for an address to be added to the vector twice which could result in an error if the address is deleted and has not yet been re-set before being deleted again.