### PR TITLE
`family-command` stabilization updates - make handler module private

### DIFF
--- a/libtransact/src/families/command/mod.rs
+++ b/libtransact/src/families/command/mod.rs
@@ -15,7 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-pub mod handler;
+mod handler;
 #[cfg(feature = "family-command-workload")]
 pub mod workload;
 


### PR DESCRIPTION
`CommandTransactionHandler` is already re-exported so the handler module can
be made private.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>