### PR TITLE
Update MerkleRadixLeafReader rustdoc

### DIFF
--- a/libtransact/src/state/merkle/error.rs
+++ b/libtransact/src/state/merkle/error.rs
@@ -20,9 +20,18 @@ use std::fmt;
 
 use crate::error::{InternalError, InvalidStateError};
 
+/// Error variants that may occur while reading Merkle Radix tree leaves.
 #[derive(Debug)]
 pub enum MerkleRadixLeafReadError {
+    /// An internal error occurred.
+    ///
+    /// This error may be caused by an issue outside of the control of the application, such as
+    /// invalid storage.
     InternalError(InternalError),
+    /// An invalid state error occurred.
+    ///
+    /// This error may occur in cases where the reader has been provided invalid state, such as a
+    /// non-existent state root hash.
     InvalidStateError(InvalidStateError),
 }
 

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -40,11 +40,20 @@ type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
 #[cfg(feature = "state-merkle-leaf-reader")]
 type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
+/// A Merkle-Radix tree leaf reader.
+///
+/// This trait provides an interface to a Merkle-Radix state implementation in order to return an
+/// iterator over the leaves of the tree at a given state root hash.
 #[cfg(feature = "state-merkle-leaf-reader")]
 pub trait MerkleRadixLeafReader: Read<StateId = String, Key = String, Value = Vec<u8>> {
     /// Returns an iterator over the leaves of a merkle radix tree.
+    ///
+    /// The leaves returned by this iterator are tied to a specific state ID - in the merkle tree,
+    /// this is defined as a specific state root hash. The leaves are returned in natural address
+    /// order.
+    ///
     /// By providing an optional address prefix, the caller can limit the iteration
-    /// over the leaves in a specific subtree.
+    /// over the leaves in a specific sub-tree.
     fn leaves(
         &self,
         state_id: &Self::StateId,


### PR DESCRIPTION
This change updates the rustdoc for the `MerkleRadixLeafReader` trait and its associated error.
