### PR TITLE
SQL Merkle State

### DIFF
--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -15,8 +15,22 @@
  * -----------------------------------------------------------------------------
  */
 
-pub mod backend;
-mod migration;
-mod models;
-mod operations;
-mod schema;
+#[cfg(feature = "sqlite")]
+mod sqlite;
+
+use crate::error::InternalError;
+
+#[cfg(feature = "sqlite")]
+pub use sqlite::{JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection, Synchronous};
+
+pub trait Connection {
+    type ConnectionType: diesel::Connection;
+
+    fn as_inner(&self) -> &Self::ConnectionType;
+}
+
+pub trait Backend: Sync + Send {
+    type Connection: Connection;
+
+    fn connection(&self) -> Result<Self::Connection, InternalError>;
+}

--- a/libtransact/src/state/merkle/sql/backend/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/backend/sqlite.rs
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! A Backend implementation for SQLite databases.
+
+use std::convert::TryFrom;
+use std::fmt;
+use std::num::NonZeroU32;
+
+use diesel::{
+    connection::SimpleConnection,
+    r2d2::{ConnectionManager, CustomizeConnection, Pool, PooledConnection},
+    sqlite,
+};
+
+use crate::error::{InternalError, InvalidStateError};
+
+use super::{Backend, Connection};
+
+/// A connection to a SQLite database.
+pub struct SqliteConnection(
+    pub(in crate::state::merkle::sql) PooledConnection<ConnectionManager<sqlite::SqliteConnection>>,
+);
+
+impl Connection for SqliteConnection {
+    type ConnectionType = sqlite::SqliteConnection;
+
+    fn as_inner(&self) -> &Self::ConnectionType {
+        &*self.0
+    }
+}
+
+/// The SQLite Backend
+///
+/// This struct provides the backend implementation details for SQLite databases.
+#[derive(Clone)]
+pub struct SqliteBackend {
+    connection_pool: Pool<ConnectionManager<sqlite::SqliteConnection>>,
+}
+
+impl Backend for SqliteBackend {
+    type Connection = SqliteConnection;
+
+    fn connection(&self) -> Result<Self::Connection, InternalError> {
+        self.connection_pool
+            .get()
+            .map(SqliteConnection)
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}
+
+/// The default size
+pub const DEFAULT_MMAP_SIZE: i64 = 100 * 1024 * 1024;
+
+/// Synchronous setting values.
+///
+/// See the [PRAGMA "synchronous"](https://sqlite.org/pragma.html#pragma_journal_mode)
+/// documentation for more details.
+#[derive(Debug)]
+pub enum Synchronous {
+    /// With synchronous Off, SQLite continues without syncing as soon as it has handed data
+    /// off to the operating system. If the application running SQLite crashes, the data will be
+    /// safe, but the database might become corrupted if the operating system crashes or the
+    /// computer loses power before that data has been written to the disk surface. On the other
+    /// hand, commits can be orders of magnitude faster with synchronous Off.
+    ///
+    /// Not Recommended for production use.
+    Off,
+    /// When synchronous is Normal, the SQLite database engine will still sync at the most
+    /// critical moments, but less often than in FULL mode.  WAL mode is safe from corruption with
+    /// Normal. WAL mode is always consistent with Normal, but WAL mode does lose durability. A
+    /// transaction committed in WAL mode with Normal might roll back following a power loss or
+    /// system crash. Transactions are durable across application crashes regardless of the
+    /// synchronous setting or journal mode. The Normal setting is a good choice for most
+    /// applications running in WAL mode.
+    Normal,
+    /// When synchronous is Full, the SQLite database engine will use the xSync method of the VFS
+    /// to ensure that all content is safely written to the disk surface prior to continuing. This
+    /// ensures that an operating system crash or power failure will not corrupt the database. Full
+    /// synchronous is very safe, but it is also slower. Full is the most commonly used synchronous
+    /// setting when not in WAL mode.
+    Full,
+}
+
+impl fmt::Display for Synchronous {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Synchronous::Off => f.write_str("OFF"),
+            Synchronous::Normal => f.write_str("NORMAL"),
+            Synchronous::Full => f.write_str("FULL"),
+        }
+    }
+}
+
+/// Journal Mode setting values.
+///
+/// See the [PRAGMA "journal_mode"](https://sqlite.org/pragma.html#pragma_journal_mode)
+/// documentation for more details.
+#[derive(Debug)]
+pub enum JournalMode {
+    /// The DELETE journaling mode is the normal behavior. In the DELETE mode, the rollback journal
+    /// is deleted at the conclusion of each transaction. Indeed, the delete operation is the
+    /// action that causes the transaction to commit.
+    Delete,
+    /// The TRUNCATE journaling mode commits transactions by truncating the rollback journal to
+    /// zero-length instead of deleting it.
+    Truncate,
+    /// The PERSIST journaling mode prevents the rollback journal from being deleted at the end of
+    /// each transaction. Instead, the header of the journal is overwritten with zeros. This will
+    /// prevent other database connections from rolling the journal back.
+    Persist,
+    /// The MEMORY journaling mode stores the rollback journal in volatile RAM.
+    Memory,
+    /// Enable "Write-Ahead Log" (WAL) journal mode.
+    ///
+    /// In SQLite, WAL journal mode provides considerable performance improvements in most
+    /// scenarios.  See [https://sqlite.org/wal.html](https://sqlite.org/wal.html) for more
+    /// details on this mode.
+    ///
+    /// While many of the disadvantages of this mode are unlikely to effect transact and its
+    /// use-cases, WAL mode cannot be used with a database file on a networked file system.
+    Wal,
+    /// Disables the rollback journal completely.
+    Off,
+}
+
+impl fmt::Display for JournalMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            JournalMode::Delete => f.write_str("DELETE"),
+            JournalMode::Truncate => f.write_str("TRUNCATE"),
+            JournalMode::Persist => f.write_str("PERSIST"),
+            JournalMode::Memory => f.write_str("MEMORY"),
+            JournalMode::Wal => f.write_str("WAL"),
+            JournalMode::Off => f.write_str("OFF"),
+        }
+    }
+}
+
+pub struct SqliteBackendBuilder {
+    connection_path: Option<String>,
+    create: bool,
+    pool_size: Option<u32>,
+    memory_map_size: i64,
+    journal_mode: Option<JournalMode>,
+    synchronous: Option<Synchronous>,
+}
+
+impl SqliteBackendBuilder {
+    /// Constructs a new SqliteBackendBuilder.
+    pub fn new() -> Self {
+        Self {
+            connection_path: None,
+            create: false,
+            pool_size: None,
+            memory_map_size: DEFAULT_MMAP_SIZE,
+            journal_mode: None,
+            synchronous: None,
+        }
+    }
+
+    /// Configures the SqliteBackend instance as a memory database, with a connection pool size of 1.
+    pub fn with_memory_database(mut self) -> Self {
+        self.connection_path = Some(":memory:".into());
+        self.pool_size = Some(1);
+        self
+    }
+
+    /// Set the path for the Sqlite database.
+    ///
+    /// This is a required field.
+    pub fn with_connection_path<S: Into<String>>(mut self, connection_path: S) -> Self {
+        self.connection_path = Some(connection_path.into());
+        self
+    }
+
+    /// Create the database file if it does not exist.
+    pub fn with_create(mut self) -> Self {
+        self.create = true;
+        self
+    }
+
+    /// Set the connection pool size.
+    pub fn with_connection_pool_size(mut self, pool_size: NonZeroU32) -> Self {
+        self.pool_size = Some(pool_size.get());
+        self
+    }
+
+    /// Set the size used for Memory-Mapped I/O.
+    ///
+    /// This can be disabled by setting the value to `0`
+    pub fn with_memory_map_size(mut self, memory_map_size: u64) -> Self {
+        // The try from would fail if the u64 is greater than max i64, so we can unwrap this as
+        // such.
+        self.memory_map_size = i64::try_from(memory_map_size).unwrap_or(std::i64::MAX);
+        self
+    }
+
+    /// Modify the "journal mode" setting for the SQLite connection.
+    ///
+    /// See the [pragma journal_mode
+    /// documentation](https://sqlite.org/pragma.html#pragma_journal_mode) for more information.
+    ///
+    /// If unchanged, the default value is left to underlying SQLite installation.
+    pub fn with_journal_mode(mut self, journal_mode: JournalMode) -> Self {
+        self.journal_mode = Some(journal_mode);
+        self
+    }
+
+    /// Modify the "synchronous" setting for the SQLite connection.
+    ///
+    /// This setting changes the mode of how the transaction journal is synchronized to disk. See
+    /// the [pragma synchronouse documentation](https://sqlite.org/pragma.html#pragma_synchronous)
+    /// for more information.
+    ///
+    /// If unchanged, the default value is left to underlying SQLite installation.
+    pub fn with_synchronous(mut self, synchronous: Synchronous) -> Self {
+        self.synchronous = Some(synchronous);
+        self
+    }
+
+    /// Constructs the database instance.
+    ///
+    /// # Errors
+    ///
+    /// This may return a InvalidStateError for a variety of reasons:
+    ///
+    /// * No connection_path provided
+    /// * Unable to connect to the database.
+    /// * Unable to configure the provided memory map size
+    /// * Unable to configure the journal mode, if requested
+    /// * Unable to create tables, as required.
+    pub fn build(self) -> Result<SqliteBackend, InvalidStateError> {
+        let path = self.connection_path.ok_or_else(|| {
+            InvalidStateError::with_message("must provide a sqlite connection URI".into())
+        })?;
+
+        let mmap_size = self.memory_map_size;
+        let journal_mode_opt = self.journal_mode;
+        let synchronous_opt = self.synchronous;
+
+        if !self.create && (path != ":memory:") && !std::path::Path::new(&path).exists() {
+            return Err(InvalidStateError::with_message(format!(
+                "Database file '{}' does not exist",
+                path
+            )));
+        }
+
+        let connection_manager = ConnectionManager::<diesel::sqlite::SqliteConnection>::new(&path);
+
+        let mut pool_builder = Pool::builder();
+        if let Some(pool_size) = self.pool_size {
+            pool_builder = pool_builder.max_size(pool_size);
+        }
+        let pool = pool_builder
+            .connection_customizer(Box::new(SqliteCustomizer::new(
+                mmap_size,
+                journal_mode_opt,
+                synchronous_opt,
+            )))
+            .build(connection_manager)
+            .map_err(|err| InvalidStateError::with_message(err.to_string()))?;
+
+        // Validate that connections can be made
+        let _conn = pool
+            .get()
+            .map_err(|err| InvalidStateError::with_message(err.to_string()))?;
+
+        Ok(SqliteBackend {
+            connection_pool: pool,
+        })
+    }
+}
+
+impl Default for SqliteBackendBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug)]
+struct SqliteCustomizer {
+    on_connect_sql: String,
+}
+
+impl SqliteCustomizer {
+    fn new(
+        mmap_size: i64,
+        journal_mode: Option<JournalMode>,
+        synchronous: Option<Synchronous>,
+    ) -> Self {
+        let mut on_connect_sql = format!("PRAGMA mmap_size={};", mmap_size);
+
+        if let Some(journal_mode) = journal_mode {
+            on_connect_sql += &format!("PRAGMA journal_mode={};", journal_mode);
+        }
+
+        if let Some(synchronous) = synchronous {
+            on_connect_sql += &format!("PRAGMA synchronous={};", synchronous);
+        }
+
+        on_connect_sql += "PRAGMA foreign_keys = ON;";
+        Self { on_connect_sql }
+    }
+}
+
+impl CustomizeConnection<diesel::sqlite::SqliteConnection, diesel::r2d2::Error>
+    for SqliteCustomizer
+{
+    fn on_acquire(
+        &self,
+        conn: &mut diesel::sqlite::SqliteConnection,
+    ) -> Result<(), diesel::r2d2::Error> {
+        conn.batch_execute(&self.on_connect_sql)
+            .map_err(diesel::r2d2::Error::QueryError)
+    }
+}

--- a/libtransact/src/state/merkle/sql/migration/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/mod.rs
@@ -15,6 +15,19 @@
  * -----------------------------------------------------------------------------
  */
 
+//! Provides the MigrationManageer trait.
+
 #[cfg(feature = "sqlite")]
-#[allow(dead_code)]
-pub mod sqlite;
+pub(crate) mod sqlite;
+
+use crate::error::InternalError;
+
+use super::backend::Backend;
+
+/// Provides backend migration execution.
+///
+/// Backend's that implement this trait can expose a migration operation on their underlying
+/// database system.
+pub trait MigrationManager: Backend {
+    fn run_migrations(&self) -> Result<(), InternalError>;
+}

--- a/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
@@ -20,6 +20,9 @@
 embed_migrations!("./src/state/merkle/sql/migration/sqlite/migrations");
 
 use crate::error::InternalError;
+use crate::state::merkle::sql::backend::{Backend, Connection, SqliteBackend};
+
+use super::MigrationManager;
 
 /// Run database migrations to create tables defined by biome
 ///
@@ -33,4 +36,10 @@ pub fn run_migrations(conn: &diesel::sqlite::SqliteConnection) -> Result<(), Int
     info!("Successfully applied SQLite migrations");
 
     Ok(())
+}
+
+impl MigrationManager for SqliteBackend {
+    fn run_migrations(&self) -> Result<(), InternalError> {
+        run_migrations(self.connection()?.as_inner())
+    }
 }

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -15,8 +15,498 @@
  * -----------------------------------------------------------------------------
  */
 
+//! SQL-backed merkle-radix state implementation.
+
 pub mod backend;
 pub mod migration;
 mod models;
 mod operations;
 mod schema;
+
+use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
+
+use crate::error::InternalError;
+use crate::state::error::{StateReadError, StateWriteError};
+#[cfg(feature = "state-merkle-leaf-reader")]
+use crate::state::merkle::{MerkleRadixLeafReadError, MerkleRadixLeafReader};
+use crate::state::{Read, StateChange, Write};
+
+use super::node::Node;
+
+use backend::{Backend, Connection};
+use operations::get_leaves::MerkleRadixGetLeavesOperation as _;
+use operations::get_path::MerkleRadixGetPathOperation as _;
+use operations::has_root::MerkleRadixHasRootOperation as _;
+use operations::insert_nodes::MerkleRadixInsertNodesOperation as _;
+use operations::list_leaves::MerkleRadixListLeavesOperation as _;
+use operations::update_index::MerkleRadixUpdateIndexOperation as _;
+use operations::MerkleRadixOperations;
+
+const TOKEN_SIZE: usize = 2;
+
+/// SqlMerkleState provides a merkle-radix implementation over a SQL database.
+///
+/// Databases are implemented using a Backend to provide connections. Note that the database must
+/// have the correct set of tables applied via migrations before this struct may be usable.
+#[derive(Clone)]
+pub struct SqlMerkleState<B: Backend + Clone> {
+    backend: B,
+}
+
+impl<B: Backend + Clone> SqlMerkleState<B> {
+    /// Constructs a new SqlMerkleState with the given backend.
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+
+    /// Returns the initial state root.
+    ///
+    /// This value is the state root that applies to a empty merkle radix tree.
+    pub fn initial_state_root_hash(&self) -> Result<String, InternalError> {
+        let (hash, _) = encode_and_hash(Node::default())?;
+
+        Ok(hex::encode(&hash))
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl Write for SqlMerkleState<backend::SqliteBackend> {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        let overlay = MerkleRadixOverlay::new(&*state_id, SqlOverlay::new(&self.backend));
+
+        let (next_state_id, changes) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+
+        let deleted_addresses = state_changes
+            .iter()
+            .filter(|change| matches!(change, StateChange::Delete { .. }))
+            .map(|change| change.key())
+            .collect::<Vec<_>>();
+
+        overlay
+            .write_updates(&next_state_id, changes, &deleted_addresses)
+            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+
+        Ok(next_state_id)
+    }
+
+    fn compute_state_id(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        let overlay = MerkleRadixOverlay::new(&*state_id, SqlOverlay::new(&self.backend));
+
+        let (next_state_id, _) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+
+        Ok(next_state_id)
+    }
+}
+
+impl Read for SqlMerkleState<backend::SqliteBackend> {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
+        let overlay = MerkleRadixOverlay::new(&*state_id, SqlOverlay::new(&self.backend));
+
+        if !overlay
+            .has_root()
+            .map_err(|e| StateReadError::StorageError(Box::new(e)))?
+        {
+            return Err(StateReadError::InvalidStateId(state_id.into()));
+        }
+
+        overlay
+            .get_entries(keys)
+            .map_err(|e| StateReadError::StorageError(Box::new(e)))
+    }
+
+    fn clone_box(
+        &self,
+    ) -> Box<dyn Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>> {
+        Box::new(self.clone())
+    }
+}
+
+#[cfg(feature = "state-merkle-leaf-reader")]
+type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
+#[cfg(feature = "state-merkle-leaf-reader")]
+type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
+
+#[cfg(all(feature = "state-merkle-leaf-reader", feature = "sqlite"))]
+impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
+    /// Returns an iterator over the leaves of a merkle radix tree.
+    /// By providing an optional address prefix, the caller can limit the iteration
+    /// over the leaves in a specific subtree.
+    fn leaves(
+        &self,
+        state_id: &Self::StateId,
+        subtree: Option<&str>,
+    ) -> IterResult<LeafIter<(Self::Key, Self::Value)>> {
+        let conn = self.backend.connection()?;
+
+        if &self.initial_state_root_hash()? == state_id {
+            return Ok(Box::new(std::iter::empty()));
+        }
+
+        let leaves = MerkleRadixOperations::new(conn.as_inner()).list_leaves(state_id, subtree)?;
+
+        Ok(Box::new(leaves.into_iter().map(Ok)))
+    }
+}
+
+struct MerkleRadixOverlay<'s, O> {
+    state_root_hash: &'s str,
+    inner: O,
+}
+
+// (Hash, packed bytes, path address)
+type NodeChanges = Vec<(String, Node, String)>;
+
+impl<'s, O> MerkleRadixOverlay<'s, O>
+where
+    O: OverlayReader + OverlayWriter,
+{
+    fn new(state_root_hash: &'s str, inner: O) -> Self {
+        Self {
+            state_root_hash,
+            inner,
+        }
+    }
+
+    fn write_updates(
+        &self,
+        new_state_root: &str,
+        node_changes: NodeChanges,
+        deleted_addresses: &[&str],
+    ) -> Result<(), InternalError> {
+        self.inner.write_changes(
+            new_state_root,
+            self.state_root_hash,
+            node_changes,
+            deleted_addresses,
+        )?;
+
+        Ok(())
+    }
+
+    fn has_root(&self) -> Result<bool, InternalError> {
+        self.inner.has_root(self.state_root_hash)
+    }
+
+    fn get_entries(&self, keys: &[String]) -> Result<HashMap<String, Vec<u8>>, InternalError> {
+        let keys = keys.iter().map(|k| &**k).collect::<Vec<_>>();
+        self.inner
+            .get_entries(self.state_root_hash, keys)
+            .map(|result| result.into_iter().collect::<HashMap<_, _>>())
+    }
+
+    fn generate_updates(
+        &self,
+        state_changes: &[StateChange],
+    ) -> Result<(String, NodeChanges), StateWriteError> {
+        if state_changes.is_empty() {
+            return Ok((self.state_root_hash.to_string(), vec![]));
+        }
+
+        let mut path_map = HashMap::new();
+
+        let mut deletions = HashSet::new();
+        let mut additions = HashSet::new();
+
+        let mut delete_items = vec![];
+        for state_change in state_changes {
+            match state_change {
+                StateChange::Set { key, value } => {
+                    let mut set_path_map = self
+                        .get_path(self.state_root_hash, &key)
+                        .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+                    {
+                        let node = set_path_map
+                            .get_mut(key)
+                            .expect("Path map not correctly generated");
+                        node.value = Some(value.to_vec());
+                    }
+                    for pkey in set_path_map.keys() {
+                        additions.insert(pkey.clone());
+                    }
+                    path_map.extend(set_path_map);
+                }
+                StateChange::Delete { key } => {
+                    let del_path_map = self
+                        .get_path(self.state_root_hash, &key)
+                        .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+                    path_map.extend(del_path_map);
+                    delete_items.push(key);
+                }
+            }
+        }
+
+        for del_address in delete_items.iter() {
+            path_map.remove(*del_address);
+            let (mut parent_address, mut path_branch) = parent_and_branch(del_address);
+            while !parent_address.is_empty() {
+                let remove_parent = {
+                    let parent_node = path_map
+                        .get_mut(parent_address)
+                        .expect("Path map not correctly generated or entry is deleted");
+
+                    if let Some(old_hash_key) = parent_node.children.remove(path_branch) {
+                        deletions.insert(old_hash_key);
+                    }
+
+                    parent_node.children.is_empty()
+                };
+
+                // There's no children to the parent node already in the tree, remove it from
+                // path_map if a new node doesn't have this as its parent
+                if remove_parent && !additions.contains(parent_address) {
+                    // Empty node delete it.
+                    path_map.remove(parent_address);
+                } else {
+                    // Found a node that is not empty no need to continue
+                    break;
+                }
+
+                let (next_parent, next_branch) = parent_and_branch(parent_address);
+                parent_address = next_parent;
+                path_branch = next_branch;
+
+                if parent_address.is_empty() {
+                    let parent_node = path_map
+                        .get_mut(parent_address)
+                        .expect("Path map not correctly generated");
+
+                    if let Some(old_hash_key) = parent_node.children.remove(path_branch) {
+                        deletions.insert(old_hash_key);
+                    }
+                }
+            }
+        }
+
+        let mut sorted_paths: Vec<_> = path_map.keys().cloned().collect();
+        // Sort by longest to shortest
+        sorted_paths.sort_by_key(|a| Reverse(a.len()));
+
+        // Initializing this to empty, to make the compiler happy
+        let mut key_hash_hex = String::new();
+        let mut batch = Vec::with_capacity(sorted_paths.len());
+        for path in sorted_paths {
+            let node = path_map
+                .remove(&path)
+                .expect("Path map keys are out of sink");
+            let (hash_key, _) = encode_and_hash(node.clone())
+                .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+            key_hash_hex = hex::encode(&hash_key);
+
+            if !path.is_empty() {
+                let (parent_address, path_branch) = parent_and_branch(&path);
+                let parent = path_map
+                    .get_mut(parent_address)
+                    .expect("Path map not correctly generated");
+                if let Some(old_hash_key) = parent
+                    .children
+                    .insert(path_branch.to_string(), key_hash_hex.clone())
+                {
+                    deletions.insert(old_hash_key);
+                }
+            }
+
+            batch.push((key_hash_hex.clone(), node, path));
+        }
+
+        Ok((key_hash_hex, batch))
+    }
+
+    fn get_path(
+        &self,
+        state_root_hash: &str,
+        address: &str,
+    ) -> Result<HashMap<String, Node>, InternalError> {
+        // Build up the address along the path, starting with the empty address for the root, and
+        // finishing with the complete address.
+        let addresses_along_path: Vec<String> = (0..address.len())
+            .step_by(2)
+            .map(|i| address[0..i].to_string())
+            .chain(std::iter::once(address.to_string()))
+            .collect();
+
+        let node_path_iter = self
+            .inner
+            .get_path(state_root_hash, address)?
+            .into_iter()
+            .map(|(_, node)| node)
+            // include empty nodes after the queried path, to cover cases where the branch doesn't
+            // exist.
+            .chain(std::iter::repeat(Node::default()));
+
+        Ok(addresses_along_path
+            .into_iter()
+            .zip(node_path_iter)
+            .collect::<HashMap<_, _>>())
+    }
+}
+
+trait OverlayReader {
+    fn has_root(&self, state_root_hash: &str) -> Result<bool, InternalError>;
+
+    fn get_path(
+        &self,
+        state_root_hash: &str,
+        address: &str,
+    ) -> Result<Vec<(String, Node)>, InternalError>;
+
+    fn get_entries(
+        &self,
+        state_root_hash: &str,
+        keys: Vec<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
+}
+
+trait OverlayWriter {
+    fn write_changes(
+        &self,
+        state_root_hash: &str,
+        parent_state_root_hash: &str,
+        changes: Vec<(String, Node, String)>,
+        deleted_addresses: &[&str],
+    ) -> Result<(), InternalError>;
+}
+
+struct SqlOverlay<'b, B: Backend> {
+    backend: &'b B,
+}
+
+impl<'b, B: Backend> SqlOverlay<'b, B> {
+    fn new(backend: &'b B) -> Self {
+        Self { backend }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'b> OverlayReader for SqlOverlay<'b, backend::SqliteBackend> {
+    fn has_root(&self, state_root_hash: &str) -> Result<bool, InternalError> {
+        let conn = self.backend.connection()?;
+
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.has_root(state_root_hash)
+    }
+
+    fn get_path(
+        &self,
+        state_root_hash: &str,
+        address: &str,
+    ) -> Result<Vec<(String, Node)>, InternalError> {
+        let conn = self.backend.connection()?;
+
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.get_path(state_root_hash, address)
+    }
+
+    fn get_entries(
+        &self,
+        state_root_hash: &str,
+        keys: Vec<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
+        let conn = self.backend.connection()?;
+
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.get_leaves(state_root_hash, keys)
+    }
+}
+
+#[cfg(feature = "sqlite")]
+impl<'b> OverlayWriter for SqlOverlay<'b, backend::SqliteBackend> {
+    fn write_changes(
+        &self,
+        state_root_hash: &str,
+        parent_state_root_hash: &str,
+        changes: Vec<(String, Node, String)>,
+        deleted_addresses: &[&str],
+    ) -> Result<(), InternalError> {
+        let conn = self.backend.connection()?;
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+
+        let insertable_changes = changes
+            .into_iter()
+            .map(
+                |(hash, node, address)| operations::insert_nodes::InsertableNode {
+                    hash,
+                    node,
+                    address,
+                },
+            )
+            .collect::<Vec<_>>();
+
+        let indexable_info = operations.insert_nodes(&insertable_changes)?;
+
+        let changes = indexable_info
+            .iter()
+            .map(
+                |leaf_info| operations::update_index::ChangedLeaf::AddedOrUpdated {
+                    address: &leaf_info.address,
+                    leaf_id: leaf_info.leaf_id,
+                },
+            )
+            .chain(
+                deleted_addresses
+                    .iter()
+                    .map(|address| operations::update_index::ChangedLeaf::Deleted(address)),
+            )
+            .collect();
+
+        operations.update_index(state_root_hash, parent_state_root_hash, changes)?;
+
+        Ok(())
+    }
+}
+
+/// Given a path, split it into its parent's path and the specific branch for
+/// this path, such that the following assertion is true:
+fn parent_and_branch(path: &str) -> (&str, &str) {
+    let parent_address = if !path.is_empty() {
+        &path[..path.len() - TOKEN_SIZE]
+    } else {
+        ""
+    };
+
+    let path_branch = if !path.is_empty() {
+        &path[(path.len() - TOKEN_SIZE)..]
+    } else {
+        ""
+    };
+
+    (parent_address, path_branch)
+}
+/// Encodes the given node, and returns the hash of the bytes.
+fn encode_and_hash(node: Node) -> Result<(Vec<u8>, Vec<u8>), InternalError> {
+    let packed = node.into_bytes()?;
+    let hash = hash(&packed);
+    Ok((hash, packed))
+}
+
+/// Creates a hash of the given bytes
+fn hash(input: &[u8]) -> Vec<u8> {
+    let mut bytes: Vec<u8> = Vec::new();
+    bytes.extend(openssl::sha::sha512(input).iter());
+    let (hash, _rest) = bytes.split_at(bytes.len() / 2);
+    hash.to_vec()
+}

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -16,7 +16,7 @@
  */
 
 pub mod backend;
-mod migration;
+pub mod migration;
 mod models;
 mod operations;
 mod schema;

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -40,7 +40,6 @@ impl<'a, C> MerkleRadixOperations<'a, C>
 where
     C: diesel::Connection,
 {
-    #[allow(dead_code)]
     pub fn new(conn: &'a C) -> Self {
         MerkleRadixOperations { conn }
     }

--- a/libtransact/src/state/merkle/sql/operations/update_index.rs
+++ b/libtransact/src/state/merkle/sql/operations/update_index.rs
@@ -29,9 +29,7 @@ use super::last_insert_rowid;
 use super::MerkleRadixOperations;
 
 pub enum ChangedLeaf<'data> {
-    #[allow(dead_code)]
     AddedOrUpdated { address: &'data str, leaf_id: i64 },
-    #[allow(dead_code)]
     Deleted(&'data str),
 }
 

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -17,6 +17,8 @@ mod btree;
 mod lmdb;
 #[cfg(feature = "state-merkle-redis-db-tests")]
 mod redisdb;
+#[cfg(all(feature = "state-merkle-sql", feature = "sqlite"))]
+mod sql_sqlite;
 #[cfg(feature = "database-sqlite")]
 mod sqlitedb;
 
@@ -893,6 +895,64 @@ fn test_same_results(left: Box<dyn Database>, right: Box<dyn Database>) {
         prune_result_left.sort_unstable(),
         prune_result_right.sort_unstable()
     );
+}
+
+/// Check that two merkle state implementations will produce the same results.
+///
+/// 1. Perform set operations and verify the same result root
+/// 2. Perform a delete operation and verify the same result root
+#[cfg(all(feature = "state-merkle-sql", feature = "sqlite"))]
+fn test_produce_same_state<L, R>(
+    left_initial_state_root: String,
+    left: L,
+    right_initial_state_root: String,
+    right: R,
+) where
+    L: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+    R: Read<StateId = String, Key = String, Value = Vec<u8>>
+        + Write<StateId = String, Key = String, Value = Vec<u8>>,
+{
+    assert_eq!(
+        left_initial_state_root, right_initial_state_root,
+        "State not starting from the same initial state root hash"
+    );
+    let mut updates: Vec<StateChange> = Vec::with_capacity(3);
+
+    updates.push(StateChange::Set {
+        key: "ab0000".to_string(),
+        value: "0001".as_bytes().to_vec(),
+    });
+    updates.push(StateChange::Set {
+        key: "ab0a01".to_string(),
+        value: "0002".as_bytes().to_vec(),
+    });
+    updates.push(StateChange::Set {
+        key: "abff00".to_string(),
+        value: "0003".as_bytes().to_vec(),
+    });
+    updates.push(StateChange::Set {
+        key: "abff01".to_string(),
+        value: "0004".as_bytes().to_vec(),
+    });
+
+    let merkle_left_root = left.commit(&left_initial_state_root, &updates).unwrap();
+    let merkle_right_root = right.commit(&right_initial_state_root, &updates).unwrap();
+
+    assert_eq!(merkle_left_root, merkle_right_root);
+
+    let state_change_delete = vec![StateChange::Delete {
+        key: "abff01".to_string(),
+    }];
+
+    let merkle_left_root_del = left
+        .commit(&merkle_left_root, &state_change_delete)
+        .unwrap();
+    let merkle_right_root_del = right
+        .commit(&merkle_right_root, &state_change_delete)
+        .unwrap();
+
+    assert_eq!(merkle_left_root_del, merkle_right_root_del);
 }
 
 fn assert_value_at_address(merkle_db: &MerkleRadixTree, address: &str, expected_value: &str) {

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -1,0 +1,147 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQL-backed tests for the merkle state implementation
+
+use std::error::Error;
+
+use transact::state::merkle::sql::{
+    backend::{JournalMode, SqliteBackend, SqliteBackendBuilder},
+    migration::MigrationManager,
+    SqlMerkleState,
+};
+use transact::{database::btree::BTreeDatabase, state::merkle::INDEXES};
+
+use super::*;
+
+fn new_sql_merkle_state_and_root(
+    dbpath: &str,
+) -> Result<(SqlMerkleState<SqliteBackend>, String), Box<dyn Error>> {
+    let backend = SqliteBackendBuilder::new()
+        .with_connection_path(dbpath)
+        .with_journal_mode(JournalMode::Wal)
+        .with_create()
+        .build()?;
+    backend.run_migrations()?;
+
+    let state = SqlMerkleState::new(backend);
+    let initial_state_root_hash = state.initial_state_root_hash()?;
+
+    Ok((state, initial_state_root_hash))
+}
+
+#[test]
+fn merkle_trie_empty_changes() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_empty_changes(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_delete() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_delete(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_update() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_update(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_update_same_address_space() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_update_same_address_space(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_update_same_address_space_with_no_children() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_update_same_address_space_with_no_children(orig_root, state);
+        Ok(())
+    })
+}
+
+#[cfg(feature = "state-merkle-leaf-reader")]
+#[test]
+fn leaf_iteration() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_leaf_iteration(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_produce_same_state_as_btree() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (sql_state, sql_orig_root) = new_sql_merkle_state_and_root(db_path)?;
+
+        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
+        let btree_state = MerkleState::new(btree_db.clone());
+
+        let merkle_db = MerkleRadixTree::new(btree_db, None)
+            .expect("Could not overlay the merkle tree on the database");
+
+        let btree_orig_root = merkle_db.get_merkle_root();
+
+        test_produce_same_state(btree_orig_root, btree_state, sql_orig_root, sql_state);
+
+        Ok(())
+    })
+}
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+fn run_test<T>(test: T) -> Result<(), Box<dyn Error>>
+where
+    T: FnOnce(&str) -> Result<(), Box<dyn Error>> + std::panic::UnwindSafe,
+{
+    let dbpath = temp_db_path();
+
+    let testpath = dbpath.clone();
+    let result = std::panic::catch_unwind(move || test(&testpath));
+
+    std::fs::remove_file(dbpath).unwrap();
+
+    match result {
+        Ok(res) => res,
+        Err(err) => {
+            std::panic::resume_unwind(err);
+        }
+    }
+}
+
+static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(1);
+
+fn temp_db_path() -> String {
+    let mut temp_dir = std::env::temp_dir();
+
+    let thread_id = GLOBAL_THREAD_COUNT.fetch_add(1, Ordering::SeqCst);
+    temp_dir.push(format!("sql_sqlite-test-{:?}.db", thread_id));
+    temp_dir.to_str().unwrap().to_string()
+}


### PR DESCRIPTION
This PR adds an implementation of state that applies a Merkle-Radix tree using a SQL database as its back-end.  This PR includes a diesel/SQLite implementation

Experimental feature implementation of [RFC 10](https://github.com/hyperledger/transact-rfcs/pull/10)