### PR TITLE
Backport 0-3: Add MerkleLeafIter back to public API

### DIFF
--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -593,8 +593,10 @@ impl MerkleRadixTree {
     }
 }
 
-// A MerkleLeafIterator is fixed to iterate over the state address/value pairs
-// the merkle root hash at the time of its creation.
+/// A MerkleLeafIterator is fixed to iterate over the state address/value pairs
+/// the merkle root hash at the time of its creation.
+///
+/// This struct is soft-deprecated, as it should not be directly referenced.
 pub struct MerkleLeafIterator {
     merkle_db: MerkleRadixTree,
     visited: VecDeque<(String, Node)>,

--- a/libtransact/src/state/merkle/mod.rs
+++ b/libtransact/src/state/merkle/mod.rs
@@ -31,8 +31,8 @@ use crate::state::Read;
 #[cfg(feature = "state-merkle-leaf-reader")]
 pub use error::MerkleRadixLeafReadError;
 pub use kv::{
-    MerkleRadixTree, MerkleState, StateDatabaseError, CHANGE_LOG_INDEX, DUPLICATE_LOG_INDEX,
-    INDEXES,
+    MerkleLeafIterator, MerkleRadixTree, MerkleState, StateDatabaseError, CHANGE_LOG_INDEX,
+    DUPLICATE_LOG_INDEX, INDEXES,
 };
 
 // These types make the clippy happy


### PR DESCRIPTION
Back-port of #205 