### PR TITLE
Support multiple trees with a single backend

### DIFF
--- a/libtransact/src/state/merkle/sql/error.rs
+++ b/libtransact/src/state/merkle/sql/error.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Errors related to SQL-backed merkle-radix state representation.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::error::{InternalError, InvalidStateError};
+
+/// This error may occur during the construction of a SqlMerkeState instance.
+#[derive(Debug)]
+pub enum SqlMerkleStateBuildError {
+    InternalError(InternalError),
+    InvalidStateError(InvalidStateError),
+}
+
+impl fmt::Display for SqlMerkleStateBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SqlMerkleStateBuildError::InternalError(e) => f.write_str(&e.to_string()),
+            SqlMerkleStateBuildError::InvalidStateError(e) => f.write_str(&e.to_string()),
+        }
+    }
+}
+
+impl Error for SqlMerkleStateBuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            SqlMerkleStateBuildError::InternalError(ref e) => Some(&*e),
+            SqlMerkleStateBuildError::InvalidStateError(ref e) => Some(&*e),
+        }
+    }
+}
+
+impl From<InternalError> for SqlMerkleStateBuildError {
+    fn from(err: InternalError) -> Self {
+        SqlMerkleStateBuildError::InternalError(err)
+    }
+}
+
+impl From<InvalidStateError> for SqlMerkleStateBuildError {
+    fn from(err: InvalidStateError) -> Self {
+        SqlMerkleStateBuildError::InvalidStateError(err)
+    }
+}

--- a/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2021-06-21-043900-multiple-tree-support/up.sql
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2021-06-21-043900-multiple-tree-support/up.sql
@@ -1,0 +1,99 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS merkle_radix_tree (
+    id INTEGER PRIMARY KEY,
+    name TEXT,
+    UNIQUE(name)
+);
+
+INSERT INTO merkle_radix_tree (id, name) VALUES (1, 'default');
+
+-- Rename all the current tables to _old:
+ALTER TABLE merkle_radix_state_root_leaf_index
+    RENAME TO _merkle_radix_state_root_leaf_index_old;
+
+ALTER TABLE merkle_radix_state_root RENAME TO _merkle_radix_state_root_old;
+
+ALTER TABLE merkle_radix_tree_node RENAME TO _merkle_radix_tree_node_old;
+
+ALTER TABLE merkle_radix_leaf RENAME TO _merkle_radix_leaf_old;
+
+-- Recreate the tables with a tree ID, in the order of foreign key relationships
+
+-- Add tree_id to the merkle_radix_leaf table
+CREATE TABLE IF NOT EXISTS merkle_radix_leaf (
+    id INTEGER PRIMARY KEY,
+    tree_id INTEGER NOT NULL,
+    address STRING NOT NULL,
+    data BLOB,
+    FOREIGN KEY(tree_id) REFERENCES merkle_radix_tree (id)
+);
+
+INSERT INTO merkle_radix_leaf
+    (id, tree_id, address, data)
+    SELECT id, 1, address, data FROM _merkle_radix_leaf_old;
+
+-- Add tree_id to the merkle_radix_tree_node table
+CREATE TABLE IF NOT EXISTS merkle_radix_tree_node (
+    hash STRING NOT NULL,
+    tree_id INTEGER NOT NULL,
+    leaf_id INTEGER,
+    children TEXT,
+    PRIMARY KEY (hash, tree_id),
+    FOREIGN KEY(tree_id) REFERENCES merkle_radix_tree(id),
+    FOREIGN KEY(leaf_id) REFERENCES merkle_radix_leaf(id)
+);
+
+INSERT INTO merkle_radix_tree_node
+    (hash, tree_id, leaf_id, children)
+    SELECT hash, 1, leaf_id, children FROM _merkle_radix_tree_node_old;
+
+-- Add tree_id to the merkle_radix_state_root table
+CREATE TABLE IF NOT EXISTS merkle_radix_state_root (
+    id INTEGER PRIMARY KEY,
+    tree_id INTEGER NOT NULL,
+    state_root STRING NOT NULL,
+    parent_state_root STRING NOT NULL,
+    FOREIGN KEY(state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id)
+);
+
+INSERT INTO merkle_radix_state_root
+    (id, tree_id, state_root, parent_state_root)
+    SELECT id, 1, state_root, parent_state_root
+    FROM _merkle_radix_state_root_old;
+
+-- Add tree_id to the merkle_radix_state_root_leaf_index table
+CREATE TABLE IF NOT EXISTS merkle_radix_state_root_leaf_index (
+    id INTEGER PRIMARY KEY,
+    leaf_id INTEGER NOT NULL,
+    tree_id INTEGER NOT NULL,
+    from_state_root_id INTEGER NOT NULL,
+    to_state_root_id INTEGER,
+    FOREIGN KEY(from_state_root_id) REFERENCES merkle_radix_state_root(id),
+    FOREIGN KEY(leaf_id) REFERENCES merkle_radix_leaf (id),
+    FOREIGN KEY(tree_id) REFERENCES merkle_radix_tree (id)
+);
+
+INSERT INTO merkle_radix_state_root_leaf_index
+    (id, leaf_id, tree_id, from_state_root_id, to_state_root_id)
+    SELECT id, leaf_id, 1, from_state_root_id, to_state_root_id
+    FROM _merkle_radix_state_root_leaf_index_old;
+
+-- Drop the old tables
+DROP TABLE _merkle_radix_state_root_leaf_index_old;
+DROP TABLE _merkle_radix_state_root_old;
+DROP TABLE _merkle_radix_tree_node_old;
+DROP TABLE _merkle_radix_leaf_old;

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -130,14 +130,6 @@ pub struct SqlMerkleState<B: Backend + Clone> {
 }
 
 impl<B: Backend + Clone> SqlMerkleState<B> {
-    /// Constructs a new SqlMerkleState with the given backend.
-    pub fn new(backend: B) -> Self {
-        Self {
-            backend,
-            tree_id: 1,
-        }
-    }
-
     /// Returns the initial state root.
     ///
     /// This value is the state root that applies to a empty merkle radix tree.

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -18,6 +18,7 @@
 //! SQL-backed merkle-radix state implementation.
 
 pub mod backend;
+mod error;
 pub mod migration;
 mod models;
 mod operations;

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -16,6 +16,35 @@
  */
 
 //! SQL-backed merkle-radix state implementation.
+//!
+//! A merkle-radix tree can be applied to a SQL database using the [`SqlMerkleState`] struct.  This
+//! struct uses several specialized tables to represent the tree, with optimizations made depending
+//! on the specific SQL database platform.
+//!
+//! A instance can be constructed using a [`Backend`] instance and a tree name.  The tree name
+//! allows for multiple trees to be stored under the same set of tables.
+//!
+//! For example, an instance using SQLite:
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use transact::state::merkle::sql::SqlMerkleStateBuilder;
+//! # use transact::state::merkle::sql::migration::MigrationManager;
+//! # use transact::state::merkle::sql::backend::{Backend, SqliteBackendBuilder};
+//! let backend = SqliteBackendBuilder::new().with_memory_database().build()?;
+//! # backend.run_migrations()?;
+//!
+//! let merkle_state = SqlMerkleStateBuilder::new()
+//!     .with_backend(backend)
+//!     .with_tree("example")
+//!     .create_tree_if_necessary()
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The resulting `merkle_state` can then be used via the [`Read`], [`Write`] and
+//! [`MerkleRadixLeafReader`] traits.
 
 pub mod backend;
 mod error;

--- a/libtransact/src/state/merkle/sql/models/mod.rs
+++ b/libtransact/src/state/merkle/sql/models/mod.rs
@@ -22,10 +22,27 @@ use super::schema::*;
 
 #[derive(Insertable, Queryable, Identifiable)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_tree"]
+#[primary_key(id)]
+pub struct MerkleRadixTree {
+    pub id: i64,
+    pub name: String,
+}
+
+#[derive(Insertable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_tree"]
+pub struct NewMerkleRadixTree<'a> {
+    pub name: &'a str,
+}
+
+#[derive(Insertable, Queryable, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 #[table_name = "merkle_radix_leaf"]
 #[primary_key(id)]
 pub struct MerkleRadixLeaf {
     pub id: i64,
+    pub tree_id: i64,
     pub address: String,
     pub data: Vec<u8>,
 }
@@ -35,6 +52,7 @@ pub struct MerkleRadixLeaf {
 #[table_name = "merkle_radix_leaf"]
 pub struct NewMerkleRadixLeaf<'a> {
     pub id: i64,
+    pub tree_id: i64,
     pub address: &'a str,
     pub data: &'a [u8],
 }
@@ -42,9 +60,10 @@ pub struct NewMerkleRadixLeaf<'a> {
 #[derive(Insertable, Queryable, QueryableByName, Identifiable)]
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[table_name = "merkle_radix_tree_node"]
-#[primary_key(hash)]
+#[primary_key(hash, tree_id)]
 pub struct MerkleRadixTreeNode {
     pub hash: String,
+    pub tree_id: i64,
     pub leaf_id: Option<i64>,
     pub children: Children,
 }
@@ -61,6 +80,7 @@ pub struct Children(pub Vec<Option<String>>);
 #[primary_key(id)]
 pub struct MerkleRadixStateRoot {
     pub id: i64,
+    pub tree_id: i64,
     pub state_root: String,
     pub parent_state_root: String,
 }
@@ -69,6 +89,7 @@ pub struct MerkleRadixStateRoot {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[table_name = "merkle_radix_state_root"]
 pub struct NewMerkleRadixStateRoot<'a> {
+    pub tree_id: i64,
     pub state_root: &'a str,
     pub parent_state_root: &'a str,
 }
@@ -79,6 +100,7 @@ pub struct NewMerkleRadixStateRoot<'a> {
 #[primary_key(id)]
 pub struct MerkleRadixStateRootLeafIndexEntry {
     pub id: i64,
+    pub tree_id: i64,
     pub leaf_id: i64,
     pub from_state_root_id: i64,
     pub to_state_root_id: Option<i64>,

--- a/libtransact/src/state/merkle/sql/operations/get_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_leaves.rs
@@ -28,6 +28,7 @@ use super::MerkleRadixOperations;
 pub trait MerkleRadixGetLeavesOperation {
     fn get_leaves(
         &self,
+        tree_id: i64,
         state_root_hash: &str,
         addresses: Vec<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
@@ -42,6 +43,7 @@ where
 {
     fn get_leaves(
         &self,
+        tree_id: i64,
         state_root_hash: &str,
         addresses: Vec<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
@@ -49,7 +51,11 @@ where
             .transaction::<_, diesel::result::Error, _>(|| {
                 let mut results = vec![];
                 let state_root_id = merkle_radix_state_root::table
-                    .filter(merkle_radix_state_root::state_root.eq(state_root_hash))
+                    .filter(
+                        merkle_radix_state_root::tree_id
+                            .eq(tree_id)
+                            .and(merkle_radix_state_root::state_root.eq(state_root_hash)),
+                    )
                     .select(merkle_radix_state_root::id)
                     .get_result::<i64>(self.conn)?;
 
@@ -59,6 +65,7 @@ where
                         .filter(
                             merkle_radix_leaf::address
                                 .eq(address)
+                                .and(merkle_radix_state_root_leaf_index::tree_id.eq(tree_id))
                                 .and(
                                     merkle_radix_state_root_leaf_index::from_state_root_id
                                         .le(state_root_id),
@@ -141,6 +148,7 @@ mod test {
 
         // update the index
         operations.update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -160,6 +168,7 @@ mod test {
             .execute(&conn)?;
 
         operations.update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -168,15 +177,15 @@ mod test {
             }],
         )?;
 
-        let leaves = operations.get_leaves("initial-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
         assert!(leaves.is_empty());
 
-        let leaves = operations.get_leaves("first-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");
 
-        let leaves = operations.get_leaves("second-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "second-state-root", vec!["aabbcc"])?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"goodbye");
@@ -218,6 +227,7 @@ mod test {
 
         // update the index
         operations.update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -228,20 +238,21 @@ mod test {
 
         // insert the changed leaf
         operations.update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::Deleted("aabbcc")],
         )?;
 
-        let leaves = operations.get_leaves("initial-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
         assert!(leaves.is_empty());
 
-        let leaves = operations.get_leaves("first-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");
 
-        let leaves = operations.get_leaves("second-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "second-state-root", vec!["aabbcc"])?;
         assert!(leaves.is_empty());
 
         Ok(())
@@ -281,6 +292,7 @@ mod test {
 
         // update the index
         operations.update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -300,6 +312,7 @@ mod test {
             .execute(&conn)?;
 
         operations.update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -308,15 +321,15 @@ mod test {
             }],
         )?;
 
-        let leaves = operations.get_leaves("initial-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
         assert!(leaves.is_empty());
 
-        let leaves = operations.get_leaves("first-state-root", vec!["aabbcc"])?;
+        let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");
 
-        let leaves = operations.get_leaves("second-state-root", vec!["112233", "aabbcc"])?;
+        let leaves = operations.get_leaves(1, "second-state-root", vec!["112233", "aabbcc"])?;
         assert_eq!(leaves.len(), 2);
         assert_eq!(leaves[0].0, "112233");
         assert_eq!(leaves[0].1, b"goodbye");

--- a/libtransact/src/state/merkle/sql/operations/get_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_leaves.rs
@@ -123,6 +123,7 @@ mod test {
         // insert the initial root:
         insert_into(merkle_radix_state_root::table)
             .values((
+                merkle_radix_state_root::tree_id.eq(1),
                 merkle_radix_state_root::state_root.eq("initial-state-root"),
                 merkle_radix_state_root::parent_state_root.eq(""),
             ))
@@ -132,6 +133,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -151,6 +153,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 2,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"goodbye".to_vec(),
             })
@@ -197,6 +200,7 @@ mod test {
         // insert the initial root:
         insert_into(merkle_radix_state_root::table)
             .values((
+                merkle_radix_state_root::tree_id.eq(1),
                 merkle_radix_state_root::state_root.eq("initial-state-root"),
                 merkle_radix_state_root::parent_state_root.eq(""),
             ))
@@ -206,6 +210,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -258,6 +263,7 @@ mod test {
         // insert the initial root:
         insert_into(merkle_radix_state_root::table)
             .values((
+                merkle_radix_state_root::tree_id.eq(1),
                 merkle_radix_state_root::state_root.eq("initial-state-root"),
                 merkle_radix_state_root::parent_state_root.eq(""),
             ))
@@ -267,6 +273,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -286,6 +293,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 2,
+                tree_id: 1,
                 address: "112233".into(),
                 data: b"goodbye".to_vec(),
             })

--- a/libtransact/src/state/merkle/sql/operations/get_or_create_tree.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_or_create_tree.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::dsl::{insert_into, select};
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::models::NewMerkleRadixTree;
+use crate::state::merkle::sql::schema::merkle_radix_tree;
+
+use super::{last_insert_rowid, MerkleRadixOperations};
+
+pub trait MerkleRadixGetOrCreateTreeOperation {
+    fn get_or_create_tree(&self, tree_name: &str) -> Result<i64, InternalError>;
+}
+
+impl<'a> MerkleRadixGetOrCreateTreeOperation for MerkleRadixOperations<'a, SqliteConnection> {
+    fn get_or_create_tree(&self, tree_name: &str) -> Result<i64, InternalError> {
+        self.conn.transaction::<_, InternalError, _>(|| {
+            if let Some(tree_id) = merkle_radix_tree::table
+                .filter(merkle_radix_tree::name.eq(tree_name))
+                .select(merkle_radix_tree::id)
+                .get_result(self.conn)
+                .optional()
+                .map_err(|e| InternalError::from_source(Box::new(e)))?
+            {
+                return Ok(tree_id);
+            }
+
+            insert_into(merkle_radix_tree::table)
+                .values(NewMerkleRadixTree { name: tree_name })
+                .execute(self.conn)?;
+
+            select(last_insert_rowid)
+                .get_result::<i64>(self.conn)
+                .map_err(|e| InternalError::from_source(Box::new(e)))
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+
+    /// This tests that a tree id can be returned from its name.
+    #[test]
+    fn test_get_tree_id_by_name() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        let id = operations.get_or_create_tree("test")?;
+        assert_eq!(2, id);
+
+        let id = operations.get_or_create_tree("default")?;
+        assert_eq!(1, id);
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/get_path.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_path.rs
@@ -51,6 +51,7 @@ struct ExtendedMerkleRadixTreeNode {
 pub trait MerkleRadixGetPathOperation {
     fn get_path(
         &self,
+        tree_id: i64,
         state_root_hash: &str,
         address: &str,
     ) -> Result<Vec<(String, Node)>, InternalError>;
@@ -60,10 +61,10 @@ pub trait MerkleRadixGetPathOperation {
 impl<'a> MerkleRadixGetPathOperation for MerkleRadixOperations<'a, SqliteConnection> {
     fn get_path(
         &self,
+        tree_id: i64,
         state_root_hash: &str,
         address: &str,
     ) -> Result<Vec<(String, Node)>, InternalError> {
-        let tree_id: i64 = 1;
         let address_bytes =
             hex::decode(address).map_err(|e| InternalError::from_source(Box::new(e)))?;
         let path = sql_query(
@@ -152,7 +153,7 @@ mod sqlite_tests {
 
         run_migrations(&conn)?;
 
-        let path = MerkleRadixOperations::new(&conn).get_path("state-root", "aabbcc")?;
+        let path = MerkleRadixOperations::new(&conn).get_path(1, "state-root", "aabbcc")?;
 
         assert!(path.is_empty());
 
@@ -208,7 +209,7 @@ mod sqlite_tests {
             ])
             .execute(&conn)?;
 
-        let path = MerkleRadixOperations::new(&conn).get_path("root-hash", "000000")?;
+        let path = MerkleRadixOperations::new(&conn).get_path(1, "root-hash", "000000")?;
 
         assert_eq!(
             path,
@@ -245,7 +246,7 @@ mod sqlite_tests {
         );
 
         // verify that a path that doesn't exist returns just the intermediate nodes.
-        let path = MerkleRadixOperations::new(&conn).get_path("root-hash", "000001")?;
+        let path = MerkleRadixOperations::new(&conn).get_path(1, "root-hash", "000001")?;
 
         assert_eq!(
             path,
@@ -275,7 +276,7 @@ mod sqlite_tests {
         );
 
         // verify that a path that is completely non-existent only returns the root node.
-        let path = MerkleRadixOperations::new(&conn).get_path("root-hash", "aabbcc")?;
+        let path = MerkleRadixOperations::new(&conn).get_path(1, "root-hash", "aabbcc")?;
 
         assert_eq!(
             path,

--- a/libtransact/src/state/merkle/sql/operations/get_tree_by_name.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_tree_by_name.rs
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::schema::merkle_radix_tree;
+
+use super::MerkleRadixOperations;
+
+pub trait MerkleRadixGetTreeByNameOperation {
+    fn get_tree_id_by_name(&self, tree_name: &str) -> Result<Option<i64>, InternalError>;
+}
+
+impl<'a, C> MerkleRadixGetTreeByNameOperation for MerkleRadixOperations<'a, C>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    fn get_tree_id_by_name(&self, tree_name: &str) -> Result<Option<i64>, InternalError> {
+        merkle_radix_tree::table
+            .filter(merkle_radix_tree::name.eq(tree_name))
+            .select(merkle_radix_tree::id)
+            .get_result(self.conn)
+            .optional()
+            .map_err(|e| InternalError::from_source(Box::new(e)))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::state::merkle::sql::migration::sqlite::run_migrations;
+    use crate::state::merkle::sql::models::NewMerkleRadixTree;
+    use diesel::dsl::insert_into;
+
+    /// This tests that a tree id can be returned from its name.
+    #[test]
+    fn test_get_tree_id_by_name() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+        run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        let id_opt = operations.get_tree_id_by_name("test")?;
+        assert_eq!(None, id_opt);
+
+        let id_opt = operations.get_tree_id_by_name("default")?;
+        assert_eq!(Some(1), id_opt);
+
+        insert_into(merkle_radix_tree::table)
+            .values(NewMerkleRadixTree { name: "test" })
+            .execute(&conn)?;
+
+        let id_opt = operations.get_tree_id_by_name("test")?;
+        assert_eq!(Some(2), id_opt);
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/operations/has_root.rs
+++ b/libtransact/src/state/merkle/sql/operations/has_root.rs
@@ -25,7 +25,7 @@ use crate::state::merkle::sql::schema::merkle_radix_tree_node;
 use super::MerkleRadixOperations;
 
 pub trait MerkleRadixHasRootOperation {
-    fn has_root(&self, state_root_hash: &str) -> Result<bool, InternalError>;
+    fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError>;
 }
 
 impl<'a, C> MerkleRadixHasRootOperation for MerkleRadixOperations<'a, C>
@@ -34,10 +34,12 @@ where
     C::Backend: diesel::sql_types::HasSqlType<diesel::sql_types::Bool>,
     bool: diesel::deserialize::FromSql<diesel::sql_types::Bool, C::Backend>,
 {
-    fn has_root(&self, state_root_hash: &str) -> Result<bool, InternalError> {
-        select(exists(merkle_radix_tree_node::table.find(state_root_hash)))
-            .get_result::<bool>(self.conn)
-            .map_err(|e| InternalError::from_source(Box::new(e)))
+    fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError> {
+        select(exists(
+            merkle_radix_tree_node::table.find((state_root_hash, tree_id)),
+        ))
+        .get_result::<bool>(self.conn)
+        .map_err(|e| InternalError::from_source(Box::new(e)))
     }
 }
 
@@ -59,7 +61,7 @@ mod tests {
         run_migrations(&conn)?;
 
         // Does not exist
-        assert!(!MerkleRadixOperations::new(&conn).has_root("initial-state-root")?);
+        assert!(!MerkleRadixOperations::new(&conn).has_root(1, "initial-state-root")?);
 
         // insert the root only into the tree:
         insert_into(merkle_radix_tree_node::table)
@@ -71,7 +73,7 @@ mod tests {
             })
             .execute(&conn)?;
 
-        assert!(MerkleRadixOperations::new(&conn).has_root("initial-state-root")?);
+        assert!(MerkleRadixOperations::new(&conn).has_root(1, "initial-state-root")?);
 
         Ok(())
     }

--- a/libtransact/src/state/merkle/sql/operations/has_root.rs
+++ b/libtransact/src/state/merkle/sql/operations/has_root.rs
@@ -65,6 +65,7 @@ mod tests {
         insert_into(merkle_radix_tree_node::table)
             .values(MerkleRadixTreeNode {
                 hash: "initial-state-root".into(),
+                tree_id: 1,
                 leaf_id: None,
                 children: Children(vec![]),
             })

--- a/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
+++ b/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
@@ -70,6 +70,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, SqliteCon
                             id: initial_id.checked_add(1 + i as i64).ok_or_else(|| {
                                 InternalError::with_message("exceeded id space".into())
                             })?,
+                            tree_id: 1,
                             address: &insertable_node.address,
                             data,
                         })
@@ -94,6 +95,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, SqliteCon
                 .map::<Result<MerkleRadixTreeNode, InternalError>, _>(|insertable_node| {
                     Ok(MerkleRadixTreeNode {
                         hash: insertable_node.hash.clone(),
+                        tree_id: 1,
                         leaf_id: leaf_ids.get(insertable_node.address.as_str()).copied(),
                         children: node_to_children(&insertable_node.node)?,
                     })
@@ -182,6 +184,7 @@ mod tests {
             nodes[0],
             MerkleRadixTreeNode {
                 hash: "initial-state-root".into(),
+                tree_id: 1,
                 leaf_id: None,
                 children: Children(vec![None; 256]),
             }
@@ -258,21 +261,25 @@ mod tests {
             vec![
                 MerkleRadixTreeNode {
                     hash: "state-root".into(),
+                    tree_id: 1,
                     leaf_id: None,
                     children: single_child(10, "first-node-hash"),
                 },
                 MerkleRadixTreeNode {
                     hash: "first-node-hash".into(),
+                    tree_id: 1,
                     leaf_id: None,
                     children: single_child(1, "second-node-hash"),
                 },
                 MerkleRadixTreeNode {
                     hash: "second-node-hash".into(),
+                    tree_id: 1,
                     leaf_id: None,
                     children: single_child(255, "leaf-node-hash"),
                 },
                 MerkleRadixTreeNode {
                     hash: "leaf-node-hash".into(),
+                    tree_id: 1,
                     leaf_id: Some(leaves[0].id),
                     children: Children(vec![None; 256])
                 },

--- a/libtransact/src/state/merkle/sql/operations/list_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/list_leaves.rs
@@ -121,6 +121,7 @@ mod test {
         // insert the initial root:
         insert_into(merkle_radix_state_root::table)
             .values((
+                merkle_radix_state_root::tree_id.eq(1),
                 merkle_radix_state_root::state_root.eq("initial-state-root"),
                 merkle_radix_state_root::parent_state_root.eq(""),
             ))
@@ -130,6 +131,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -149,6 +151,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 2,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"goodbye".to_vec(),
             })
@@ -195,6 +198,7 @@ mod test {
         // insert the initial root:
         insert_into(merkle_radix_state_root::table)
             .values((
+                merkle_radix_state_root::tree_id.eq(1),
                 merkle_radix_state_root::state_root.eq("initial-state-root"),
                 merkle_radix_state_root::parent_state_root.eq(""),
             ))
@@ -204,6 +208,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -257,6 +262,7 @@ mod test {
         // insert the initial root:
         insert_into(merkle_radix_state_root::table)
             .values((
+                merkle_radix_state_root::tree_id.eq(1),
                 merkle_radix_state_root::state_root.eq("initial-state-root"),
                 merkle_radix_state_root::parent_state_root.eq(""),
             ))
@@ -266,6 +272,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -285,6 +292,7 @@ mod test {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 2,
+                tree_id: 1,
                 address: "112233".into(),
                 data: b"goodbye".to_vec(),
             })

--- a/libtransact/src/state/merkle/sql/operations/list_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/list_leaves.rs
@@ -28,6 +28,7 @@ use super::MerkleRadixOperations;
 pub trait MerkleRadixListLeavesOperation {
     fn list_leaves(
         &self,
+        tree_id: i64,
         state_root_hash: &str,
         prefix: Option<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
@@ -42,13 +43,18 @@ where
 {
     fn list_leaves(
         &self,
+        tree_id: i64,
         state_root_hash: &str,
         prefix: Option<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
         self.conn
             .transaction::<_, diesel::result::Error, _>(|| {
                 let state_root_id = merkle_radix_state_root::table
-                    .filter(merkle_radix_state_root::state_root.eq(state_root_hash))
+                    .filter(
+                        merkle_radix_state_root::state_root
+                            .eq(state_root_hash)
+                            .and(merkle_radix_state_root::tree_id.eq(tree_id)),
+                    )
                     .select(merkle_radix_state_root::id)
                     .get_result::<i64>(self.conn)?;
 
@@ -57,6 +63,7 @@ where
                     .filter(
                         merkle_radix_state_root_leaf_index::from_state_root_id
                             .le(state_root_id)
+                            .and(merkle_radix_state_root_leaf_index::tree_id.eq(tree_id))
                             .and(
                                 merkle_radix_state_root_leaf_index::to_state_root_id
                                     .is_null()
@@ -139,6 +146,7 @@ mod test {
 
         // update the index
         operations.update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -158,6 +166,7 @@ mod test {
             .execute(&conn)?;
 
         operations.update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -166,15 +175,15 @@ mod test {
             }],
         )?;
 
-        let leaves = operations.list_leaves("initial-state-root", None)?;
+        let leaves = operations.list_leaves(1, "initial-state-root", None)?;
         assert!(leaves.is_empty());
 
-        let leaves = operations.list_leaves("first-state-root", None)?;
+        let leaves = operations.list_leaves(1, "first-state-root", None)?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");
 
-        let leaves = operations.list_leaves("second-state-root", None)?;
+        let leaves = operations.list_leaves(1, "second-state-root", None)?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"goodbye");
@@ -216,6 +225,7 @@ mod test {
 
         // update the index
         operations.update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -226,20 +236,21 @@ mod test {
 
         // insert the changed leaf
         operations.update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::Deleted("aabbcc")],
         )?;
 
-        let leaves = operations.list_leaves("initial-state-root", None)?;
+        let leaves = operations.list_leaves(1, "initial-state-root", None)?;
         assert!(leaves.is_empty());
 
-        let leaves = operations.list_leaves("first-state-root", None)?;
+        let leaves = operations.list_leaves(1, "first-state-root", None)?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");
 
-        let leaves = operations.list_leaves("second-state-root", None)?;
+        let leaves = operations.list_leaves(1, "second-state-root", None)?;
         assert!(leaves.is_empty());
 
         Ok(())
@@ -280,6 +291,7 @@ mod test {
 
         // update the index
         operations.update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -299,6 +311,7 @@ mod test {
             .execute(&conn)?;
 
         operations.update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -307,15 +320,15 @@ mod test {
             }],
         )?;
 
-        let leaves = operations.list_leaves("initial-state-root", None)?;
+        let leaves = operations.list_leaves(1, "initial-state-root", None)?;
         assert!(leaves.is_empty());
 
-        let leaves = operations.list_leaves("first-state-root", None)?;
+        let leaves = operations.list_leaves(1, "first-state-root", None)?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");
 
-        let leaves = operations.list_leaves("second-state-root", None)?;
+        let leaves = operations.list_leaves(1, "second-state-root", None)?;
         assert_eq!(leaves.len(), 2);
         assert_eq!(leaves[0].0, "112233");
         assert_eq!(leaves[0].1, b"goodbye");
@@ -323,7 +336,7 @@ mod test {
         assert_eq!(leaves[1].1, b"hello");
 
         // Test with a prefix
-        let leaves = operations.list_leaves("second-state-root", Some("aa"))?;
+        let leaves = operations.list_leaves(1, "second-state-root", Some("aa"))?;
         assert_eq!(leaves.len(), 1);
         assert_eq!(leaves[0].0, "aabbcc");
         assert_eq!(leaves[0].1, b"hello");

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -16,7 +16,9 @@
  */
 
 pub(super) mod get_leaves;
+pub(super) mod get_or_create_tree;
 pub(super) mod get_path;
+pub(super) mod get_tree_by_name;
 pub(super) mod has_root;
 pub(super) mod insert_nodes;
 pub(super) mod list_leaves;

--- a/libtransact/src/state/merkle/sql/operations/update_index.rs
+++ b/libtransact/src/state/merkle/sql/operations/update_index.rs
@@ -45,6 +45,7 @@ impl<'data> ChangedLeaf<'data> {
 pub trait MerkleRadixUpdateIndexOperation {
     fn update_index(
         &self,
+        tree_id: i64,
         state_root: &str,
         parent_state_root: &str,
         changed_addresses: Vec<ChangedLeaf>,
@@ -55,11 +56,11 @@ pub trait MerkleRadixUpdateIndexOperation {
 impl<'a> MerkleRadixUpdateIndexOperation for MerkleRadixOperations<'a, SqliteConnection> {
     fn update_index(
         &self,
+        tree_id: i64,
         state_root: &str,
         parent_state_root: &str,
         changed_addresses: Vec<ChangedLeaf>,
     ) -> Result<(), InternalError> {
-        let tree_id: i64 = 1;
         self.conn
             .transaction::<_, diesel::result::Error, _>(|| {
                 let fork = merkle_radix_state_root::table
@@ -176,6 +177,7 @@ mod sqlite_tests {
             .execute(&conn)?;
 
         MerkleRadixOperations::new(&conn).update_index(
+            1,
             "new-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -227,6 +229,7 @@ mod sqlite_tests {
 
         // update the index
         MerkleRadixOperations::new(&conn).update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -249,6 +252,7 @@ mod sqlite_tests {
             .execute(&conn)?;
 
         MerkleRadixOperations::new(&conn).update_index(
+            1,
             "second-state-root",
             "first-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -311,6 +315,7 @@ mod sqlite_tests {
 
         // update the index
         MerkleRadixOperations::new(&conn).update_index(
+            1,
             "first-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {
@@ -335,6 +340,7 @@ mod sqlite_tests {
         // update the index as if it's transition from the initial state root again (i.e.
         // a new forked tree)
         MerkleRadixOperations::new(&conn).update_index(
+            1,
             "second-state-root",
             "initial-state-root",
             vec![ChangedLeaf::AddedOrUpdated {

--- a/libtransact/src/state/merkle/sql/operations/update_index.rs
+++ b/libtransact/src/state/merkle/sql/operations/update_index.rs
@@ -59,6 +59,7 @@ impl<'a> MerkleRadixUpdateIndexOperation for MerkleRadixOperations<'a, SqliteCon
         parent_state_root: &str,
         changed_addresses: Vec<ChangedLeaf>,
     ) -> Result<(), InternalError> {
+        let tree_id: i64 = 1;
         self.conn
             .transaction::<_, diesel::result::Error, _>(|| {
                 let fork = merkle_radix_state_root::table
@@ -89,6 +90,7 @@ impl<'a> MerkleRadixUpdateIndexOperation for MerkleRadixOperations<'a, SqliteCon
 
                 insert_into(merkle_radix_state_root::table)
                     .values(NewMerkleRadixStateRoot {
+                        tree_id,
                         state_root,
                         parent_state_root,
                     })
@@ -124,6 +126,7 @@ impl<'a> MerkleRadixUpdateIndexOperation for MerkleRadixOperations<'a, SqliteCon
                             .filter(|change| matches!(change, ChangedLeaf::AddedOrUpdated { .. }))
                             .map(|change| match change {
                                 ChangedLeaf::AddedOrUpdated { leaf_id, .. } => (
+                                    merkle_radix_state_root_leaf_index::tree_id.eq(tree_id),
                                     merkle_radix_state_root_leaf_index::leaf_id.eq(leaf_id),
                                     merkle_radix_state_root_leaf_index::from_state_root_id
                                         .eq(state_root_id),
@@ -166,6 +169,7 @@ mod sqlite_tests {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -215,6 +219,7 @@ mod sqlite_tests {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -237,6 +242,7 @@ mod sqlite_tests {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 2,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"goodbye".to_vec(),
             })
@@ -297,6 +303,7 @@ mod sqlite_tests {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 1,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"hello".to_vec(),
             })
@@ -319,6 +326,7 @@ mod sqlite_tests {
         insert_into(merkle_radix_leaf::table)
             .values(MerkleRadixLeaf {
                 id: 2,
+                tree_id: 1,
                 address: "aabbcc".into(),
                 data: b"goodbye".to_vec(),
             })

--- a/libtransact/src/state/merkle/sql/schema.rs
+++ b/libtransact/src/state/merkle/sql/schema.rs
@@ -17,18 +17,26 @@
 
 // Due to schema differences, this may have to be under a submodule specific to sqlite or postgres
 // (or other array-supporting dbs). This may only be the case with the merkle_radix_leaf table.
+table! {
+    merkle_radix_tree (id) {
+        id -> Int8,
+        name -> VarChar,
+    }
+}
 
 table! {
     merkle_radix_leaf (id) {
         id -> Int8,
+        tree_id -> Int8,
         address -> VarChar,
         data -> Blob,
     }
 }
 
 table! {
-    merkle_radix_tree_node (hash) {
+    merkle_radix_tree_node (hash, tree_id) {
         hash -> VarChar,
+        tree_id -> Int8,
         leaf_id -> Nullable<Int8>,
         // JSON children
         children -> Text,
@@ -38,6 +46,7 @@ table! {
 table! {
     merkle_radix_state_root (id) {
         id -> Int8,
+        tree_id -> Int8,
         state_root -> VarChar,
         parent_state_root -> VarChar,
     }
@@ -46,6 +55,7 @@ table! {
 table! {
     merkle_radix_state_root_leaf_index (id) {
         id -> Int8,
+        tree_id -> Int8,
         leaf_id -> Int8,
         from_state_root_id -> Int8,
         to_state_root_id -> Nullable<Int8>,
@@ -55,6 +65,7 @@ table! {
 joinable!(merkle_radix_state_root_leaf_index -> merkle_radix_leaf (leaf_id));
 
 allow_tables_to_appear_in_same_query!(
+    merkle_radix_tree,
     merkle_radix_leaf,
     merkle_radix_tree_node,
     merkle_radix_state_root,


### PR DESCRIPTION
This PR updates the SqlMerkleState to support the use of multiple trees in a single backend.  This is accomplished by introducing a `merkle_radix_tree` table and added a `tree_id` reference to the existing tables.  `SqlMerkleState` structs must now be constructed via a builder.