### PR TITLE
SQL merkle state with postgres backend

### DIFF
--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -22,6 +22,8 @@ mod sqlite;
 
 use crate::error::InternalError;
 
+#[cfg(feature = "state-merkle-sql-postgres-tests")]
+pub use postgres::test::run_postgres_test;
 #[cfg(feature = "postgres")]
 pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
 #[cfg(feature = "sqlite")]

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -22,6 +22,8 @@ mod sqlite;
 
 use crate::error::InternalError;
 
+#[cfg(feature = "postgres")]
+pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
 #[cfg(feature = "sqlite")]
 pub use sqlite::{JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection, Synchronous};
 

--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -15,6 +15,95 @@
  * -----------------------------------------------------------------------------
  */
 
+use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
+
+use crate::error::{InternalError, InvalidStateError};
+
+use super::{Backend, Connection};
+
+pub struct PostgresConnection(
+    pub(in crate::state::merkle::sql) PooledConnection<ConnectionManager<diesel::pg::PgConnection>>,
+);
+
+impl Connection for PostgresConnection {
+    type ConnectionType = diesel::pg::PgConnection;
+
+    fn as_inner(&self) -> &Self::ConnectionType {
+        &*self.0
+    }
+}
+
+/// The Postgres Backend
+///
+/// This struct provides the backend implementation details for postgres databases.
+#[derive(Clone)]
+pub struct PostgresBackend {
+    connection_pool: Pool<ConnectionManager<diesel::pg::PgConnection>>,
+}
+
+impl Backend for PostgresBackend {
+    type Connection = PostgresConnection;
+
+    fn connection(&self) -> Result<Self::Connection, InternalError> {
+        self.connection_pool
+            .get()
+            .map(PostgresConnection)
+            .map_err(|err| InternalError::from_source(Box::new(err)))
+    }
+}
+
+/// A Builder for the PostgresBackend.
+#[derive(Default)]
+pub struct PostgresBackendBuilder {
+    url: Option<String>,
+}
+
+impl PostgresBackendBuilder {
+    /// Constructs a new builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the URL for the postgres database instance.
+    ///
+    /// This URL should follow the format as documented at
+    /// [https://www.postgresql.org/docs/9.4/libpq-connect.html#LIBPQ-CONNSTRING](https://www.postgresql.org/docs/9.4/libpq-connect.html#LIBPQ-CONNSTRING).
+    ///
+    /// This is a required field.
+    pub fn with_url<S: Into<String>>(mut self, url: S) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    /// Constructs the [PostgresBackend] instance.
+    ///
+    /// # Errors
+    ///
+    /// This may return a [InvalidStateError] for a variety of reasons:
+    ///
+    /// * No URL provided
+    /// * Unable to connect to the database.
+    pub fn build(self) -> Result<PostgresBackend, InvalidStateError> {
+        let url = self.url.ok_or_else(|| {
+            InvalidStateError::with_message("must provide a postgres connection URL".into())
+        })?;
+
+        let connection_manager = ConnectionManager::<diesel::pg::PgConnection>::new(url);
+        let pool = Pool::builder()
+            .build(connection_manager)
+            .map_err(|err| InvalidStateError::with_message(err.to_string()))?;
+
+        // Validate that connections can be made
+        let _conn = pool
+            .get()
+            .map_err(|err| InvalidStateError::with_message(err.to_string()))?;
+
+        Ok(PostgresBackend {
+            connection_pool: pool,
+        })
+    }
+}
+
 #[cfg(feature = "state-merkle-sql-postgres-tests")]
 #[cfg(test)]
 pub mod test {

--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -105,7 +105,6 @@ impl PostgresBackendBuilder {
 }
 
 #[cfg(feature = "state-merkle-sql-postgres-tests")]
-#[cfg(test)]
 pub mod test {
     use std::env;
     use std::error::Error;

--- a/libtransact/src/state/merkle/sql/migration/postgres/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/postgres/mod.rs
@@ -20,6 +20,9 @@
 embed_migrations!("./src/state/merkle/sql/migration/postgres/migrations");
 
 use crate::error::InternalError;
+use crate::state::merkle::sql::backend::{Backend, Connection, PostgresBackend};
+
+use super::MigrationManager;
 
 /// Run database migrations to create tables defined for the SqlMerkleState.
 ///
@@ -34,4 +37,10 @@ pub fn run_migrations(conn: &diesel::pg::PgConnection) -> Result<(), InternalErr
     info!("Successfully applied PostgreSQL migrations");
 
     Ok(())
+}
+
+impl MigrationManager for PostgresBackend {
+    fn run_migrations(&self) -> Result<(), InternalError> {
+        run_migrations(self.connection()?.as_inner())
+    }
 }

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -149,6 +149,42 @@ impl SqlMerkleStateBuilder<backend::SqliteBackend> {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl SqlMerkleStateBuilder<backend::PostgresBackend> {
+    /// Construct the final SqlMerkleState instance
+    ///
+    /// # Errors
+    ///
+    /// An error may be returned under the following circumstances:
+    /// * If a Backend has not been provided
+    /// * If a tree name has not been provided
+    /// * If an internal error occurs while trying to create or lookup the tree
+    pub fn build(
+        self,
+    ) -> Result<SqlMerkleState<backend::PostgresBackend>, SqlMerkleStateBuildError> {
+        let backend = self
+            .backend
+            .ok_or_else(|| InvalidStateError::with_message("must provide a backend".into()))?;
+
+        let tree_name = self
+            .tree_name
+            .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
+
+        let conn = backend.connection()?;
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+
+        let tree_id: i64 = if self.create_tree {
+            operations.get_or_create_tree(&tree_name)?
+        } else {
+            operations.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
+                InvalidStateError::with_message("must provide the name of an existing tree".into())
+            })?
+        };
+
+        Ok(SqlMerkleState { backend, tree_id })
+    }
+}
+
 /// SqlMerkleState provides a merkle-radix implementation over a SQL database.
 ///
 /// Databases are implemented using a Backend to provide connections. Note that the database must
@@ -250,6 +286,86 @@ impl Read for SqlMerkleState<backend::SqliteBackend> {
     }
 }
 
+#[cfg(feature = "postgres")]
+impl Write for SqlMerkleState<backend::PostgresBackend> {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        let overlay =
+            MerkleRadixOverlay::new(self.tree_id, &*state_id, SqlOverlay::new(&self.backend));
+
+        let (next_state_id, changes) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+
+        let deleted_addresses = state_changes
+            .iter()
+            .filter(|change| matches!(change, StateChange::Delete { .. }))
+            .map(|change| change.key())
+            .collect::<Vec<_>>();
+
+        overlay
+            .write_updates(&next_state_id, changes, &deleted_addresses)
+            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+
+        Ok(next_state_id)
+    }
+
+    fn compute_state_id(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        let overlay =
+            MerkleRadixOverlay::new(self.tree_id, &*state_id, SqlOverlay::new(&self.backend));
+
+        let (next_state_id, _) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
+
+        Ok(next_state_id)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl Read for SqlMerkleState<backend::PostgresBackend> {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
+        let overlay =
+            MerkleRadixOverlay::new(self.tree_id, &*state_id, SqlOverlay::new(&self.backend));
+
+        if !overlay
+            .has_root()
+            .map_err(|e| StateReadError::StorageError(Box::new(e)))?
+        {
+            return Err(StateReadError::InvalidStateId(state_id.into()));
+        }
+
+        overlay
+            .get_entries(keys)
+            .map_err(|e| StateReadError::StorageError(Box::new(e)))
+    }
+
+    fn clone_box(
+        &self,
+    ) -> Box<dyn Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>> {
+        Box::new(self.clone())
+    }
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
 #[cfg(feature = "state-merkle-leaf-reader")]
@@ -257,6 +373,32 @@ type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
 #[cfg(all(feature = "state-merkle-leaf-reader", feature = "sqlite"))]
 impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
+    /// Returns an iterator over the leaves of a merkle radix tree.
+    /// By providing an optional address prefix, the caller can limit the iteration
+    /// over the leaves in a specific subtree.
+    fn leaves(
+        &self,
+        state_id: &Self::StateId,
+        subtree: Option<&str>,
+    ) -> IterResult<LeafIter<(Self::Key, Self::Value)>> {
+        let conn = self.backend.connection()?;
+
+        if &self.initial_state_root_hash()? == state_id {
+            return Ok(Box::new(std::iter::empty()));
+        }
+
+        let leaves = MerkleRadixOperations::new(conn.as_inner()).list_leaves(
+            self.tree_id,
+            state_id,
+            subtree,
+        )?;
+
+        Ok(Box::new(leaves.into_iter().map(Ok)))
+    }
+}
+
+#[cfg(all(feature = "state-merkle-leaf-reader", feature = "postgres"))]
+impl MerkleRadixLeafReader for SqlMerkleState<backend::PostgresBackend> {
     /// Returns an iterator over the leaves of a merkle radix tree.
     /// By providing an optional address prefix, the caller can limit the iteration
     /// over the leaves in a specific subtree.
@@ -547,6 +689,87 @@ impl<'b> OverlayReader for SqlOverlay<'b, backend::SqliteBackend> {
 
 #[cfg(feature = "sqlite")]
 impl<'b> OverlayWriter for SqlOverlay<'b, backend::SqliteBackend> {
+    fn write_changes(
+        &self,
+        tree_id: i64,
+        state_root_hash: &str,
+        parent_state_root_hash: &str,
+        changes: Vec<(String, Node, String)>,
+        deleted_addresses: &[&str],
+    ) -> Result<(), InternalError> {
+        let conn = self.backend.connection()?;
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+
+        let insertable_changes = changes
+            .into_iter()
+            .map(
+                |(hash, node, address)| operations::insert_nodes::InsertableNode {
+                    hash,
+                    node,
+                    address,
+                },
+            )
+            .collect::<Vec<_>>();
+
+        let indexable_info = operations.insert_nodes(tree_id, &insertable_changes)?;
+
+        let changes = indexable_info
+            .iter()
+            .map(
+                |leaf_info| operations::update_index::ChangedLeaf::AddedOrUpdated {
+                    address: &leaf_info.address,
+                    leaf_id: leaf_info.leaf_id,
+                },
+            )
+            .chain(
+                deleted_addresses
+                    .iter()
+                    .map(|address| operations::update_index::ChangedLeaf::Deleted(address)),
+            )
+            .collect();
+
+        operations.update_index(tree_id, state_root_hash, parent_state_root_hash, changes)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'b> OverlayReader for SqlOverlay<'b, backend::PostgresBackend> {
+    fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError> {
+        let conn = self.backend.connection()?;
+
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.has_root(tree_id, state_root_hash)
+    }
+
+    fn get_path(
+        &self,
+        tree_id: i64,
+        state_root_hash: &str,
+        address: &str,
+    ) -> Result<Vec<(String, Node)>, InternalError> {
+        let conn = self.backend.connection()?;
+
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.get_path(tree_id, state_root_hash, address)
+    }
+
+    fn get_entries(
+        &self,
+        tree_id: i64,
+        state_root_hash: &str,
+        keys: Vec<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
+        let conn = self.backend.connection()?;
+
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.get_leaves(tree_id, state_root_hash, keys)
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'b> OverlayWriter for SqlOverlay<'b, backend::PostgresBackend> {
     fn write_changes(
         &self,
         tree_id: i64,

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -115,6 +115,7 @@ impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
     }
 }
 
+#[cfg(feature = "sqlite")]
 impl SqlMerkleStateBuilder<backend::SqliteBackend> {
     /// Construct the final SqlMerkleState instance
     ///
@@ -216,6 +217,7 @@ impl Write for SqlMerkleState<backend::SqliteBackend> {
     }
 }
 
+#[cfg(feature = "sqlite")]
 impl Read for SqlMerkleState<backend::SqliteBackend> {
     type StateId = String;
     type Key = String;

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -17,6 +17,8 @@ mod btree;
 mod lmdb;
 #[cfg(feature = "state-merkle-redis-db-tests")]
 mod redisdb;
+#[cfg(feature = "state-merkle-sql-postgres-tests")]
+mod sql_postgres;
 #[cfg(all(feature = "state-merkle-sql", feature = "sqlite"))]
 mod sql_sqlite;
 #[cfg(feature = "database-sqlite")]

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -1,0 +1,115 @@
+// Copyright 2021 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SQL-backed tests for the merkle state implementation
+
+use std::error::Error;
+
+use transact::state::merkle::sql::{
+    backend::{run_postgres_test, PostgresBackend, PostgresBackendBuilder},
+    SqlMerkleState, SqlMerkleStateBuilder,
+};
+use transact::{database::btree::BTreeDatabase, state::merkle::INDEXES};
+
+use super::*;
+
+fn new_sql_merkle_state_and_root(
+    db_url: &str,
+) -> Result<(SqlMerkleState<PostgresBackend>, String), Box<dyn Error>> {
+    let backend = PostgresBackendBuilder::new().with_url(db_url).build()?;
+
+    let state = SqlMerkleStateBuilder::new()
+        .with_backend(backend)
+        .with_tree("test-tree")
+        .create_tree_if_necessary()
+        .build()?;
+
+    let initial_state_root_hash = state.initial_state_root_hash()?;
+
+    Ok((state, initial_state_root_hash))
+}
+
+#[test]
+fn merkle_trie_empty_changes() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_empty_changes(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_delete() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_delete(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_update() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_update(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_update_same_address_space() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_update_same_address_space(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_update_same_address_space_with_no_children() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_update_same_address_space_with_no_children(orig_root, state);
+        Ok(())
+    })
+}
+
+#[cfg(feature = "state-merkle-leaf-reader")]
+#[test]
+fn leaf_iteration() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_leaf_iteration(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_produce_same_state_as_btree() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (sql_state, sql_orig_root) = new_sql_merkle_state_and_root(db_url)?;
+
+        let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
+        let btree_state = MerkleState::new(btree_db.clone());
+
+        let merkle_db = MerkleRadixTree::new(btree_db, None)
+            .expect("Could not overlay the merkle tree on the database");
+
+        let btree_orig_root = merkle_db.get_merkle_root();
+
+        test_produce_same_state(btree_orig_root, btree_state, sql_orig_root, sql_state);
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
This PR adds an implementation of state that applies a Merkle-Radix tree using a PostgresSQL database as its back-end. 

Continued development on the experimental feature described in [RFC 10](https://github.com/hyperledger/transact-rfcs/pull/10)