### PR TITLE
Allow migrations to be run against a single connection

### DIFF
--- a/libtransact/src/state/merkle/sql/migration/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/mod.rs
@@ -26,6 +26,11 @@ use crate::error::InternalError;
 
 use super::backend::Backend;
 
+#[cfg(feature = "postgres")]
+pub use postgres::run_migrations as run_postgres_migrations;
+#[cfg(feature = "sqlite")]
+pub use sqlite::run_migrations as run_sqlite_migrations;
+
 /// Provides backend migration execution.
 ///
 /// Backend's that implement this trait can expose a migration operation on their underlying


### PR DESCRIPTION
This change allows the user to run the migrations directly against a reference to a diesel connection.  It accomplishes this by re-exporting the database-specific migration functions directly from the migration module.

This allows migrations to be run in instances where the caller does not have access to a pool or the connection string, and therefore cannot use a `Backend` instance via the `MigrationManager`.
 