### PR TITLE
Remove unnecessary DB test URL loading

### DIFF
--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -152,9 +152,6 @@ pub mod test {
             let result = panic::catch_unwind(move || test(&test_url));
 
             // rollback
-            let url = env::var("STATE_MERKLE_SQL_POSTGRES_TEST_URL")
-                .ok()
-                .unwrap_or_else(|| "".into());
             let conn = PgConnection::establish(&url)?;
             let migration_result: Result<(), Box<dyn Error>> = loop {
                 match revert_latest_migration_in_directory(


### PR DESCRIPTION
This change removes a duplicate URL loading from the environment variable for tests.
