### PR TITLE
`workload` stabilization updates

### DIFF
--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -23,7 +23,8 @@ pub mod batch_gen;
 pub mod error;
 #[cfg(feature = "workload-runner")]
 mod runner;
-pub mod source;
+#[cfg(feature = "workload-batch-gen")]
+mod source;
 
 use crate::protocol::batch::BatchPair;
 use crate::protocol::transaction::TransactionPair;


### PR DESCRIPTION
Stabilization related updates for the workload feature
- Add documentation for the workload module
- Make the source module private and put it behind the "workload-batch-gen" feature because it's only used in the `batch_gen` module which is behind this feature 