### PR TITLE
Correct feature guard for serde_derive

### DIFF
--- a/libtransact/src/lib.rs
+++ b/libtransact/src/lib.rs
@@ -142,6 +142,6 @@ pub mod workload;
 
 #[macro_use]
 extern crate log;
-#[cfg(feature = "contract-archive")]
+#[cfg(feature = "serde_derive")]
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
This change corrects the feature guard for serde_derive to "serde_derive", making it less dependent on the feature defined in
libtransact's Cargo.toml, and merely dependent on whether or not the optional dependency is included in the set of active features.
