### PR TITLE
SQL State pruning

### DIFF
--- a/libtransact/src/state/merkle/sql/migration/postgres/migrations/2021-07-29-105100-change-log/down.sql
+++ b/libtransact/src/state/merkle/sql/migration/postgres/migrations/2021-07-29-105100-change-log/down.sql
@@ -1,0 +1,17 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS merkle_radix_change_log_addition;
+DROP TABLE IF EXISTS merkle_radix_change_log_deletion;

--- a/libtransact/src/state/merkle/sql/migration/postgres/migrations/2021-07-29-105100-change-log/up.sql
+++ b/libtransact/src/state/merkle/sql/migration/postgres/migrations/2021-07-29-105100-change-log/up.sql
@@ -1,0 +1,36 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+create TABLE IF NOT EXISTS merkle_radix_change_log_addition (
+    id BIGSERIAL PRIMARY KEY,
+    tree_id BIGINT NOT NULL,
+    state_root VARCHAR(64) NOT NULL,
+    parent_state_root VARCHAR(64),
+    addition VARCHAR(64),
+    FOREIGN KEY(state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(parent_state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(addition, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id)
+);
+
+create TABLE IF NOT EXISTS merkle_radix_change_log_deletion (
+    id BIGSERIAL PRIMARY KEY,
+    tree_id BIGINT NOT NULL,
+    successor_state_root VARCHAR(64) NOT NULL,
+    state_root VARCHAR(64) NOT NULL,
+    deletion VARCHAR(64),
+    FOREIGN KEY(successor_state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(deletion, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id)
+);

--- a/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2021-07-29-105100-change-log/down.sql
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2021-07-29-105100-change-log/down.sql
@@ -1,0 +1,17 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS merkle_radix_change_log_addition;
+DROP TABLE IF EXISTS merkle_radix_change_log_deletion;

--- a/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2021-07-29-105100-change-log/up.sql
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2021-07-29-105100-change-log/up.sql
@@ -1,0 +1,36 @@
+-- Copyright 2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+create TABLE IF NOT EXISTS merkle_radix_change_log_addition (
+    id INTEGER PRIMARY KEY,
+    tree_id BIGINT NOT NULL,
+    state_root VARCHAR(64) NOT NULL,
+    parent_state_root VARCHAR(64),
+    addition VARCHAR(64),
+    FOREIGN KEY(state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(parent_state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(addition, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id)
+);
+
+create TABLE IF NOT EXISTS merkle_radix_change_log_deletion (
+    id INTEGER PRIMARY KEY,
+    tree_id BIGINT NOT NULL,
+    successor_state_root VARCHAR(64) NOT NULL,
+    state_root VARCHAR(64) NOT NULL,
+    deletion VARCHAR(64),
+    FOREIGN KEY(successor_state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(state_root, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id),
+    FOREIGN KEY(deletion, tree_id) REFERENCES merkle_radix_tree_node(hash, tree_id)
+);

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -137,8 +137,9 @@ impl SqlMerkleStateBuilder<backend::SqliteBackend> {
         let conn = backend.connection()?;
         let operations = MerkleRadixOperations::new(conn.as_inner());
 
+        let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
         let tree_id: i64 = if self.create_tree {
-            operations.get_or_create_tree(&tree_name)?
+            operations.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
         } else {
             operations.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
                 InvalidStateError::with_message("must provide the name of an existing tree".into())
@@ -173,8 +174,9 @@ impl SqlMerkleStateBuilder<backend::PostgresBackend> {
         let conn = backend.connection()?;
         let operations = MerkleRadixOperations::new(conn.as_inner());
 
+        let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
         let tree_id: i64 = if self.create_tree {
-            operations.get_or_create_tree(&tree_name)?
+            operations.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
         } else {
             operations.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
                 InvalidStateError::with_message("must provide the name of an existing tree".into())

--- a/libtransact/src/state/merkle/sql/models/mod.rs
+++ b/libtransact/src/state/merkle/sql/models/mod.rs
@@ -90,3 +90,47 @@ pub struct MerkleRadixStateRootLeafIndexEntry {
     pub from_state_root_id: i64,
     pub to_state_root_id: Option<i64>,
 }
+
+#[derive(Insertable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_change_log_addition"]
+pub struct NewMerkleRadixChangeLogAddition<'a> {
+    pub tree_id: i64,
+    pub state_root: &'a str,
+    pub parent_state_root: Option<&'a str>,
+    pub addition: &'a str,
+}
+
+#[derive(Queryable, QueryableByName, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_change_log_addition"]
+#[primary_key(id)]
+pub struct MerkleRadixChangeLogAddition {
+    pub id: i64,
+    pub tree_id: i64,
+    pub state_root: String,
+    pub parent_state_root: Option<String>,
+    pub addition: String,
+}
+
+#[derive(Insertable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_change_log_deletion"]
+pub struct NewMerkleRadixChangeLogDeletion<'a> {
+    pub tree_id: i64,
+    pub successor_state_root: &'a str,
+    pub state_root: &'a str,
+    pub deletion: &'a str,
+}
+
+#[derive(Queryable, QueryableByName, Identifiable)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[table_name = "merkle_radix_change_log_deletion"]
+#[primary_key(id)]
+pub struct MerkleRadixChangeLogDeletion {
+    pub id: i64,
+    pub tree_id: i64,
+    pub successor_state_root: String,
+    pub state_root: String,
+    pub deletion: String,
+}

--- a/libtransact/src/state/merkle/sql/operations/get_leaves.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_leaves.rs
@@ -16,12 +16,12 @@
  */
 
 use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Binary, Nullable, Text};
+#[cfg(feature = "postgres")]
+use diesel::{pg::types::sql_types::Array, sql_types::SmallInt};
 
 use crate::error::InternalError;
-
-use crate::state::merkle::sql::schema::{
-    merkle_radix_leaf, merkle_radix_state_root, merkle_radix_state_root_leaf_index,
-};
 
 use super::MerkleRadixOperations;
 
@@ -34,585 +34,291 @@ pub trait MerkleRadixGetLeavesOperation {
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
 }
 
-impl<'a, C> MerkleRadixGetLeavesOperation for MerkleRadixOperations<'a, C>
-where
-    C: diesel::Connection,
-    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
-    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
-    Vec<u8>: diesel::deserialize::FromSql<diesel::sql_types::Blob, C::Backend>,
-{
+#[cfg(feature = "sqlite")]
+impl<'a> MerkleRadixGetLeavesOperation for MerkleRadixOperations<'a, SqliteConnection> {
     fn get_leaves(
         &self,
         tree_id: i64,
         state_root_hash: &str,
         addresses: Vec<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
-        self.conn
-            .transaction::<_, diesel::result::Error, _>(|| {
-                let mut results = vec![];
-                let state_root_id = merkle_radix_state_root::table
-                    .filter(
-                        merkle_radix_state_root::tree_id
-                            .eq(tree_id)
-                            .and(merkle_radix_state_root::state_root.eq(state_root_hash)),
-                    )
-                    .select(merkle_radix_state_root::id)
-                    .get_result::<i64>(self.conn)?;
+        self.conn.transaction(|| {
+            let mut results = vec![];
+            for address in addresses {
+                let address_bytes =
+                    hex::decode(address).map_err(|e| InternalError::from_source(Box::new(e)))?;
+                let values = sql_query(
+                    r#"
+                    WITH RECURSIVE tree_path AS
+                    (
+                        -- This is the initial node
+                        SELECT hash, tree_id, leaf_id, children, 0 as depth
+                        FROM merkle_radix_tree_node
+                        WHERE hash = ? AND tree_id = ?
 
-                for address in addresses {
-                    let query = merkle_radix_leaf::table
-                        .inner_join(merkle_radix_state_root_leaf_index::table)
-                        .filter(
-                            merkle_radix_leaf::address
-                                .eq(address)
-                                .and(merkle_radix_state_root_leaf_index::tree_id.eq(tree_id))
-                                .and(
-                                    merkle_radix_state_root_leaf_index::from_state_root_id
-                                        .le(state_root_id),
-                                )
-                                .and(
-                                    merkle_radix_state_root_leaf_index::to_state_root_id
-                                        .is_null()
-                                        .or(merkle_radix_state_root_leaf_index::to_state_root_id
-                                            .gt(state_root_id)),
-                                ),
+                        UNION ALL
+
+                        -- Recurse through the tree
+                        SELECT c.hash, c.tree_id, c.leaf_id, c.children, p.depth + 1
+                        FROM merkle_radix_tree_node c, tree_path p
+                        WHERE c.hash = json_extract(
+                          p.children,
+                          '$[' || json_extract(?, '$[' || p.depth || ']') || ']'
                         )
-                        .select((
-                            merkle_radix_leaf::id,
-                            merkle_radix_leaf::address,
-                            merkle_radix_leaf::data,
-                            merkle_radix_state_root_leaf_index::to_state_root_id,
-                        ))
-                        .order(merkle_radix_leaf::address.asc())
-                        .then_order_by(merkle_radix_state_root_leaf_index::to_state_root_id.desc());
+                    )
+                    SELECT l.data
+                    FROM tree_path t, merkle_radix_leaf l
+                    WHERE t.tree_id = ? AND t.leaf_id = l.id
+                    "#,
+                )
+                .bind::<Text, _>(state_root_hash)
+                .bind::<BigInt, _>(tree_id)
+                .bind::<Text, _>(
+                    serde_json::to_string(&address_bytes)
+                        .map_err(|err| InternalError::from_source(Box::new(err)))?,
+                )
+                .bind::<BigInt, _>(tree_id)
+                .load::<LeafData>(self.conn)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
 
-                    let leaf = query
-                        .get_result::<(i64, String, Vec<u8>, Option<i64>)>(self.conn)
-                        .optional()?;
-
-                    if let Some((_, address, data, _)) = leaf {
-                        results.push((address, data));
-                    }
+                if let Some(LeafData { data: Some(data) }) = values.into_iter().next() {
+                    results.push((address.to_string(), data))
                 }
+            }
 
-                Ok(results)
-            })
-            .map_err(|e| InternalError::from_source(Box::new(e)))
+            Ok(results)
+        })
     }
 }
 
+#[cfg(feature = "postgres")]
+impl<'a> MerkleRadixGetLeavesOperation for MerkleRadixOperations<'a, PgConnection> {
+    fn get_leaves(
+        &self,
+        tree_id: i64,
+        state_root_hash: &str,
+        addresses: Vec<&str>,
+    ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
+        self.conn.transaction(|| {
+            let mut results = vec![];
+            for addr in addresses {
+                // both the indexes in the array and the depth in the SQL statement are set to start at 1,
+                // as the SQL arrays are 1-indexed.
+                let address_branches: Vec<i16> = hex::decode(addr)
+                    .map_err(|e| InternalError::from_source(Box::new(e)))?
+                    .into_iter()
+                    .map(|b| i16::from(b) + 1)
+                    .collect();
+
+                let values = sql_query(
+                    r#"
+                    WITH RECURSIVE tree_path AS
+                    (
+                        -- This is the initial node
+                        SELECT hash, tree_id, leaf_id, children, 1 as depth
+                        FROM merkle_radix_tree_node
+                        WHERE hash = $1 AND tree_id = $2
+
+                        UNION ALL
+
+                        -- Recurse through the tree
+                        SELECT c.hash, c.tree_id, c.leaf_id, c.children, p.depth + 1
+                        FROM merkle_radix_tree_node c, tree_path p
+                        WHERE c.hash = p.children[$3[p.depth]]
+                    )
+                    SELECT l.data
+                    FROM tree_path t, merkle_radix_leaf l
+                    WHERE t.tree_id = $2 AND t.leaf_id = l.id
+                    "#,
+                )
+                .bind::<Text, _>(state_root_hash)
+                .bind::<BigInt, _>(tree_id)
+                .bind::<Array<SmallInt>, _>(&address_branches)
+                .load::<LeafData>(self.conn)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+                if let Some(LeafData { data: Some(data) }) = values.into_iter().next() {
+                    results.push((addr.to_string(), data))
+                }
+            }
+
+            Ok(results)
+        })
+    }
+}
+
+#[derive(QueryableByName)]
+struct LeafData {
+    #[column_name = "data"]
+    #[sql_type = "Nullable<Binary>"]
+    pub data: Option<Vec<u8>>,
+}
+
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     use diesel::dsl::insert_into;
+    #[cfg(feature = "sqlite")]
+    use diesel::dsl::select;
 
     #[cfg(feature = "state-merkle-sql-postgres-tests")]
-    use crate::state::merkle::sql::backend::postgres::test::run_postgres_test;
-    #[cfg(feature = "sqlite")]
-    use crate::state::merkle::sql::migration;
-    #[cfg(feature = "state-merkle-sql-postgres-tests")]
-    use crate::state::merkle::sql::models::postgres;
-    use crate::state::merkle::sql::models::MerkleRadixLeaf;
-    use crate::state::merkle::sql::operations::update_index::{
-        ChangedLeaf, MerkleRadixUpdateIndexOperation,
+    use crate::state::merkle::sql::{
+        backend::postgres::test::run_postgres_test, models::postgres,
+        schema::postgres_merkle_radix_tree_node,
     };
-    #[cfg(feature = "state-merkle-sql-postgres-tests")]
-    use crate::state::merkle::sql::schema::postgres_merkle_radix_tree_node;
+    #[cfg(feature = "sqlite")]
+    use crate::state::merkle::sql::{
+        migration, models::sqlite, schema::sqlite_merkle_radix_tree_node,
+    };
 
-    /// This tests that a leaf changed across several state root hashes is returned when requested
-    /// at the given state root hash. It verifies that:
-    /// 1. No leaves are returned for the initial state root hash
-    /// 2. The first leaf change is returned for first state root.
-    /// 3. The second leaf change is returned for the second state root.
+    use crate::state::merkle::sql::models::NewMerkleRadixLeaf;
+    #[cfg(feature = "sqlite")]
+    use crate::state::merkle::sql::operations::last_insert_rowid;
+    use crate::state::merkle::sql::schema::merkle_radix_leaf;
+
+    /// Test that the get entries on a non-existent root returns a empty entries.
     #[cfg(feature = "sqlite")]
     #[test]
-    fn sqlite_get_leaves_at_state_root() -> Result<(), Box<dyn std::error::Error>> {
+    fn sqlite_get_entries_empty_tree() -> Result<(), Box<dyn std::error::Error>> {
         let conn = SqliteConnection::establish(":memory:")?;
 
         migration::sqlite::run_migrations(&conn)?;
 
-        let operations = MerkleRadixOperations::new(&conn);
+        let entries =
+            MerkleRadixOperations::new(&conn).get_leaves(1, "state-root", vec!["aabbcc"])?;
 
-        // insert the initial root:
-        insert_into(merkle_radix_state_root::table)
-            .values((
-                merkle_radix_state_root::tree_id.eq(1),
-                merkle_radix_state_root::state_root.eq("initial-state-root"),
-                merkle_radix_state_root::parent_state_root.eq(""),
-            ))
-            .execute(&conn)?;
-
-        // insert the initial leaf
-        insert_into(merkle_radix_leaf::table)
-            .values(MerkleRadixLeaf {
-                id: 1,
-                tree_id: 1,
-                address: "aabbcc".into(),
-                data: b"hello".to_vec(),
-            })
-            .execute(&conn)?;
-
-        // update the index
-        operations.update_index(
-            1,
-            "first-state-root",
-            "initial-state-root",
-            vec![ChangedLeaf::AddedOrUpdated {
-                address: "aabbcc",
-                leaf_id: 1,
-            }],
-        )?;
-
-        // insert the changed leaf
-        insert_into(merkle_radix_leaf::table)
-            .values(MerkleRadixLeaf {
-                id: 2,
-                tree_id: 1,
-                address: "aabbcc".into(),
-                data: b"goodbye".to_vec(),
-            })
-            .execute(&conn)?;
-
-        operations.update_index(
-            1,
-            "second-state-root",
-            "first-state-root",
-            vec![ChangedLeaf::AddedOrUpdated {
-                address: "aabbcc",
-                leaf_id: 2,
-            }],
-        )?;
-
-        let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
-        assert!(leaves.is_empty());
-
-        let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
-        assert_eq!(leaves.len(), 1);
-        assert_eq!(leaves[0].0, "aabbcc");
-        assert_eq!(leaves[0].1, b"hello");
-
-        let leaves = operations.get_leaves(1, "second-state-root", vec!["aabbcc"])?;
-        assert_eq!(leaves.len(), 1);
-        assert_eq!(leaves[0].0, "aabbcc");
-        assert_eq!(leaves[0].1, b"goodbye");
+        assert!(entries.is_empty());
 
         Ok(())
     }
 
-    /// This tests that a leaf changed across several state root hashes is returned when requested
-    /// at the given state root hash. It verifies that:
-    /// 1. No leaves are returned for the initial state root hash
-    /// 2. The first leaf change is returned for first state root.
-    /// 3. The second leaf change is returned for the second state root.
+    /// Test that the get entries on a non-existent root returns a empty entries.
     #[cfg(feature = "state-merkle-sql-postgres-tests")]
     #[test]
-    fn postgres_get_leaves_at_state_root() -> Result<(), Box<dyn std::error::Error>> {
+    fn postgres_get_entries_empty_tree() -> Result<(), Box<dyn std::error::Error>> {
         run_postgres_test(|url| {
             let conn = PgConnection::establish(&url)?;
 
-            insert_state_root_nodes(&conn)?;
+            let entries =
+                MerkleRadixOperations::new(&conn).get_leaves(1, "state-root", vec!["aabbcc"])?;
 
-            let operations = MerkleRadixOperations::new(&conn);
-
-            // insert the initial root:
-            insert_into(merkle_radix_state_root::table)
-                .values((
-                    merkle_radix_state_root::tree_id.eq(1),
-                    merkle_radix_state_root::state_root.eq("initial-state-root"),
-                    merkle_radix_state_root::parent_state_root.eq(""),
-                ))
-                .execute(&conn)?;
-
-            // insert the initial leaf
-            insert_into(merkle_radix_leaf::table)
-                .values(MerkleRadixLeaf {
-                    id: 1,
-                    tree_id: 1,
-                    address: "aabbcc".into(),
-                    data: b"hello".to_vec(),
-                })
-                .execute(&conn)?;
-
-            // update the index
-            operations.update_index(
-                1,
-                "first-state-root",
-                "initial-state-root",
-                vec![ChangedLeaf::AddedOrUpdated {
-                    address: "aabbcc",
-                    leaf_id: 1,
-                }],
-            )?;
-
-            // insert the changed leaf
-            insert_into(merkle_radix_leaf::table)
-                .values(MerkleRadixLeaf {
-                    id: 2,
-                    tree_id: 1,
-                    address: "aabbcc".into(),
-                    data: b"goodbye".to_vec(),
-                })
-                .execute(&conn)?;
-
-            operations.update_index(
-                1,
-                "second-state-root",
-                "first-state-root",
-                vec![ChangedLeaf::AddedOrUpdated {
-                    address: "aabbcc",
-                    leaf_id: 2,
-                }],
-            )?;
-
-            let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
-            assert!(leaves.is_empty());
-
-            let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
-            assert_eq!(leaves.len(), 1);
-            assert_eq!(leaves[0].0, "aabbcc");
-            assert_eq!(leaves[0].1, b"hello");
-
-            let leaves = operations.get_leaves(1, "second-state-root", vec!["aabbcc"])?;
-            assert_eq!(leaves.len(), 1);
-            assert_eq!(leaves[0].0, "aabbcc");
-            assert_eq!(leaves[0].1, b"goodbye");
+            assert!(entries.is_empty());
 
             Ok(())
         })
     }
 
-    /// This tests that a leaf inserted then deleted across several state root hashes is returned
-    /// only on the state root hash where it exists.  It verifies that:
-    /// 1. No leaves are returned for the initial state root hash
-    /// 2. The leaf is returned for first state root.
-    /// 3. The leaf is no longer returned for the second state root.
+    /// Test that a single leaf, with intermediate nodes will return the correct entry address and
+    /// bytes.
     #[cfg(feature = "sqlite")]
     #[test]
-    fn sqlite_get_leaves_with_deletion() -> Result<(), Box<dyn std::error::Error>> {
+    fn sqlite_get_entries_single_entry() -> Result<(), Box<dyn std::error::Error>> {
         let conn = SqliteConnection::establish(":memory:")?;
 
         migration::sqlite::run_migrations(&conn)?;
 
-        let operations = MerkleRadixOperations::new(&conn);
-
-        // insert the initial root:
-        insert_into(merkle_radix_state_root::table)
-            .values((
-                merkle_radix_state_root::tree_id.eq(1),
-                merkle_radix_state_root::state_root.eq("initial-state-root"),
-                merkle_radix_state_root::parent_state_root.eq(""),
-            ))
-            .execute(&conn)?;
-
-        // insert the initial leaf
         insert_into(merkle_radix_leaf::table)
-            .values(MerkleRadixLeaf {
+            .values(NewMerkleRadixLeaf {
                 id: 1,
                 tree_id: 1,
-                address: "aabbcc".into(),
-                data: b"hello".to_vec(),
+                address: "000000",
+                data: b"hello",
             })
             .execute(&conn)?;
 
-        // update the index
-        operations.update_index(
-            1,
-            "first-state-root",
-            "initial-state-root",
-            vec![ChangedLeaf::AddedOrUpdated {
-                address: "aabbcc",
-                leaf_id: 1,
-            }],
-        )?;
+        let inserted_id = select(last_insert_rowid).get_result::<i64>(&conn)?;
 
-        // insert the changed leaf
-        operations.update_index(
-            1,
-            "second-state-root",
-            "first-state-root",
-            vec![ChangedLeaf::Deleted("aabbcc")],
-        )?;
-
-        let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
-        assert!(leaves.is_empty());
-
-        let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
-        assert_eq!(leaves.len(), 1);
-        assert_eq!(leaves[0].0, "aabbcc");
-        assert_eq!(leaves[0].1, b"hello");
-
-        let leaves = operations.get_leaves(1, "second-state-root", vec!["aabbcc"])?;
-        assert!(leaves.is_empty());
-
-        Ok(())
-    }
-
-    /// This tests that a leaf inserted then deleted across several state root hashes is returned
-    /// only on the state root hash where it exists.  It verifies that:
-    /// 1. No leaves are returned for the initial state root hash
-    /// 2. The leaf is returned for first state root.
-    /// 3. The leaf is no longer returned for the second state root.
-    #[cfg(feature = "state-merkle-sql-postgres-tests")]
-    #[test]
-    fn postgres_get_leaves_with_deletion() -> Result<(), Box<dyn std::error::Error>> {
-        run_postgres_test(|url| {
-            let conn = PgConnection::establish(&url)?;
-
-            insert_state_root_nodes(&conn)?;
-
-            let operations = MerkleRadixOperations::new(&conn);
-
-            // insert the initial root:
-            insert_into(merkle_radix_state_root::table)
-                .values((
-                    merkle_radix_state_root::tree_id.eq(1),
-                    merkle_radix_state_root::state_root.eq("initial-state-root"),
-                    merkle_radix_state_root::parent_state_root.eq(""),
-                ))
-                .execute(&conn)?;
-
-            // insert the initial leaf
-            insert_into(merkle_radix_leaf::table)
-                .values(MerkleRadixLeaf {
-                    id: 1,
-                    tree_id: 1,
-                    address: "aabbcc".into(),
-                    data: b"hello".to_vec(),
-                })
-                .execute(&conn)?;
-
-            // update the index
-            operations.update_index(
-                1,
-                "first-state-root",
-                "initial-state-root",
-                vec![ChangedLeaf::AddedOrUpdated {
-                    address: "aabbcc",
-                    leaf_id: 1,
-                }],
-            )?;
-
-            // insert the changed leaf
-            operations.update_index(
-                1,
-                "second-state-root",
-                "first-state-root",
-                vec![ChangedLeaf::Deleted("aabbcc")],
-            )?;
-
-            let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
-            assert!(leaves.is_empty());
-
-            let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
-            assert_eq!(leaves.len(), 1);
-            assert_eq!(leaves[0].0, "aabbcc");
-            assert_eq!(leaves[0].1, b"hello");
-
-            let leaves = operations.get_leaves(1, "second-state-root", vec!["aabbcc"])?;
-            assert!(leaves.is_empty());
-
-            Ok(())
-        })
-    }
-
-    /// This tests that several leaves, added against successive state root hashes.
-    /// 1. Add a leaf and nodes to the tree at state root 1
-    /// 2. Add a second leaf and nodes to the tree at state root 2
-    /// 3. Verify that only the first leaf is returned with state root 1
-    /// 4. Verify that both leaves are returned with state root 2
-    #[cfg(feature = "sqlite")]
-    #[test]
-    fn sqlite_get_leaves_at_state_root_larger_tree() -> Result<(), Box<dyn std::error::Error>> {
-        let conn = SqliteConnection::establish(":memory:")?;
-
-        migration::sqlite::run_migrations(&conn)?;
-
-        let operations = MerkleRadixOperations::new(&conn);
-
-        // insert the initial root:
-        insert_into(merkle_radix_state_root::table)
-            .values((
-                merkle_radix_state_root::tree_id.eq(1),
-                merkle_radix_state_root::state_root.eq("initial-state-root"),
-                merkle_radix_state_root::parent_state_root.eq(""),
-            ))
-            .execute(&conn)?;
-
-        // insert the initial leaf
-        insert_into(merkle_radix_leaf::table)
-            .values(MerkleRadixLeaf {
-                id: 1,
-                tree_id: 1,
-                address: "aabbcc".into(),
-                data: b"hello".to_vec(),
-            })
-            .execute(&conn)?;
-
-        // update the index
-        operations.update_index(
-            1,
-            "first-state-root",
-            "initial-state-root",
-            vec![ChangedLeaf::AddedOrUpdated {
-                address: "aabbcc",
-                leaf_id: 1,
-            }],
-        )?;
-
-        // insert a new leaf
-        insert_into(merkle_radix_leaf::table)
-            .values(MerkleRadixLeaf {
-                id: 2,
-                tree_id: 1,
-                address: "112233".into(),
-                data: b"goodbye".to_vec(),
-            })
-            .execute(&conn)?;
-
-        operations.update_index(
-            1,
-            "second-state-root",
-            "first-state-root",
-            vec![ChangedLeaf::AddedOrUpdated {
-                address: "112233",
-                leaf_id: 2,
-            }],
-        )?;
-
-        let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
-        assert!(leaves.is_empty());
-
-        let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
-        assert_eq!(leaves.len(), 1);
-        assert_eq!(leaves[0].0, "aabbcc");
-        assert_eq!(leaves[0].1, b"hello");
-
-        let leaves = operations.get_leaves(1, "second-state-root", vec!["112233", "aabbcc"])?;
-        assert_eq!(leaves.len(), 2);
-        assert_eq!(leaves[0].0, "112233");
-        assert_eq!(leaves[0].1, b"goodbye");
-        assert_eq!(leaves[1].0, "aabbcc");
-        assert_eq!(leaves[1].1, b"hello");
-
-        Ok(())
-    }
-
-    /// This tests that several leaves, added against successive state root hashes.
-    /// 1. Add a leaf and nodes to the tree at state root 1
-    /// 2. Add a second leaf and nodes to the tree at state root 2
-    /// 3. Verify that only the first leaf is returned with state root 1
-    /// 4. Verify that both leaves are returned with state root 2
-    #[cfg(feature = "state-merkle-sql-postgres-tests")]
-    #[test]
-    fn postgres_get_leaves_at_state_root_larger_tree() -> Result<(), Box<dyn std::error::Error>> {
-        run_postgres_test(|url| {
-            let conn = PgConnection::establish(&url)?;
-
-            insert_state_root_nodes(&conn)?;
-
-            let operations = MerkleRadixOperations::new(&conn);
-
-            // insert the initial root:
-            insert_into(merkle_radix_state_root::table)
-                .values((
-                    merkle_radix_state_root::tree_id.eq(1),
-                    merkle_radix_state_root::state_root.eq("initial-state-root"),
-                    merkle_radix_state_root::parent_state_root.eq(""),
-                ))
-                .execute(&conn)?;
-
-            // insert the initial leaf
-            insert_into(merkle_radix_leaf::table)
-                .values(MerkleRadixLeaf {
-                    id: 1,
-                    tree_id: 1,
-                    address: "aabbcc".into(),
-                    data: b"hello".to_vec(),
-                })
-                .execute(&conn)?;
-
-            // update the index
-            operations.update_index(
-                1,
-                "first-state-root",
-                "initial-state-root",
-                vec![ChangedLeaf::AddedOrUpdated {
-                    address: "aabbcc",
-                    leaf_id: 1,
-                }],
-            )?;
-
-            // insert a new leaf
-            insert_into(merkle_radix_leaf::table)
-                .values(MerkleRadixLeaf {
-                    id: 2,
-                    tree_id: 1,
-                    address: "112233".into(),
-                    data: b"goodbye".to_vec(),
-                })
-                .execute(&conn)?;
-
-            operations.update_index(
-                1,
-                "second-state-root",
-                "first-state-root",
-                vec![ChangedLeaf::AddedOrUpdated {
-                    address: "112233",
-                    leaf_id: 2,
-                }],
-            )?;
-
-            let leaves = operations.get_leaves(1, "initial-state-root", vec!["aabbcc"])?;
-            assert!(leaves.is_empty());
-
-            let leaves = operations.get_leaves(1, "first-state-root", vec!["aabbcc"])?;
-            assert_eq!(leaves.len(), 1);
-            assert_eq!(leaves[0].0, "aabbcc");
-            assert_eq!(leaves[0].1, b"hello");
-
-            let leaves = operations.get_leaves(1, "second-state-root", vec!["112233", "aabbcc"])?;
-            assert_eq!(leaves.len(), 2);
-            assert_eq!(leaves[0].0, "112233");
-            assert_eq!(leaves[0].1, b"goodbye");
-            assert_eq!(leaves[1].0, "aabbcc");
-            assert_eq!(leaves[1].1, b"hello");
-
-            Ok(())
-        })
-    }
-
-    #[cfg(feature = "state-merkle-sql-postgres-tests")]
-    fn insert_state_root_nodes(conn: &PgConnection) -> Result<(), Box<dyn std::error::Error>> {
-        insert_into(postgres_merkle_radix_tree_node::table)
+        insert_into(sqlite_merkle_radix_tree_node::table)
             .values(vec![
-                postgres::MerkleRadixTreeNode {
-                    hash: "initial-state-root".into(),
+                sqlite::MerkleRadixTreeNode {
+                    hash: "000000-hash".into(),
                     tree_id: 1,
-                    leaf_id: None,
-                    children: vec![],
+                    leaf_id: Some(inserted_id),
+                    children: sqlite::Children(vec![]),
                 },
-                postgres::MerkleRadixTreeNode {
-                    hash: "new-state-root".into(),
+                sqlite::MerkleRadixTreeNode {
+                    hash: "0000-hash".into(),
                     tree_id: 1,
                     leaf_id: None,
-                    children: vec![],
+                    children: sqlite::Children(vec![Some("000000-hash".to_string())]),
                 },
-                postgres::MerkleRadixTreeNode {
-                    hash: "first-state-root".into(),
+                sqlite::MerkleRadixTreeNode {
+                    hash: "00-hash".into(),
                     tree_id: 1,
                     leaf_id: None,
-                    children: vec![],
+                    children: sqlite::Children(vec![Some("0000-hash".to_string())]),
                 },
-                postgres::MerkleRadixTreeNode {
-                    hash: "second-state-root".into(),
+                sqlite::MerkleRadixTreeNode {
+                    hash: "root-hash".into(),
                     tree_id: 1,
                     leaf_id: None,
-                    children: vec![],
+                    children: sqlite::Children(vec![Some("00-hash".to_string())]),
                 },
             ])
-            .execute(conn)?;
+            .execute(&conn)?;
+
+        let entries =
+            MerkleRadixOperations::new(&conn).get_leaves(1, "root-hash", vec!["000000"])?;
+
+        assert_eq!(entries, vec![("000000".to_string(), b"hello".to_vec(),),]);
 
         Ok(())
+    }
+
+    /// Test that a single leaf, with intermediate nodes will return the correct entry address and
+    /// bytes.
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    #[test]
+    fn postgres_get_entries_single_entry() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let conn = PgConnection::establish(&url)?;
+
+            let leaf_id = 1;
+            insert_into(merkle_radix_leaf::table)
+                .values(NewMerkleRadixLeaf {
+                    id: leaf_id,
+                    tree_id: 1,
+                    address: "000000",
+                    data: b"hello",
+                })
+                .execute(&conn)?;
+
+            insert_into(postgres_merkle_radix_tree_node::table)
+                .values(vec![
+                    postgres::MerkleRadixTreeNode {
+                        hash: "000000-hash".into(),
+                        tree_id: 1,
+                        leaf_id: Some(leaf_id),
+                        children: vec![],
+                    },
+                    postgres::MerkleRadixTreeNode {
+                        hash: "0000-hash".into(),
+                        tree_id: 1,
+                        leaf_id: None,
+                        children: vec![Some("000000-hash".to_string())],
+                    },
+                    postgres::MerkleRadixTreeNode {
+                        hash: "00-hash".into(),
+                        tree_id: 1,
+                        leaf_id: None,
+                        children: vec![Some("0000-hash".to_string())],
+                    },
+                    postgres::MerkleRadixTreeNode {
+                        hash: "root-hash".into(),
+                        tree_id: 1,
+                        leaf_id: None,
+                        children: vec![Some("00-hash".to_string())],
+                    },
+                ])
+                .execute(&conn)?;
+
+            let entries =
+                MerkleRadixOperations::new(&conn).get_leaves(1, "root-hash", vec!["000000"])?;
+
+            assert_eq!(entries, vec![("000000".to_string(), b"hello".to_vec(),),]);
+
+            Ok(())
+        })
     }
 }

--- a/libtransact/src/state/merkle/sql/operations/get_path.rs
+++ b/libtransact/src/state/merkle/sql/operations/get_path.rs
@@ -198,18 +198,11 @@ impl<'a> MerkleRadixGetPathOperation for MerkleRadixOperations<'a, PgConnection>
 }
 
 fn vec_to_btree(hashes: Vec<Option<String>>) -> BTreeMap<String, String> {
-    let mut btree = BTreeMap::new();
-
-    for (i, hash_opt) in hashes
+    hashes
         .into_iter()
         .enumerate()
-        .filter(|(_, opt)| opt.is_some())
-    {
-        if let Some(hash) = hash_opt {
-            btree.insert(format!("{:02x}", i), hash);
-        }
-    }
-    btree
+        .filter_map(|(i, hash_opt)| hash_opt.map(|hash| (format!("{:02x}", i), hash)))
+        .collect()
 }
 
 #[cfg(test)]

--- a/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
+++ b/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
@@ -70,7 +70,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, SqliteCon
             let initial_id: i64 = merkle_radix_leaf::table
                 .select(max(merkle_radix_leaf::id))
                 .first::<Option<i64>>(self.conn)?
-                .unwrap_or(1);
+                .unwrap_or(0);
 
             let leaves = nodes
                 .iter()
@@ -150,7 +150,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, PgConnect
             let initial_id: i64 = merkle_radix_leaf::table
                 .select(max(merkle_radix_leaf::id))
                 .first::<Option<i64>>(self.conn)?
-                .unwrap_or(1);
+                .unwrap_or(0);
 
             let leaves = nodes
                 .iter()

--- a/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
+++ b/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
@@ -191,7 +191,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, PgConnect
                 .collect::<Result<Vec<_>, _>>()?;
 
             insert_into(postgres_merkle_radix_tree_node::table)
-                .values(node_models)
+                .values(&node_models)
                 .on_conflict_do_nothing()
                 .execute(self.conn)?;
 

--- a/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
+++ b/libtransact/src/state/merkle/sql/operations/insert_nodes.rs
@@ -74,10 +74,9 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, SqliteCon
 
             let leaves = nodes
                 .iter()
-                .filter(|insertable_node| insertable_node.node.value.is_some())
                 .enumerate()
-                .map(|(i, insertable_node)| {
-                    if let Some(data) = insertable_node.node.value.as_deref() {
+                .filter_map(|(i, insertable_node)| {
+                    insertable_node.node.value.as_deref().map(|data| {
                         Ok(NewMerkleRadixLeaf {
                             id: initial_id.checked_add(1 + i as i64).ok_or_else(|| {
                                 InternalError::with_message("exceeded id space".into())
@@ -86,10 +85,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, SqliteCon
                             address: &insertable_node.address,
                             data,
                         })
-                    } else {
-                        // we already filtered out the None values
-                        unreachable!()
-                    }
+                    })
                 })
                 .collect::<Result<Vec<NewMerkleRadixLeaf>, InternalError>>()?;
 
@@ -158,10 +154,9 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, PgConnect
 
             let leaves = nodes
                 .iter()
-                .filter(|insertable_node| insertable_node.node.value.is_some())
                 .enumerate()
-                .map(|(i, insertable_node)| {
-                    if let Some(data) = insertable_node.node.value.as_deref() {
+                .filter_map(|(i, insertable_node)| {
+                    insertable_node.node.value.as_deref().map(|data| {
                         Ok(NewMerkleRadixLeaf {
                             id: initial_id.checked_add(1 + i as i64).ok_or_else(|| {
                                 InternalError::with_message("exceeded id space".into())
@@ -170,10 +165,7 @@ impl<'a> MerkleRadixInsertNodesOperation for MerkleRadixOperations<'a, PgConnect
                             address: &insertable_node.address,
                             data,
                         })
-                    } else {
-                        // we already filtered out the None values
-                        unreachable!()
-                    }
+                    })
                 })
                 .collect::<Result<Vec<NewMerkleRadixLeaf>, InternalError>>()?;
 

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -22,6 +22,7 @@ pub(super) mod get_tree_by_name;
 pub(super) mod has_root;
 pub(super) mod insert_nodes;
 pub(super) mod list_leaves;
+pub(super) mod update_change_log;
 pub(super) mod update_index;
 
 #[cfg(feature = "sqlite")]

--- a/libtransact/src/state/merkle/sql/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/operations/mod.rs
@@ -22,6 +22,7 @@ pub(super) mod get_tree_by_name;
 pub(super) mod has_root;
 pub(super) mod insert_nodes;
 pub(super) mod list_leaves;
+pub(super) mod prune_entries;
 pub(super) mod update_change_log;
 pub(super) mod update_index;
 

--- a/libtransact/src/state/merkle/sql/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/operations/prune_entries.rs
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+
+use diesel::dsl::{delete, update};
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::models::{
+    MerkleRadixChangeLogAddition, MerkleRadixChangeLogDeletion, MerkleRadixStateRoot,
+};
+#[cfg(feature = "postgres")]
+use crate::state::merkle::sql::schema::postgres_merkle_radix_tree_node;
+#[cfg(feature = "sqlite")]
+use crate::state::merkle::sql::schema::sqlite_merkle_radix_tree_node;
+use crate::state::merkle::sql::schema::{
+    merkle_radix_change_log_addition, merkle_radix_change_log_deletion, merkle_radix_state_root,
+    merkle_radix_state_root_leaf_index,
+};
+
+use super::MerkleRadixOperations;
+
+const NULL_PARENT: Option<String> = None;
+const NULL_STATE_ROOT_ID: Option<i64> = None;
+
+pub trait MerkleRadixPruneEntriesOperation {
+    fn prune_entries(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> MerkleRadixPruneEntriesOperation for MerkleRadixOperations<'a, SqliteConnection> {
+    fn prune_entries(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError> {
+        self.conn.transaction(|| {
+            let deletion_candidates = get_deletion_candidates(self.conn, tree_id, state_root)?;
+
+            // delete from the index
+            update_indexes(self.conn, tree_id, state_root)?;
+
+            // Remove the change logs for this root
+            // delete its additions entry
+            delete(
+                merkle_radix_change_log_addition::table.filter(
+                    merkle_radix_change_log_addition::tree_id
+                        .eq(tree_id)
+                        .and(merkle_radix_change_log_addition::state_root.eq(state_root)),
+                ),
+            )
+            .execute(self.conn)?;
+            // Unlink any successors it might have
+            delete(
+                merkle_radix_change_log_deletion::table.filter(
+                    merkle_radix_change_log_deletion::tree_id
+                        .eq(tree_id)
+                        .and(merkle_radix_change_log_deletion::state_root.eq(state_root)),
+                ),
+            )
+            .execute(self.conn)?;
+            // Delete its successor entry
+            delete(
+                merkle_radix_change_log_deletion::table.filter(
+                    merkle_radix_change_log_deletion::tree_id
+                        .eq(tree_id)
+                        .and(merkle_radix_change_log_deletion::successor_state_root.eq(state_root)),
+                ),
+            )
+            .execute(self.conn)?;
+            // Remove the parent relation ship on its successors
+            update(
+                merkle_radix_change_log_addition::table
+                    .filter(merkle_radix_change_log_addition::parent_state_root.eq(state_root)),
+            )
+            .set(merkle_radix_change_log_addition::parent_state_root.eq(NULL_PARENT))
+            .execute(self.conn)?;
+
+            let mut deleted_values = vec![];
+            for hash in deletion_candidates.into_iter() {
+                match delete(
+                    sqlite_merkle_radix_tree_node::table.filter(
+                        sqlite_merkle_radix_tree_node::tree_id
+                            .eq(tree_id)
+                            .and(sqlite_merkle_radix_tree_node::hash.eq(&hash)),
+                    ),
+                )
+                .execute(self.conn)
+                {
+                    Ok(_) => deleted_values.push(hash),
+                    Err(diesel::result::Error::DatabaseError(
+                        diesel::result::DatabaseErrorKind::ForeignKeyViolation,
+                        _,
+                    )) => (),
+                    Err(err) => return Err(InternalError::from(err)),
+                }
+            }
+            Ok(deleted_values)
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> MerkleRadixPruneEntriesOperation for MerkleRadixOperations<'a, PgConnection> {
+    fn prune_entries(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError> {
+        self.conn.transaction(|| {
+            let deletion_candidates = get_deletion_candidates(self.conn, tree_id, state_root)?;
+
+            // delete from the index
+            update_indexes(self.conn, tree_id, state_root)?;
+
+            // Remove the change logs for this root
+            // delete its additions entry
+            delete(
+                merkle_radix_change_log_addition::table.filter(
+                    merkle_radix_change_log_addition::tree_id
+                        .eq(tree_id)
+                        .and(merkle_radix_change_log_addition::state_root.eq(state_root)),
+                ),
+            )
+            .execute(self.conn)?;
+            // Unlink any successors it might have
+            delete(
+                merkle_radix_change_log_deletion::table.filter(
+                    merkle_radix_change_log_deletion::tree_id
+                        .eq(tree_id)
+                        .and(merkle_radix_change_log_deletion::state_root.eq(state_root)),
+                ),
+            )
+            .execute(self.conn)?;
+            // Delete its successor entry
+            delete(
+                merkle_radix_change_log_deletion::table.filter(
+                    merkle_radix_change_log_deletion::tree_id
+                        .eq(tree_id)
+                        .and(merkle_radix_change_log_deletion::successor_state_root.eq(state_root)),
+                ),
+            )
+            .execute(self.conn)?;
+            // Remove the parent relation ship on its successors
+            update(
+                merkle_radix_change_log_addition::table
+                    .filter(merkle_radix_change_log_addition::parent_state_root.eq(state_root)),
+            )
+            .set(merkle_radix_change_log_addition::parent_state_root.eq(NULL_PARENT))
+            .execute(self.conn)?;
+
+            let mut deleted_values = vec![];
+            for hash in deletion_candidates.into_iter().rev() {
+                // Put this in a new save-point.
+                match self.conn.transaction(|| {
+                    delete(
+                        postgres_merkle_radix_tree_node::table.filter(
+                            postgres_merkle_radix_tree_node::tree_id
+                                .eq(tree_id)
+                                .and(postgres_merkle_radix_tree_node::hash.eq(&hash)),
+                        ),
+                    )
+                    .execute(self.conn)
+                }) {
+                    Ok(_) => deleted_values.push(hash),
+                    Err(diesel::result::Error::DatabaseError(
+                        diesel::result::DatabaseErrorKind::ForeignKeyViolation,
+                        _,
+                    )) => (),
+                    Err(err) => return Err(InternalError::from(err)),
+                }
+            }
+            Ok(deleted_values)
+        })
+    }
+}
+
+fn get_deletion_candidates<C>(
+    conn: &C,
+    tree_id: i64,
+    state_root: &str,
+) -> Result<Vec<String>, InternalError>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    let change_additions = merkle_radix_change_log_addition::table
+        .filter(
+            merkle_radix_change_log_addition::tree_id
+                .eq(tree_id)
+                .and(merkle_radix_change_log_addition::state_root.eq(state_root)),
+        )
+        .get_results::<MerkleRadixChangeLogAddition>(conn)?
+        .into_iter()
+        .map(|addition| addition.addition)
+        .collect::<Vec<_>>();
+
+    if change_additions.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Find all successors
+    let successors = merkle_radix_change_log_deletion::table
+        .filter(
+            merkle_radix_change_log_deletion::tree_id
+                .eq(tree_id)
+                .and(merkle_radix_change_log_deletion::state_root.eq(state_root)),
+        )
+        .load::<MerkleRadixChangeLogDeletion>(conn)?
+        .into_iter()
+        .fold(HashMap::new(), |mut acc, successor| {
+            let hashes = acc
+                .entry(successor.successor_state_root)
+                .or_insert_with(Vec::new);
+            hashes.push(successor.deletion);
+            acc
+        });
+
+    // Currently, don't clean up a parent with multiple successors
+    if successors.len() > 1 {
+        return Ok(vec![]);
+    }
+
+    let deletion_candidates: Vec<String> = if successors.is_empty() {
+        // this root is the tip of the trie history
+        change_additions
+    } else {
+        // we have one successor, based on our criteria, so we can safely unwrap
+        let (_successor_state_root, mut deletions) = successors.into_iter().next().unwrap();
+        deletions.push(state_root.into());
+        deletions
+    };
+
+    Ok(deletion_candidates)
+}
+
+fn update_indexes<C>(conn: &C, tree_id: i64, pruned_state_root: &str) -> Result<(), InternalError>
+where
+    C: diesel::Connection,
+    i64: diesel::deserialize::FromSql<diesel::sql_types::BigInt, C::Backend>,
+    String: diesel::deserialize::FromSql<diesel::sql_types::Text, C::Backend>,
+{
+    let (root_id, successor) = {
+        use self::merkle_radix_state_root::dsl::*;
+        let root_id = merkle_radix_state_root
+            .select(id)
+            .filter(tree_id.eq(tree_id).and(state_root.eq(pruned_state_root)))
+            .get_result::<i64>(conn)
+            .optional()?;
+
+        let successor = merkle_radix_state_root
+            .filter(
+                tree_id
+                    .eq(tree_id)
+                    .and(parent_state_root.eq(pruned_state_root)),
+            )
+            .get_result::<MerkleRadixStateRoot>(conn)
+            .optional()?;
+
+        (root_id, successor)
+    };
+
+    let root_id = match root_id {
+        Some(id) => id,
+        // Branch is not in the index
+        None => return Ok(()),
+    };
+
+    update(
+        merkle_radix_state_root_leaf_index::table.filter(
+            merkle_radix_state_root_leaf_index::tree_id
+                .eq(tree_id)
+                .and(merkle_radix_state_root_leaf_index::to_state_root_id.eq(root_id)),
+        ),
+    )
+    .set(merkle_radix_state_root_leaf_index::to_state_root_id.eq(NULL_STATE_ROOT_ID))
+    .execute(conn)?;
+
+    if let Some(successor) = successor {
+        // move the starting root ID to the successor root
+        update(
+            merkle_radix_state_root_leaf_index::table.filter(
+                merkle_radix_state_root_leaf_index::tree_id
+                    .eq(tree_id)
+                    .and(merkle_radix_state_root_leaf_index::from_state_root_id.eq(root_id)),
+            ),
+        )
+        .set(merkle_radix_state_root_leaf_index::from_state_root_id.eq(successor.id))
+        .execute(conn)?;
+
+        // Set the root parent to itself.
+        update(merkle_radix_state_root::table.find(successor.id))
+            .set(merkle_radix_state_root::parent_state_root.eq(successor.state_root))
+            .execute(conn)?;
+    } else {
+        // remove any leaves added on this root
+        delete(
+            merkle_radix_state_root_leaf_index::table.filter(
+                merkle_radix_state_root_leaf_index::tree_id
+                    .eq(tree_id)
+                    .and(merkle_radix_state_root_leaf_index::from_state_root_id.eq(root_id)),
+            ),
+        )
+        .execute(conn)?;
+    }
+
+    delete(merkle_radix_state_root::table.find(root_id)).execute(conn)?;
+
+    Ok(())
+}

--- a/libtransact/src/state/merkle/sql/operations/update_change_log.rs
+++ b/libtransact/src/state/merkle/sql/operations/update_change_log.rs
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::dsl::insert_into;
+use diesel::prelude::*;
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::{
+    models::{NewMerkleRadixChangeLogAddition, NewMerkleRadixChangeLogDeletion},
+    schema::merkle_radix_change_log_addition,
+    schema::merkle_radix_change_log_deletion,
+};
+
+use super::MerkleRadixOperations;
+
+pub trait MerkleRadixUpdateUpdateChangeLogOperation {
+    fn update_change_log(
+        &self,
+        tree_id: i64,
+        state_root: &str,
+        parent_state_root: &str,
+        additions: &[&str],
+        deletions: &[&str],
+    ) -> Result<(), InternalError>;
+}
+
+#[cfg(feature = "sqlite")]
+impl<'a> MerkleRadixUpdateUpdateChangeLogOperation for MerkleRadixOperations<'a, SqliteConnection> {
+    fn update_change_log(
+        &self,
+        tree_id: i64,
+        state_root: &str,
+        parent_state_root: &str,
+        additions: &[&str],
+        deletions: &[&str],
+    ) -> Result<(), InternalError> {
+        self.conn.transaction::<_, InternalError, _>(|| {
+            let change_log_additions = additions
+                .iter()
+                .map(|hash| NewMerkleRadixChangeLogAddition {
+                    state_root,
+                    tree_id,
+                    parent_state_root: Some(parent_state_root),
+                    addition: hash,
+                })
+                .collect::<Vec<_>>();
+
+            insert_into(merkle_radix_change_log_addition::table)
+                .values(change_log_additions)
+                .execute(self.conn)?;
+
+            let change_log_deletions = deletions
+                .iter()
+                .map(|hash| NewMerkleRadixChangeLogDeletion {
+                    state_root: parent_state_root,
+                    tree_id,
+                    successor_state_root: state_root,
+                    deletion: hash,
+                })
+                .collect::<Vec<_>>();
+
+            insert_into(merkle_radix_change_log_deletion::table)
+                .values(change_log_deletions)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl<'a> MerkleRadixUpdateUpdateChangeLogOperation for MerkleRadixOperations<'a, PgConnection> {
+    fn update_change_log(
+        &self,
+        tree_id: i64,
+        state_root: &str,
+        parent_state_root: &str,
+        additions: &[&str],
+        deletions: &[&str],
+    ) -> Result<(), InternalError> {
+        self.conn.transaction::<_, InternalError, _>(|| {
+            let change_log_additions = additions
+                .iter()
+                .map(|hash| NewMerkleRadixChangeLogAddition {
+                    state_root,
+                    tree_id,
+                    parent_state_root: Some(parent_state_root),
+                    addition: hash,
+                })
+                .collect::<Vec<_>>();
+
+            insert_into(merkle_radix_change_log_addition::table)
+                .values(change_log_additions)
+                .execute(self.conn)?;
+
+            let change_log_deletions = deletions
+                .iter()
+                .map(|hash| NewMerkleRadixChangeLogDeletion {
+                    state_root: parent_state_root,
+                    tree_id,
+                    successor_state_root: state_root,
+                    deletion: hash,
+                })
+                .collect::<Vec<_>>();
+
+            insert_into(merkle_radix_change_log_deletion::table)
+                .values(change_log_deletions)
+                .execute(self.conn)?;
+
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    use crate::state::merkle::sql::backend::postgres::test::run_postgres_test;
+    #[cfg(feature = "sqlite")]
+    use crate::state::merkle::sql::{
+        migration, models::sqlite, schema::sqlite_merkle_radix_tree_node,
+    };
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    use crate::state::merkle::sql::{models::postgres, schema::postgres_merkle_radix_tree_node};
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_update_change_log() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+
+        migration::sqlite::run_migrations(&conn)?;
+
+        sqlite_insert_state_root_nodes(&conn)?;
+
+        MerkleRadixOperations::new(&conn).update_change_log(
+            1,
+            "new-state-root",
+            "initial-state-root",
+            &[],
+            &[],
+        )?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    #[test]
+    fn postgres_update_change_log() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let conn = PgConnection::establish(&url)?;
+
+            postgres_insert_state_root_nodes(&conn)?;
+
+            MerkleRadixOperations::new(&conn).update_change_log(
+                1,
+                "new-state-root",
+                "initial-state-root",
+                &[],
+                &[],
+            )?;
+
+            Ok(())
+        })
+    }
+
+    #[cfg(feature = "sqlite")]
+    fn sqlite_insert_state_root_nodes(
+        conn: &SqliteConnection,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        insert_into(sqlite_merkle_radix_tree_node::table)
+            .values(vec![
+                sqlite::MerkleRadixTreeNode {
+                    hash: "initial-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: sqlite::Children(vec![]),
+                },
+                sqlite::MerkleRadixTreeNode {
+                    hash: "new-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: sqlite::Children(vec![]),
+                },
+                sqlite::MerkleRadixTreeNode {
+                    hash: "first-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: sqlite::Children(vec![]),
+                },
+                sqlite::MerkleRadixTreeNode {
+                    hash: "second-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: sqlite::Children(vec![]),
+                },
+            ])
+            .execute(conn)?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    fn postgres_insert_state_root_nodes(
+        conn: &PgConnection,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        insert_into(postgres_merkle_radix_tree_node::table)
+            .values(vec![
+                postgres::MerkleRadixTreeNode {
+                    hash: "initial-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: vec![],
+                },
+                postgres::MerkleRadixTreeNode {
+                    hash: "new-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: vec![],
+                },
+                postgres::MerkleRadixTreeNode {
+                    hash: "first-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: vec![],
+                },
+                postgres::MerkleRadixTreeNode {
+                    hash: "second-state-root".into(),
+                    tree_id: 1,
+                    leaf_id: None,
+                    children: vec![],
+                },
+            ])
+            .execute(conn)?;
+
+        Ok(())
+    }
+}

--- a/libtransact/src/state/merkle/sql/schema.rs
+++ b/libtransact/src/state/merkle/sql/schema.rs
@@ -75,6 +75,26 @@ table! {
     }
 }
 
+table! {
+    merkle_radix_change_log_addition (id) {
+        id -> Int8,
+        tree_id -> Int8,
+        state_root -> VarChar,
+        parent_state_root -> Nullable<VarChar>,
+        addition -> VarChar,
+    }
+}
+
+table! {
+    merkle_radix_change_log_deletion (id) {
+        id -> Int8,
+        tree_id -> Int8,
+        successor_state_root -> VarChar,
+        state_root -> VarChar,
+        deletion -> VarChar,
+    }
+}
+
 joinable!(merkle_radix_state_root_leaf_index -> merkle_radix_leaf (leaf_id));
 
 #[cfg(all(feature = "sqlite", feature = "postgres"))]

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -67,6 +67,12 @@ fn merkle_trie_update_same_address_space_with_no_children() {
 }
 
 #[test]
+fn merkle_trie_prune_parent() {
+    let (state, orig_root) = new_btree_state_and_root();
+    test_merkle_trie_prune_parent(orig_root, state);
+}
+
+#[test]
 fn merkle_trie_pruning_parent() {
     let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
     test_merkle_trie_pruning_parent(btree_db);

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -108,6 +108,12 @@ fn merkle_trie_pruning_successor_duplicate_leaves() {
     test_merkle_trie_pruning_successor_duplicate_leaves(btree_db);
 }
 
+#[test]
+fn merkle_trie_prune_successor_duplicate_leaves() {
+    let (state, orig_root) = new_btree_state_and_root();
+    test_merkle_trie_prune_successor_duplicate_leaves(orig_root, state);
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() {

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -91,6 +91,12 @@ fn merkle_trie_pruning_successors() {
 }
 
 #[test]
+fn merkle_trie_prune_duplicate_leaves() {
+    let (state, orig_root) = new_btree_state_and_root();
+    test_merkle_trie_prune_duplicate_leaves(orig_root, state);
+}
+
+#[test]
 fn merkle_trie_pruning_duplicate_leaves() {
     let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
     test_merkle_trie_pruning_duplicate_leaves(btree_db);

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -79,6 +79,12 @@ fn merkle_trie_pruning_parent() {
 }
 
 #[test]
+fn merkle_trie_prune_successors() {
+    let (state, orig_root) = new_btree_state_and_root();
+    test_merkle_trie_prune_successors(orig_root, state);
+}
+
+#[test]
 fn merkle_trie_pruning_successors() {
     let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
     test_merkle_trie_pruning_successors(btree_db);

--- a/libtransact/tests/state/merkle/lmdb.rs
+++ b/libtransact/tests/state/merkle/lmdb.rs
@@ -123,6 +123,14 @@ fn merkle_trie_pruning_successors() {
 }
 
 #[test]
+fn merkle_trie_prune_duplicate_leaves() {
+    run_test(|merkle_path| {
+        let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+        test_merkle_trie_prune_duplicate_leaves(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_duplicate_leaves() {
     run_test(|merkle_path| {
         let db = make_lmdb(&merkle_path);

--- a/libtransact/tests/state/merkle/lmdb.rs
+++ b/libtransact/tests/state/merkle/lmdb.rs
@@ -107,6 +107,14 @@ fn merkle_trie_pruning_parent() {
 }
 
 #[test]
+fn merkle_trie_prune_successors() {
+    run_test(|merkle_path| {
+        let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+        test_merkle_trie_prune_successors(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_successors() {
     run_test(|merkle_path| {
         let db = make_lmdb(&merkle_path);

--- a/libtransact/tests/state/merkle/lmdb.rs
+++ b/libtransact/tests/state/merkle/lmdb.rs
@@ -91,6 +91,14 @@ fn merkle_trie_update_same_address_space_with_no_children() {
 }
 
 #[test]
+fn merkle_trie_prune_parent() {
+    run_test(|merkle_path| {
+        let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+        test_merkle_trie_prune_parent(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_parent() {
     run_test(|merkle_path| {
         let db = make_lmdb(&merkle_path);

--- a/libtransact/tests/state/merkle/lmdb.rs
+++ b/libtransact/tests/state/merkle/lmdb.rs
@@ -139,6 +139,14 @@ fn merkle_trie_pruning_duplicate_leaves() {
 }
 
 #[test]
+fn merkle_trie_prune_successor_duplicate_leaves() {
+    run_test(|merkle_path| {
+        let (state, orig_root) = new_lmdb_state_and_root(merkle_path);
+        test_merkle_trie_prune_successor_duplicate_leaves(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_successor_duplicate_leaves() {
     run_test(|merkle_path| {
         let db = make_lmdb(&merkle_path);

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -103,6 +103,15 @@ fn merkle_trie_prune_successors() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[test]
+fn merkle_trie_prune_duplicate_leaves() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_prune_duplicate_leaves(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -112,6 +112,15 @@ fn merkle_trie_prune_duplicate_leaves() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[test]
+fn merkle_trie_prune_successor_duplicate_leaves() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_prune_successor_duplicate_leaves(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -85,6 +85,15 @@ fn merkle_trie_update_same_address_space_with_no_children() -> Result<(), Box<dy
     })
 }
 
+#[test]
+fn merkle_trie_prune_parent() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_prune_parent(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -94,6 +94,15 @@ fn merkle_trie_prune_parent() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[test]
+fn merkle_trie_prune_successors() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_prune_successors(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -94,6 +94,15 @@ fn merkle_trie_update_same_address_space_with_no_children() -> Result<(), Box<dy
     })
 }
 
+#[test]
+fn merkle_trie_prune_parent() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_prune_parent(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -112,6 +112,15 @@ fn merkle_trie_prune_successors() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[test]
+fn merkle_trie_prune_duplicate_leaves() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_prune_duplicate_leaves(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -121,6 +121,15 @@ fn merkle_trie_prune_duplicate_leaves() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[test]
+fn merkle_trie_prune_successor_duplicate_leaves() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_prune_successor_duplicate_leaves(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -103,6 +103,15 @@ fn merkle_trie_prune_parent() -> Result<(), Box<dyn Error>> {
     })
 }
 
+#[test]
+fn merkle_trie_prune_successors() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_prune_successors(orig_root, state);
+        Ok(())
+    })
+}
+
 #[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {

--- a/libtransact/tests/state/merkle/sqlitedb.rs
+++ b/libtransact/tests/state/merkle/sqlitedb.rs
@@ -184,6 +184,14 @@ fn merkle_trie_pruning_duplicate_leaves() {
 }
 
 #[test]
+fn merkle_trie_prune_successor_duplicate_leaves() {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sqlite_state_and_root(db_path);
+        test_merkle_trie_prune_successor_duplicate_leaves(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_successor_duplicate_leaves() {
     run_test(|db_path| {
         let db = Box::new(

--- a/libtransact/tests/state/merkle/sqlitedb.rs
+++ b/libtransact/tests/state/merkle/sqlitedb.rs
@@ -166,6 +166,14 @@ fn merkle_trie_pruning_successors() {
 }
 
 #[test]
+fn merkle_trie_prune_duplicate_leaves() {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sqlite_state_and_root(db_path);
+        test_merkle_trie_prune_duplicate_leaves(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_duplicate_leaves() {
     run_test(|db_path| {
         let db = Box::new(

--- a/libtransact/tests/state/merkle/sqlitedb.rs
+++ b/libtransact/tests/state/merkle/sqlitedb.rs
@@ -148,6 +148,14 @@ fn merkle_trie_pruning_parent() {
 }
 
 #[test]
+fn merkle_trie_prune_successors() {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sqlite_state_and_root(db_path);
+        test_merkle_trie_prune_successors(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_successors() {
     run_test(|db_path| {
         let db = Box::new(

--- a/libtransact/tests/state/merkle/sqlitedb.rs
+++ b/libtransact/tests/state/merkle/sqlitedb.rs
@@ -130,6 +130,14 @@ fn merkle_trie_update_same_address_space_with_no_children() {
 }
 
 #[test]
+fn merkle_trie_prune_parent() {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sqlite_state_and_root(db_path);
+        test_merkle_trie_prune_parent(orig_root, state);
+    })
+}
+
+#[test]
 fn merkle_trie_pruning_parent() {
     run_test(|db_path| {
         let db = Box::new(


### PR DESCRIPTION
This PR implements state pruning for the SqlMerkleState.  It adds two new operations, one to update a change log and the other to perform the pruning operation.

It removes the use of the index in get_leaves and goes directly against the tree node table using another recursive query - in order to support the appropriate branching needs in the state pruning tests (i.e. one parent root, two successor roots).