### PR TITLE
`workload` feature stabilization updates - errors

### DIFF
--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -196,7 +196,7 @@ impl<'a> Iterator for BatchListFeeder<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let batches = match self.batch_source.next(1) {
             Ok(batches) => batches,
-            Err(err) => return Some(Err(BatchReadingError::MessageError(err))),
+            Err(err) => return Some(Err(BatchReadingError::Message(err))),
         };
 
         let batch_proto = match batches.get(0) {
@@ -206,7 +206,7 @@ impl<'a> Iterator for BatchListFeeder<'a> {
 
         match BatchPair::from_proto(batch_proto.clone()) {
             Ok(batch) => Some(Ok(batch)),
-            Err(err) => Some(Err(BatchReadingError::ProtoConversionError(err))),
+            Err(err) => Some(Err(BatchReadingError::ProtoConversion(err))),
         }
     }
 }

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -18,6 +18,7 @@
 
 use cylinder::SigningError;
 
+#[cfg(feature = "workload-batch-gen")]
 use crate::protos::ProtoConversionError;
 
 #[cfg(feature = "workload-runner")]
@@ -95,6 +96,7 @@ impl std::error::Error for BatchingError {
 }
 
 /// Errors that may occur during the reading of batches.
+#[cfg(feature = "workload-batch-gen")]
 #[derive(Debug)]
 pub enum BatchReadingError {
     Message(protobuf::ProtobufError),
@@ -103,12 +105,14 @@ pub enum BatchReadingError {
     ProtoConversion(ProtoConversionError),
 }
 
+#[cfg(feature = "workload-batch-gen")]
 impl From<protobuf::ProtobufError> for BatchReadingError {
     fn from(err: protobuf::ProtobufError) -> Self {
         BatchReadingError::Message(err)
     }
 }
 
+#[cfg(feature = "workload-batch-gen")]
 impl std::fmt::Display for BatchReadingError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
@@ -126,6 +130,7 @@ impl std::fmt::Display for BatchReadingError {
     }
 }
 
+#[cfg(feature = "workload-batch-gen")]
 impl std::error::Error for BatchReadingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -97,29 +97,29 @@ impl std::error::Error for BatchingError {
 /// Errors that may occur during the reading of batches.
 #[derive(Debug)]
 pub enum BatchReadingError {
-    MessageError(protobuf::ProtobufError),
-    BatchingError(BatchingError),
-    UnknownError,
-    ProtoConversionError(ProtoConversionError),
+    Message(protobuf::ProtobufError),
+    Batching(BatchingError),
+    Unknown,
+    ProtoConversion(ProtoConversionError),
 }
 
 impl From<protobuf::ProtobufError> for BatchReadingError {
     fn from(err: protobuf::ProtobufError) -> Self {
-        BatchReadingError::MessageError(err)
+        BatchReadingError::Message(err)
     }
 }
 
 impl std::fmt::Display for BatchReadingError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            BatchReadingError::MessageError(ref err) => {
+            BatchReadingError::Message(ref err) => {
                 write!(f, "Error occurred reading messages: {}", err)
             }
-            BatchReadingError::BatchingError(ref err) => {
+            BatchReadingError::Batching(ref err) => {
                 write!(f, "Error creating the batch: {}", err)
             }
-            BatchReadingError::UnknownError => write!(f, "There was an unknown batching error."),
-            BatchReadingError::ProtoConversionError(ref err) => {
+            BatchReadingError::Unknown => write!(f, "There was an unknown batching error."),
+            BatchReadingError::ProtoConversion(ref err) => {
                 write!(f, "Error converting batch from proto: {}", err)
             }
         }
@@ -129,10 +129,10 @@ impl std::fmt::Display for BatchReadingError {
 impl std::error::Error for BatchReadingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            BatchReadingError::MessageError(ref err) => Some(err),
-            BatchReadingError::BatchingError(ref err) => Some(err),
-            BatchReadingError::UnknownError => Some(&BatchReadingError::UnknownError),
-            BatchReadingError::ProtoConversionError(ref err) => Some(err),
+            BatchReadingError::Message(ref err) => Some(err),
+            BatchReadingError::Batching(ref err) => Some(err),
+            BatchReadingError::Unknown => Some(&BatchReadingError::Unknown),
+            BatchReadingError::ProtoConversion(ref err) => Some(err),
         }
     }
 }

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -18,57 +18,7 @@
 
 use cylinder::SigningError;
 
-use crate::protocol::batch::BatchBuildError;
-use crate::protocol::transaction::TransactionBuildError;
 use crate::protos::ProtoConversionError;
-
-#[derive(Debug)]
-pub enum WorkloadError {
-    // Returned when an error occurs while using BatchBuilder.
-    BatchBuildError(BatchBuildError),
-
-    // Returned when an error occurs while using TransactionBuilder.
-    TransactionBuildError(TransactionBuildError),
-
-    // Underlying workload raised an error
-    InvalidState(String),
-}
-
-impl std::error::Error for WorkloadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            WorkloadError::BatchBuildError(ref err) => Some(err),
-            WorkloadError::TransactionBuildError(ref err) => Some(err),
-            WorkloadError::InvalidState(_) => None,
-        }
-    }
-}
-
-impl std::fmt::Display for WorkloadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            WorkloadError::BatchBuildError(ref err) => write!(f, "BatchBuildError: {}", err),
-            WorkloadError::TransactionBuildError(ref err) => {
-                write!(f, "TransactionBuildError: {}", err)
-            }
-            WorkloadError::InvalidState(ref err) => {
-                write!(f, "InvalidState: {}", err)
-            }
-        }
-    }
-}
-
-impl From<BatchBuildError> for WorkloadError {
-    fn from(err: BatchBuildError) -> WorkloadError {
-        WorkloadError::BatchBuildError(err)
-    }
-}
-
-impl From<TransactionBuildError> for WorkloadError {
-    fn from(err: TransactionBuildError) -> WorkloadError {
-        WorkloadError::TransactionBuildError(err)
-    }
-}
 
 #[cfg(feature = "workload-runner")]
 #[derive(Debug, PartialEq)]

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -26,9 +26,9 @@ mod runner;
 #[cfg(feature = "workload-batch-gen")]
 mod source;
 
+use crate::error::InvalidStateError;
 use crate::protocol::batch::BatchPair;
 use crate::protocol::transaction::TransactionPair;
-use crate::workload::error::WorkloadError;
 #[cfg(feature = "workload-runner")]
 pub use crate::workload::runner::{submit_batches_from_source, WorkloadRunner};
 
@@ -37,14 +37,15 @@ pub trait TransactionWorkload: Send {
     /// Get a `TransactionPair` and the result that is expected when that transaction is executed
     fn next_transaction(
         &mut self,
-    ) -> Result<(TransactionPair, Option<ExpectedBatchResult>), WorkloadError>;
+    ) -> Result<(TransactionPair, Option<ExpectedBatchResult>), InvalidStateError>;
 }
 
 /// `BatchWorkload` provides an API for generating batches
 pub trait BatchWorkload: Send {
     /// Get a `BatchPair` and the result that is expected when that batch is processed and its
     /// transactions are executed
-    fn next_batch(&mut self) -> Result<(BatchPair, Option<ExpectedBatchResult>), WorkloadError>;
+    fn next_batch(&mut self)
+        -> Result<(BatchPair, Option<ExpectedBatchResult>), InvalidStateError>;
 }
 
 #[derive(Clone)]

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -20,7 +20,7 @@
 
 #[cfg(feature = "workload-batch-gen")]
 pub mod batch_gen;
-pub mod error;
+mod error;
 #[cfg(feature = "workload-runner")]
 mod runner;
 #[cfg(feature = "workload-batch-gen")]


### PR DESCRIPTION
- Update the methods in the `TransactionWorkload` and `BatchWorkload` traits to use the `InvalidStateError` error type instead of
`WorkloadError`.
- Remove `WorkloadError` from the workload error module.
- Make workload error module private
- `enum_variant_names` clippy lint doesn't allow enum variants to repeat the enum name.
- Put the `BatchReadingError` behind the "workload-batch-gen" feature as this error type is only used by functions behind this feature.