### PR TITLE
Correct feature guard for diesel

### DIFF
--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -115,7 +115,7 @@
 
 #![cfg_attr(feature = "nightly", feature(test))]
 
-#[cfg(feature = "state-merkle-sql")]
+#[cfg(feature = "diesel")]
 #[macro_use]
 extern crate diesel;
 #[cfg(feature = "diesel_migrations")]


### PR DESCRIPTION
This change corrects the feature guard for diesel to "diesel", making it less dependent on the feature defined in libtransact's Cargo.toml, and merely dependent on whether or not the optional dependency is included in the set of active features.
