### PR TITLE
`family-smallbank` stabilization updates - make handler module private

### DIFF
--- a/libtransact/src/families/smallbank/mod.rs
+++ b/libtransact/src/families/smallbank/mod.rs
@@ -15,7 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-pub mod handler;
+mod handler;
 #[cfg(feature = "family-smallbank-workload")]
 pub mod workload;
 


### PR DESCRIPTION
`SmallbankTransactionHandler` is already re-exported so the handler module can
be made private.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>