### PR TITLE
Replace checked_sub with saturating_sub

### DIFF
--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -350,10 +350,7 @@ impl WorkerBuilder {
                                 };
                                 submission_avg = Some(submission_time);
 
-                                let wait_time = match time_to_wait.checked_sub(submission_time) {
-                                    Some(dur) => dur,
-                                    None => time::Duration::from_nanos(0),
-                                };
+                                let wait_time = time_to_wait.saturating_sub(submission_time);
 
                                 thread::sleep(wait_time);
                                 submission_start = time::Instant::now();
@@ -605,10 +602,7 @@ pub fn submit_batches_from_source(
         };
         submission_avg = Some(submission_time);
 
-        let wait_time = match time_to_wait.checked_sub(submission_time) {
-            Some(dur) => dur,
-            None => time::Duration::from_nanos(0),
-        };
+        let wait_time = time_to_wait.saturating_sub(submission_time);
 
         thread::sleep(wait_time);
         submission_start = time::Instant::now();


### PR DESCRIPTION
When I originally wrote this I wanted to use saturating_sub because it
mapped nicely to the requirements but it was one version of Rust off.

Its now stable.

The code removed was copied from the saturating_sub pull request to the
std library so for now there is no real change at all. Going forward relying
on the std lib implementations is preferable to just using unpatched
code snippets copied from pull requests.

Signed-off-by: Caleb Hill <hill@bitwise.io>