### PR TITLE
Remove openssl dependency

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -39,7 +39,6 @@ lazy_static = { version = "1.4.0", optional = true }
 libc = ">=0.2.35"
 lmdb-zero = { version = ">=0.4.1", optional = true }
 log = { version = "0.4", optional = true, features = ["std"] }
-openssl = { version = "0.10", optional = true }
 protobuf = "2.23"
 r2d2 = { version = "0.8", optional = true }
 r2d2_sqlite = { version = "0.18", optional = true }
@@ -178,7 +177,7 @@ sabre-compat = ["sabre-sdk"]
 sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
-state-merkle = ["cbor-codec", "log", "openssl"]
+state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -22,6 +22,8 @@ mod error;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use sha2::{Digest, Sha512};
+
 use crate::database::error::DatabaseError;
 use crate::database::{Database, DatabaseReader, DatabaseWriter};
 use crate::error::{InternalError, InvalidStateError};
@@ -794,8 +796,9 @@ fn get_node_by_hash(db: &dyn Database, hash: &str) -> Result<Node, StateDatabase
 
 /// Creates a hash of the given bytes
 fn hash(input: &[u8]) -> Vec<u8> {
-    let mut bytes: Vec<u8> = Vec::new();
-    bytes.extend(openssl::sha::sha512(input).iter());
+    let mut hasher = Sha512::new();
+    hasher.update(input);
+    let bytes = hasher.finalize().to_vec();
     let (hash, _rest) = bytes.split_at(bytes.len() / 2);
     hash.to_vec()
 }

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -61,6 +61,8 @@ mod store;
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};
 
+use sha2::{Digest, Sha512};
+
 use crate::error::InternalError;
 use crate::state::error::StateWriteError;
 use crate::state::StateChange;
@@ -374,8 +376,9 @@ fn encode_and_hash(node: Node) -> Result<(Vec<u8>, Vec<u8>), InternalError> {
 
 /// Creates a hash of the given bytes
 fn hash(input: &[u8]) -> Vec<u8> {
-    let mut bytes: Vec<u8> = Vec::new();
-    bytes.extend(openssl::sha::sha512(input).iter());
+    let mut hasher = Sha512::new();
+    hasher.update(input);
+    let bytes = hasher.finalize().to_vec();
     let (hash, _rest) = bytes.split_at(bytes.len() / 2);
     hash.to_vec()
 }

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -27,6 +27,7 @@ use std::str::from_utf8;
 
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
+use sha2::{Digest, Sha512};
 
 use transact::{
     database::{error::DatabaseError, Database},
@@ -1352,8 +1353,9 @@ fn assert_has_successors(change_log: &ChangeLogEntry, successor_roots: &[&[u8]])
 }
 
 fn hex_hash(input: &[u8]) -> String {
-    let mut bytes: Vec<u8> = Vec::new();
-    bytes.extend(openssl::sha::sha512(input).iter());
+    let mut hasher = Sha512::new();
+    hasher.update(input);
+    let bytes = hasher.finalize().to_vec();
     let (hash, _rest) = bytes.split_at(bytes.len() / 2);
     hex::encode(hash.to_vec())
 }


### PR DESCRIPTION
This change removes the openssl dependency.  This library was only used for SHA-512 hashing.  This same functionality can be replaced with the already-included sha2 library.