### PR TITLE
Add sabre_command and sabre_smallbank to top-level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,9 @@ members = [
   "libtransact",
   "examples/simple_xo",
   "examples/address_generator",
+  "examples/sabre_command",
   "examples/sabre_command_executor",
+  "examples/sabre_smallbank",
   "cli"
   ]
 


### PR DESCRIPTION
This fixes 'cargo clean' which in turn fixes 'just clean', and makes
sabre_command and sabre_smallbank use the shared target directory during
builds.