### PR TITLE
Remove "database-lmdb" from experimental

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -110,7 +110,6 @@ experimental = [
     "contract-address-triple-key-hash",
     "contract-context",
     "contract-context-key-value",
-    "database-lmdb",
     "database-sqlite",
     "family-command",
     "family-command-workload",


### PR DESCRIPTION
This change removes the feature "database-lmdb" from the set of experimental features, as it is already stable and included under the default features.