### PR TITLE
`family-command-workload` stabilization updates

### DIFF
--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+//! Implementations of the `BatchWorkload` and `TransactionWorkload` traits for the command family.
+
 pub mod playlist;
 
 use cylinder::Signer;


### PR DESCRIPTION
Stabilization updates for the `family-command-workload` feature
- add a module doc comment for the command::workload module