### PR TITLE
Add feature deps for family-command-workload

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -155,7 +155,13 @@ database-redis = ["redis"]
 database-sqlite = ["rusqlite", "r2d2", "r2d2_sqlite"]
 execution = ["context", "handler", "log", "protocol-transaction", "scheduler"]
 family-command = ["handler"]
-family-command-workload = ["cylinder", "family-command", "protocol-transaction-builder"]
+family-command-workload = [
+    "cylinder",
+    "family-command",
+    "protocol-sabre-exec",
+    "protocol-transaction-builder",
+    "workload",
+]
 family-smallbank = ["handler"]
 family-smallbank-workload = [
   "family-smallbank",

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -164,11 +164,11 @@ family-command-workload = [
 ]
 family-smallbank = ["handler"]
 family-smallbank-workload = [
-  "family-smallbank",
-  "protocol-sabre-exec",
-  "yaml-rust",
-  "workload",
-  "workload-runner"
+    "family-smallbank",
+    "protocol-sabre-exec",
+    "yaml-rust",
+    "workload",
+    "workload-runner"
 ]
 family-xo = ["handler", "rand_hc", "workload"]
 handler = ["protocol-transaction"]
@@ -196,17 +196,18 @@ state-merkle-redis-db-tests = ["database-redis", "state-merkle"]
 workload = []
 workload-batch-gen = ["workload"]
 workload-runner = [
-  "chrono",
-  "reqwest",
-  "serde",
-  "serde_derive",
-  "workload-batch-gen"]
+    "chrono",
+    "reqwest",
+    "serde",
+    "serde_derive",
+    "workload-batch-gen"
+]
 
 [package.metadata.docs.rs]
 features = [
-  "default",
-  "nightly",
-  "experimental",
-  "sawtooth-compat",
-  "stable",
+    "default",
+    "nightly",
+    "experimental",
+    "sawtooth-compat",
+    "stable",
 ]


### PR DESCRIPTION
This PR fixes the feature `"family-command-workload"` such that compiling like:

```
$ cargo check --manifest-path libtransact/Cargo.toml --features family-command-workload
```

will successfully compile.

It also makes the indenting consistent in the Cargo.toml