### PR TITLE
Restrict just doc to published configuration 

### DIFF
--- a/justfile
+++ b/justfile
@@ -110,7 +110,10 @@ copy-env:
 doc:
     #!/usr/bin/env sh
     set -e
-    cargo doc --no-deps
+    cargo doc \
+        --manifest-path libtransact/Cargo.toml \
+        --features stable,experimental \
+        --no-deps
 
 lint:
     #!/usr/bin/env sh

--- a/libtransact/src/contract/archive/mod.rs
+++ b/libtransact/src/contract/archive/mod.rs
@@ -80,7 +80,7 @@ impl SmartContractArchive {
     /// latest contract (based on semver requirement rules) that matches the given name and meets
     /// the version requirements will be loaded.
     ///
-    /// For more info on semver: https://semver.org/
+    /// For more info on semver: <https://semver.org/>
     ///
     /// # Example
     ///

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -43,8 +43,9 @@
 //! # }
 //! ```
 //!
-//! The resulting `merkle_state` can then be used via the [`Read`], [`Write`] and
-//! [`MerkleRadixLeafReader`] traits.
+//! The resulting `merkle_state` can then be used via the [`Read`](crate::state::Read),
+//! [`Write`](crate::state::Write) and [`MerkleRadixLeafReader`](super::MerkleRadixLeafReader)
+//! traits.
 //!
 //! Available if the feature "state-merkle-sql" is enabled.
 


### PR DESCRIPTION
This change restricts the `just doc` task to only apply the rustdoc configuration that would be run for the published crates.  Prior to this commit, `just doc` would run the whole workspace, which causes file name conflicts between libtransact and transact-cli.

Also fixes some resulting warnings from this change.
