### PR TITLE
Stabilize state-merkle-leaf-reader feature

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -119,7 +119,6 @@ experimental = [
     "postgres",
     "protocol-sabre-exec",
     "sqlite",
-    "state-merkle-leaf-reader",
     "state-merkle-sql",
     "workload",
     "workload-batch-gen",
@@ -184,7 +183,6 @@ sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log", "openssl"]
-state-merkle-leaf-reader = ["state-merkle"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -24,13 +24,11 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::database::error::DatabaseError;
 use crate::database::{Database, DatabaseReader, DatabaseWriter};
-#[cfg(feature = "state-merkle-leaf-reader")]
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::error::{StatePruneError, StateReadError, StateWriteError};
 use crate::state::{Prune, Read, StateChange, Write};
 
 use super::node::Node;
-#[cfg(feature = "state-merkle-leaf-reader")]
 use super::{MerkleRadixLeafReadError, MerkleRadixLeafReader};
 
 use self::change_log::{ChangeLogEntry, Successor};
@@ -130,12 +128,9 @@ impl Read for MerkleState {
 }
 
 // These types make the clippy happy
-#[cfg(feature = "state-merkle-leaf-reader")]
 type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
-#[cfg(feature = "state-merkle-leaf-reader")]
 type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 impl MerkleRadixLeafReader for MerkleState {
     /// Returns an iterator over the leaves of a merkle radix tree.
     /// By providing an optional address prefix, the caller can limit the iteration

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -17,17 +17,14 @@
  * -----------------------------------------------------------------------------
  */
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 mod error;
 pub mod kv;
 mod node;
 #[cfg(feature = "state-merkle-sql")]
 pub mod sql;
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 use crate::state::Read;
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 pub use error::MerkleRadixLeafReadError;
 pub use kv::{
     MerkleRadixTree, MerkleState, StateDatabaseError, CHANGE_LOG_INDEX, DUPLICATE_LOG_INDEX,
@@ -35,16 +32,13 @@ pub use kv::{
 };
 
 // These types make the clippy happy
-#[cfg(feature = "state-merkle-leaf-reader")]
 type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
-#[cfg(feature = "state-merkle-leaf-reader")]
 type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
 /// A Merkle-Radix tree leaf reader.
 ///
 /// This trait provides an interface to a Merkle-Radix state implementation in order to return an
 /// iterator over the leaves of the tree at a given state root hash.
-#[cfg(feature = "state-merkle-leaf-reader")]
 pub trait MerkleRadixLeafReader: Read<StateId = String, Key = String, Value = Vec<u8>> {
     /// Returns an iterator over the leaves of a merkle radix tree.
     ///

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -62,7 +62,6 @@ use diesel::Connection as _;
 
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::error::{StatePruneError, StateReadError, StateWriteError};
-#[cfg(feature = "state-merkle-leaf-reader")]
 use crate::state::merkle::{MerkleRadixLeafReadError, MerkleRadixLeafReader};
 use crate::state::{Prune, Read, StateChange, Write};
 
@@ -391,12 +390,10 @@ impl Read for SqlMerkleState<backend::PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
-#[cfg(feature = "state-merkle-leaf-reader")]
 type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
-#[cfg(all(feature = "state-merkle-leaf-reader", feature = "sqlite"))]
+#[cfg(feature = "sqlite")]
 impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
     /// Returns an iterator over the leaves of a merkle radix tree.
     /// By providing an optional address prefix, the caller can limit the iteration
@@ -422,7 +419,7 @@ impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-leaf-reader", feature = "postgres"))]
+#[cfg(feature = "postgres")]
 impl MerkleRadixLeafReader for SqlMerkleState<backend::PostgresBackend> {
     /// Returns an iterator over the leaves of a merkle radix tree.
     /// By providing an optional address prefix, the caller can limit the iteration

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -114,7 +114,6 @@ fn merkle_trie_prune_successor_duplicate_leaves() {
     test_merkle_trie_prune_successor_duplicate_leaves(orig_root, state);
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() {
     let (state, orig_root) = new_btree_state_and_root();

--- a/libtransact/tests/state/merkle/lmdb.rs
+++ b/libtransact/tests/state/merkle/lmdb.rs
@@ -154,7 +154,6 @@ fn merkle_trie_pruning_successor_duplicate_leaves() {
     })
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() {
     run_test(|merkle_path| {

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -30,13 +30,11 @@ use std::str::from_utf8;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 
-#[cfg(feature = "state-merkle-leaf-reader")]
-use transact::state::merkle::MerkleRadixLeafReader;
 use transact::{
     database::{error::DatabaseError, Database},
     protos::merkle::ChangeLogEntry,
     state::{
-        merkle::{MerkleRadixTree, MerkleState, CHANGE_LOG_INDEX},
+        merkle::{MerkleRadixLeafReader, MerkleRadixTree, MerkleState, CHANGE_LOG_INDEX},
         Prune, Read, StateChange, StateReadError, Write,
     },
 };
@@ -1063,7 +1061,6 @@ where
     assert_read_value_at_address(&merkle_state, &parent_root, "ab0000", Some("0001"));
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 /// Test iteration over leaves.
 fn test_leaf_iteration<M>(initial_state_root: String, merkle_state: M)
 where

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -121,7 +121,6 @@ fn merkle_trie_prune_successor_duplicate_leaves() -> Result<(), Box<dyn Error>> 
     })
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {
     run_postgres_test(|db_url| {

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -130,7 +130,6 @@ fn merkle_trie_prune_successor_duplicate_leaves() -> Result<(), Box<dyn Error>> 
     })
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {
     run_test(|db_path| {

--- a/libtransact/tests/state/merkle/sqlitedb.rs
+++ b/libtransact/tests/state/merkle/sqlitedb.rs
@@ -201,7 +201,6 @@ fn merkle_trie_pruning_successor_duplicate_leaves() {
     })
 }
 
-#[cfg(feature = "state-merkle-leaf-reader")]
 #[test]
 fn leaf_iteration() {
     run_test(|db_path| {


### PR DESCRIPTION
This change stabilizes the feature "state-merkle-leaf-reader" by removing it.  Its functionality is guarded by "state-merkle".
