### PR TITLE
Remove StateDatabaseError::InternalError variant

### DIFF
--- a/libtransact/src/state/merkle/kv/error.rs
+++ b/libtransact/src/state/merkle/kv/error.rs
@@ -17,7 +17,6 @@
 use std::error::Error;
 use std::fmt;
 
-use crate::error::InternalError;
 use crate::protos::ProtoConversionError;
 use cbor::decoder::DecodeError;
 use cbor::encoder::EncodeError;
@@ -31,7 +30,6 @@ pub enum StateDatabaseError {
     DeserializationError(DecodeError),
     SerializationError(EncodeError),
     ChangeLogEncodingError(String),
-    InternalError(InternalError),
     InvalidRecord,
     InvalidHash(String),
     InvalidChangeLogIndex(String),
@@ -53,7 +51,6 @@ impl fmt::Display for StateDatabaseError {
             StateDatabaseError::ChangeLogEncodingError(ref msg) => {
                 write!(f, "Unable to serialize change log entry: {}", msg)
             }
-            StateDatabaseError::InternalError(ref err) => f.write_str(&err.to_string()),
             StateDatabaseError::InvalidRecord => write!(f, "A node was malformed"),
             StateDatabaseError::InvalidHash(ref msg) => {
                 write!(f, "The given hash is invalid: {}", msg)
@@ -79,7 +76,6 @@ impl Error for StateDatabaseError {
             StateDatabaseError::DeserializationError(ref err) => Some(err),
             StateDatabaseError::SerializationError(ref err) => Some(err),
             StateDatabaseError::ChangeLogEncodingError(_) => None,
-            StateDatabaseError::InternalError(ref err) => Some(err),
             StateDatabaseError::InvalidRecord => None,
             StateDatabaseError::InvalidHash(_) => None,
             StateDatabaseError::InvalidChangeLogIndex(_) => None,
@@ -125,11 +121,5 @@ impl From<ProtobufError> for StateDatabaseError {
 impl From<ProtoConversionError> for StateDatabaseError {
     fn from(err: ProtoConversionError) -> Self {
         StateDatabaseError::ProtobufConversionError(err)
-    }
-}
-
-impl From<InternalError> for StateDatabaseError {
-    fn from(err: InternalError) -> Self {
-        StateDatabaseError::InternalError(err)
     }
 }

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -20,6 +20,7 @@
 #[cfg(feature = "state-merkle-leaf-reader")]
 mod error;
 pub mod kv;
+#[cfg(feature = "state-merkle-sql")]
 mod node;
 #[cfg(feature = "state-merkle-sql")]
 pub mod sql;

--- a/libtransact/src/state/merkle/node.rs
+++ b/libtransact/src/state/merkle/node.rs
@@ -18,7 +18,6 @@
 use std::collections::BTreeMap;
 use std::io::Cursor;
 
-use cbor::decoder::GenericDecoder;
 use cbor::encoder::GenericEncoder;
 use cbor::value::{Bytes, Key, Text, Value};
 
@@ -70,72 +69,6 @@ impl Node {
 
         Ok(e.into_inner().into_writer().into_inner())
     }
-
-    /// Deserializes the given bytes to a Node
-    pub fn from_bytes(bytes: &[u8]) -> Result<Node, InternalError> {
-        let input = Cursor::new(bytes);
-        let mut decoder = GenericDecoder::new(cbor::Config::default(), input);
-        let decoder_value = decoder.value()?;
-        let (val, children_raw) = match decoder_value {
-            Value::Map(mut root_map) => (
-                root_map.remove(&Key::Text(Text::Text("v".to_string()))),
-                root_map.remove(&Key::Text(Text::Text("c".to_string()))),
-            ),
-            _ => {
-                return Err(InternalError::with_message(
-                    "Invalid node record: is not a map".into(),
-                ))
-            }
-        };
-
-        let value = match val {
-            Some(Value::Bytes(Bytes::Bytes(bytes))) => Some(bytes),
-            Some(Value::Null) => None,
-            _ => {
-                return Err(InternalError::with_message(
-                    "Invalid node record: incorrect value type".into(),
-                ))
-            }
-        };
-
-        let children = match children_raw {
-            Some(Value::Map(child_map)) => {
-                let mut result = BTreeMap::new();
-                for (k, v) in child_map {
-                    result.insert(key_to_string(k)?, text_to_string(v)?);
-                }
-                result
-            }
-            None => BTreeMap::new(),
-            _ => {
-                return Err(InternalError::with_message(
-                    "Invalid node record: incorrect child map type".into(),
-                ))
-            }
-        };
-
-        Ok(Node { value, children })
-    }
-}
-
-/// Converts a CBOR Key to its String content
-fn key_to_string(key_val: Key) -> Result<String, InternalError> {
-    match key_val {
-        Key::Text(Text::Text(s)) => Ok(s),
-        _ => Err(InternalError::with_message(
-            "Invalid node record: invalid key type".into(),
-        )),
-    }
-}
-
-/// Converts a CBOR Text Value to its String content
-fn text_to_string(text_val: Value) -> Result<String, InternalError> {
-    match text_val {
-        Value::Text(Text::Text(s)) => Ok(s),
-        _ => Err(InternalError::with_message(
-            "Invalid node record: invalid value type".into(),
-        )),
-    }
 }
 
 #[cfg(test)]
@@ -162,45 +95,5 @@ mod tests {
         let output = "a26163a16261626331323361764568656c6c6f";
 
         assert_eq!(output, packed);
-    }
-
-    #[test]
-    fn node_deserialize() {
-        let packed =
-            ::hex::decode("a26163a162303063616263617647676f6f64627965").expect("improper hex");
-
-        let unpacked = Node::from_bytes(&packed).unwrap();
-        assert_eq!(
-            Node {
-                value: Some(b"goodbye".to_vec()),
-                children: vec![("00".to_string(), "abc".to_string())]
-                    .into_iter()
-                    .collect(),
-            },
-            unpacked
-        );
-    }
-
-    #[test]
-    fn node_roundtrip() {
-        let n = Node {
-            value: Some(b"hello".to_vec()),
-            children: vec![("ab".to_string(), "123".to_string())]
-                .into_iter()
-                .collect(),
-        };
-
-        let packed = n.into_bytes().unwrap();
-        let unpacked = Node::from_bytes(&packed).unwrap();
-
-        assert_eq!(
-            Node {
-                value: Some(b"hello".to_vec()),
-                children: vec![("ab".to_string(), "123".to_string())]
-                    .into_iter()
-                    .collect(),
-            },
-            unpacked
-        )
     }
 }


### PR DESCRIPTION
This change removes the StateDatabaseError InternalError variant, as this is a backwards-incompatible change.

In order to remove this, the original Node implementation has been restored in the kv module, the state::merkle::node::Node implementation has been reduced to only what the SQL implementation requires, and is guarded by the "state-merkle-sql" feature.
