### PR TITLE
BACKPORT fix lint introduced in Rust 1.54.0

### DIFF
--- a/examples/simple_xo/src/main.rs
+++ b/examples/simple_xo/src/main.rs
@@ -101,7 +101,7 @@ fn new_signer() -> Box<dyn Signer> {
 }
 
 fn print_current_state(value: &[u8]) -> &str {
-    let val = match str::from_utf8(&value) {
+    let val = match str::from_utf8(value) {
         Ok(v) => v,
         Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
     };

--- a/justfile
+++ b/justfile
@@ -43,7 +43,8 @@ build:
 clean:
     cargo clean
 
-lint: clean
+
+lint:
     #!/usr/bin/env sh
     set -e
     echo "\033[1mcargo fmt -- --check\033[0m"

--- a/libtransact/src/context/manager/mod.rs
+++ b/libtransact/src/context/manager/mod.rs
@@ -115,10 +115,10 @@ impl ContextManager {
             for context_id in context.base_contexts().iter() {
                 contexts.push_back(self.get_context(context_id)?);
             }
-            if !context.contains(&key) && !contexts.is_empty() {
+            if !context.contains(key) && !contexts.is_empty() {
                 while let Some(current_context) = contexts.pop_front() {
                     context = current_context;
-                    if current_context.contains(&key) {
+                    if current_context.contains(key) {
                         break;
                     } else {
                         for context_id in context.base_contexts().iter() {
@@ -127,12 +127,12 @@ impl ContextManager {
                     }
                 }
             }
-            if context.contains(&key) {
+            if context.contains(key) {
                 if let Some(StateChange::Set { key: k, value: v }) = context
                     .state_changes()
                     .iter()
                     .rev()
-                    .find(|state_change| state_change.has_key(&key))
+                    .find(|state_change| state_change.has_key(key))
                 {
                     key_values.push((k.clone(), v.clone()));
                 }
@@ -184,7 +184,7 @@ impl ContextManager {
         }
 
         while let Some(context) = contexts.pop_front() {
-            if context.contains(&key) {
+            if context.contains(key) {
                 containing_context = context;
                 break;
             } else {
@@ -193,8 +193,8 @@ impl ContextManager {
                 }
             }
         }
-        if containing_context.contains(&key) {
-            if let Some(v) = containing_context.get_state(&key) {
+        if containing_context.contains(key) {
+            if let Some(v) = containing_context.get_state(key) {
                 return Ok(Some(v.to_vec()));
             }
         } else if let Some(value) = self
@@ -213,7 +213,7 @@ impl ContextManager {
         context_id: &ContextId,
         event: Event,
     ) -> Result<(), ContextManagerError> {
-        let context = self.get_context_mut(&context_id)?;
+        let context = self.get_context_mut(context_id)?;
         context.add_event(event);
         Ok(())
     }
@@ -224,7 +224,7 @@ impl ContextManager {
         context_id: &ContextId,
         data: Vec<u8>,
     ) -> Result<(), ContextManagerError> {
-        let context = self.get_context_mut(&context_id)?;
+        let context = self.get_context_mut(context_id)?;
         context.add_data(data);
         Ok(())
     }

--- a/libtransact/src/context/mod.rs
+++ b/libtransact/src/context/mod.rs
@@ -119,7 +119,7 @@ impl Context {
             .state_changes
             .iter()
             .rev()
-            .find(|state_change| state_change.has_key(&key))
+            .find(|state_change| state_change.has_key(key))
         {
             return Some(v);
         }
@@ -138,7 +138,7 @@ impl Context {
             .state_changes
             .iter_mut()
             .rev()
-            .find(|state_change| state_change.has_key(&key));
+            .find(|state_change| state_change.has_key(key));
         if let Some(StateChange::Set { .. }) = found_state_change {
             // If a StateChange::Set is found associated with the key, the value set is returned.
             let mut new_state_change: StateChange = StateChange::Delete {

--- a/libtransact/src/contract/archive/mod.rs
+++ b/libtransact/src/contract/archive/mod.rs
@@ -196,7 +196,7 @@ impl SmartContractArchive {
             ))
         })?;
 
-        validate_metadata(&name, &metadata.name)?;
+        validate_metadata(name, &metadata.name)?;
 
         Ok(SmartContractArchive { contract, metadata })
     }

--- a/libtransact/src/contract/context/key_value.rs
+++ b/libtransact/src/contract/context/key_value.rs
@@ -126,7 +126,7 @@ where
             .iter()
             .map(|k| {
                 self.addresser
-                    .compute(&k)
+                    .compute(k)
                     .map_err(ContractContextError::AddresserError)
             })
             .collect::<Result<Vec<String>, ContractContextError>>()?;
@@ -188,13 +188,13 @@ where
             .iter()
             .map(|k| {
                 self.addresser
-                    .compute(&k)
+                    .compute(k)
                     .map_err(ContractContextError::AddresserError)
             })
             .collect::<Result<Vec<String>, ContractContextError>>()?;
         let normalized_keys = keys
             .iter()
-            .map(|k| self.addresser.normalize(&k))
+            .map(|k| self.addresser.normalize(k))
             .collect::<Vec<String>>();
 
         let state_entries: Vec<StateEntry> = self.flatten_state_entries(&addresses)?;
@@ -326,7 +326,7 @@ where
         addresses: &[String],
     ) -> Result<HashMap<String, StateEntryList>, ContractContextError> {
         self.context
-            .get_state_entries(&addresses)?
+            .get_state_entries(addresses)?
             .iter()
             .map(|(addr, bytes_entry)| {
                 Ok((addr.to_string(), StateEntryList::from_bytes(bytes_entry)?))

--- a/libtransact/src/database/lmdb.rs
+++ b/libtransact/src/database/lmdb.rs
@@ -115,14 +115,14 @@ impl LmdbDatabase {
         let txn = lmdb::ReadTransaction::new(self.ctx.env.clone()).map_err(|err| {
             DatabaseError::ReaderError(format!("Failed to create reader: {}", err))
         })?;
-        Ok(LmdbDatabaseReader { db: &self, txn })
+        Ok(LmdbDatabaseReader { db: self, txn })
     }
 
     pub fn writer(&self) -> Result<LmdbDatabaseWriter, DatabaseError> {
         let txn = lmdb::WriteTransaction::new(self.ctx.env.clone()).map_err(|err| {
             DatabaseError::WriterError(format!("Failed to create writer: {}", err))
         })?;
-        Ok(LmdbDatabaseWriter { db: &self, txn })
+        Ok(LmdbDatabaseWriter { db: self, txn })
     }
 }
 
@@ -131,14 +131,14 @@ impl Database for LmdbDatabase {
         let txn = lmdb::ReadTransaction::new(self.ctx.env.clone()).map_err(|err| {
             DatabaseError::ReaderError(format!("Failed to create reader: {}", err))
         })?;
-        Ok(Box::new(LmdbDatabaseReader { db: &self, txn }))
+        Ok(Box::new(LmdbDatabaseReader { db: self, txn }))
     }
 
     fn get_writer<'a>(&'a self) -> Result<Box<dyn DatabaseWriter + 'a>, DatabaseError> {
         let txn = lmdb::WriteTransaction::new(self.ctx.env.clone()).map_err(|err| {
             DatabaseError::WriterError(format!("Failed to create writer: {}", err))
         })?;
-        Ok(Box::new(LmdbDatabaseWriter { db: &self, txn }))
+        Ok(Box::new(LmdbDatabaseWriter { db: self, txn }))
     }
 
     fn clone_box(&self) -> Box<dyn Database> {

--- a/libtransact/src/execution/executor/internal.rs
+++ b/libtransact/src/execution/executor/internal.rs
@@ -417,7 +417,7 @@ impl ExecutorThread {
         fanout_threads: &HashMap<TransactionFamily, HashSet<NamedExecutionEventSender>>,
         parked: &mut ParkedExecutionEventsMap,
     ) {
-        let tf = TransactionFamily::from_pair(&execution_event.1.pair());
+        let tf = TransactionFamily::from_pair(execution_event.1.pair());
         if let Some(ea_senders) = fanout_threads.get(&tf) {
             if let Some(sender) = ea_senders.iter().next() {
                 if let Err(err) = sender.sender.send(ExecutionCommand::Event(execution_event)) {

--- a/libtransact/src/scheduler/parallel/tree.rs
+++ b/libtransact/src/scheduler/parallel/tree.rs
@@ -88,7 +88,7 @@ impl<T: Clone> RadixTree<T> {
     /// then the descendants of ADDRESS are yielded
     pub fn walk(&self, address: &str) -> Vec<(String, Option<T>)> {
         let mut return_nodes = Vec::new();
-        let accumulated_nodes = self.walk_to_address(&address);
+        let accumulated_nodes = self.walk_to_address(address);
         for node in accumulated_nodes.iter() {
             return_nodes.push((node.borrow().address.clone(), node.borrow().data.clone()));
         }
@@ -97,7 +97,7 @@ impl<T: Clone> RadixTree<T> {
             let mut to_process = VecDeque::new();
             let descendants = node.borrow().children.clone();
             for descendant in descendants.values() {
-                to_process.push_front(Rc::clone(&descendant));
+                to_process.push_front(Rc::clone(descendant));
             }
             while let Some(current_child) = to_process.pop_front() {
                 return_nodes.push((
@@ -106,7 +106,7 @@ impl<T: Clone> RadixTree<T> {
                 ));
                 let additional_descendants = &current_child.borrow().children;
                 for child in additional_descendants.values() {
-                    to_process.push_front(Rc::clone(&child));
+                    to_process.push_front(Rc::clone(child));
                 }
             }
         }
@@ -116,14 +116,14 @@ impl<T: Clone> RadixTree<T> {
     /// Walk as far down the tree as possible. If the desired address is reached, return that node.
     /// Otherwise, add a new one.
     fn get_or_create(&self, address: &str) -> Rc<RefCell<Node<T>>> {
-        let accumulated_nodes = self.walk_to_address(&address);
+        let accumulated_nodes = self.walk_to_address(address);
         let first_ancestor = accumulated_nodes
             .iter()
             .last()
             .expect("Node ancestors not formed correctly");
 
         if first_ancestor.borrow().address == address {
-            return Rc::clone(&first_ancestor);
+            return Rc::clone(first_ancestor);
         }
 
         // The address isn't in the tree, so a new node will need to be added
@@ -227,7 +227,7 @@ impl<T: Clone> RadixTree<T> {
     /// Walk to ADDRESS, creating nodes if necessary, and set the data there to
     /// UPDATER(data)
     pub fn update(&self, address: &str, updater: &dyn Fn(Option<T>) -> Option<T>, prune: bool) {
-        let node = self.get_or_create(&address);
+        let node = self.get_or_create(address);
         let existing_data = node.borrow_mut().data.take();
         node.borrow_mut().data = updater(existing_data);
 
@@ -238,7 +238,7 @@ impl<T: Clone> RadixTree<T> {
 
     /// Remove all children (and descendants) below ADDRESS
     pub fn prune(&self, address: &str) {
-        let accumulated_nodes = self.walk_to_address(&address);
+        let accumulated_nodes = self.walk_to_address(address);
         if let Some(node) = accumulated_nodes.iter().last() {
             node.borrow_mut().children.clear()
         }

--- a/libtransact/src/state/hashmap.rs
+++ b/libtransact/src/state/hashmap.rs
@@ -93,7 +93,7 @@ impl Write for HashMapState {
             StateWriteError::InvalidStateId(format!("Unknown state id {}", state_id))
         })?;
 
-        let (next_state_id, new_state_map) = HashMapState::next_state(&state, state_changes);
+        let (next_state_id, new_state_map) = HashMapState::next_state(state, state_changes);
 
         states.insert(next_state_id.clone(), new_state_map);
 
@@ -110,7 +110,7 @@ impl Write for HashMapState {
             StateWriteError::InvalidStateId(format!("Unknown state id {}", state_id))
         })?;
 
-        let (next_state_id, _) = HashMapState::next_state(&state, state_changes);
+        let (next_state_id, _) = HashMapState::next_state(state, state_changes);
 
         Ok(next_state_id)
     }

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -234,7 +234,7 @@ impl MerkleRadixTree {
                     .collect::<Vec<_>>();
                 parent_change_log.successors = new_successors;
 
-                write_change_log(&mut *db_writer, parent_root_bytes, &parent_change_log)?;
+                write_change_log(&mut *db_writer, parent_root_bytes, parent_change_log)?;
             }
 
             deletion_candidates.into_iter().collect()
@@ -272,7 +272,7 @@ impl MerkleRadixTree {
         deletions: Vec<Vec<u8>>,
     ) -> (Vec<StateHash>, Vec<StateHash>) {
         deletions.into_iter().partition(|key| {
-            if let Ok(count) = get_ref_count(db_reader, &key) {
+            if let Ok(count) = get_ref_count(db_reader, key) {
                 count == 0
             } else {
                 false
@@ -439,7 +439,7 @@ impl MerkleRadixTree {
         let root_hash_bytes = ::hex::decode(&self.root_hash).expect("Improper hex");
 
         for &(ref key, ref value) in batch {
-            match db_writer.put(::hex::encode(key).as_bytes(), &value) {
+            match db_writer.put(::hex::encode(key).as_bytes(), value) {
                 Ok(_) => continue,
                 Err(DatabaseError::DuplicateEntry) => {
                     increment_ref_count(&mut *db_writer, key)?;
@@ -686,7 +686,7 @@ fn to_bytes(num: u64) -> [u8; 8] {
 
 fn from_bytes(bytes: &[u8]) -> u64 {
     let mut num_bytes = [0u8; 8];
-    num_bytes.copy_from_slice(&bytes);
+    num_bytes.copy_from_slice(bytes);
     u64::from_le(unsafe { ::std::mem::transmute(num_bytes) })
 }
 


### PR DESCRIPTION
Additionally, back-ports the commit to remove `clean` from the `just lint` command