### PR TITLE
Add From implementation for ConnectionPool

### DIFF
--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -52,6 +52,14 @@ impl Backend for PostgresBackend {
     }
 }
 
+impl From<Pool<ConnectionManager<diesel::pg::PgConnection>>> for PostgresBackend {
+    fn from(pool: Pool<ConnectionManager<diesel::pg::PgConnection>>) -> Self {
+        Self {
+            connection_pool: pool,
+        }
+    }
+}
+
 /// A Builder for the PostgresBackend.
 #[derive(Default)]
 pub struct PostgresBackendBuilder {

--- a/libtransact/src/state/merkle/sql/backend/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/backend/sqlite.rs
@@ -63,6 +63,14 @@ impl Backend for SqliteBackend {
     }
 }
 
+impl From<Pool<ConnectionManager<sqlite::SqliteConnection>>> for SqliteBackend {
+    fn from(pool: Pool<ConnectionManager<sqlite::SqliteConnection>>) -> Self {
+        Self {
+            connection_pool: pool,
+        }
+    }
+}
+
 /// The default size
 pub const DEFAULT_MMAP_SIZE: i64 = 100 * 1024 * 1024;
 


### PR DESCRIPTION
This change adds the ability to convert from an existing `ConnectionPool` instance into a specific backend via the `From` trait.
