### PR TITLE
Add state-merkle-leaf-reader feature dep

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -184,7 +184,7 @@ sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log", "openssl"]
-state-merkle-leaf-reader = []
+state-merkle-leaf-reader = ["state-merkle"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db


### PR DESCRIPTION
This change adds a feature dependency on the feature "state-merkle", as only including the leaf reader feature will not compile.