### PR TITLE
Fix struct and module doc for Sqlite backend

### DIFF
--- a/libtransact/src/state/merkle/sql/backend/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/backend/sqlite.rs
@@ -233,17 +233,16 @@ impl SqliteBackendBuilder {
         self
     }
 
-    /// Constructs the database instance.
+    /// Constructs the [SqliteBackend] instance.
     ///
     /// # Errors
     ///
-    /// This may return a InvalidStateError for a variety of reasons:
+    /// This may return a [InvalidStateError] for a variety of reasons:
     ///
     /// * No connection_path provided
     /// * Unable to connect to the database.
     /// * Unable to configure the provided memory map size
     /// * Unable to configure the journal mode, if requested
-    /// * Unable to create tables, as required.
     pub fn build(self) -> Result<SqliteBackend, InvalidStateError> {
         let path = self.connection_path.ok_or_else(|| {
             InvalidStateError::with_message("must provide a sqlite connection URI".into())

--- a/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
@@ -15,7 +15,7 @@
  * -----------------------------------------------------------------------------
  */
 
-//! Defines methods and utilities to interact with biome tables in a SQLite database.
+//! Defines methods and utilities to interact with merkle-radix tables in a SQLite database.
 
 embed_migrations!("./src/state/merkle/sql/migration/sqlite/migrations");
 
@@ -24,7 +24,7 @@ use crate::state::merkle::sql::backend::{Backend, Connection, SqliteBackend};
 
 use super::MigrationManager;
 
-/// Run database migrations to create tables defined by biome
+/// Run database migrations to create tables defined for the SqlMerkleState.
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
This change fixes the rust doc for the Sqlite backend as well as the migrations module.
