### PR TITLE
Add MerkleLeafIter back to public API

### DIFF
--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -591,8 +591,10 @@ impl MerkleRadixTree {
     }
 }
 
-// A MerkleLeafIterator is fixed to iterate over the state address/value pairs
-// the merkle root hash at the time of its creation.
+/// A MerkleLeafIterator is fixed to iterate over the state address/value pairs
+/// the merkle root hash at the time of its creation.
+///
+/// This struct is soft-deprecated, as it should not be directly referenced.
 pub struct MerkleLeafIterator {
     merkle_db: MerkleRadixTree,
     visited: VecDeque<(String, Node)>,

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -27,8 +27,8 @@ use crate::state::Read;
 
 pub use error::MerkleRadixLeafReadError;
 pub use kv::{
-    MerkleRadixTree, MerkleState, StateDatabaseError, CHANGE_LOG_INDEX, DUPLICATE_LOG_INDEX,
-    INDEXES,
+    MerkleLeafIterator, MerkleRadixTree, MerkleState, StateDatabaseError, CHANGE_LOG_INDEX,
+    DUPLICATE_LOG_INDEX, INDEXES,
 };
 
 // These types make the clippy happy


### PR DESCRIPTION
This change re-exports the `MerkleLeafIterator` struct as part of the public API of `transact::state::merkle`.

While this struct is not returned by any of the public functions on `MerkleState` or `MerkleRadixTree`, it was part of the public API and may be used by library consumers.

It also soft-deprecates this struct, as it should not be part of the public API in the future.