### PR TITLE
`workload` transact CLI stabilization updates

### DIFF
--- a/cli/src/action/time.rs
+++ b/cli/src/action/time.rs
@@ -154,7 +154,7 @@ impl From<&Time> for Duration {
     fn from(interval: &Time) -> Duration {
         match interval.time_type {
             TimeType::Rate => {
-                Duration::from_secs_f64(interval.numeric / interval.unit.to_sec() as f64)
+                Duration::from_secs_f64(interval.unit.to_sec() as f64 / interval.numeric)
             }
             TimeType::Duration => {
                 Duration::from_secs_f64(interval.numeric * interval.unit.to_sec() as f64)

--- a/cli/src/action/time.rs
+++ b/cli/src/action/time.rs
@@ -41,7 +41,7 @@ impl Time {
             Minute => 60_000.0,
             Second => 1_000.0,
         };
-        self.numeric * mult
+        mult / self.numeric
     }
 
     pub fn make_duration_type_time(time_str: &str) -> Result<Self, TimeParseError> {

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -220,12 +220,17 @@ fn start_smallbank_workloads(
             SmallbankTransactionWorkload::new(smallbank_generator, signer.clone());
         let smallbank_workload = SmallbankBatchWorkload::new(transaction_workload, signer.clone());
 
-        let rate = if target_rate_min < target_rate_max {
+        let rate = if target_rate_min == target_rate_max {
             target_rate_min
         } else {
-            let numeric = rng.gen_range(target_rate_min.to_milli()..=target_rate_max.to_milli());
+            // Calculate the amount of time, in milliseconds, to wait between batch submissions for
+            // the min and max target rates and generate a random number between the two times
+            let time_to_wait =
+                rng.gen_range(target_rate_max.to_milli()..=target_rate_min.to_milli());
+            // Calculate the number of batches that should be submitted per second with the new time
+            let numeric = 1000.0 / time_to_wait;
             Time {
-                numeric: numeric / 1000.0,
+                numeric,
                 unit: TimeUnit::Second,
                 time_type: TimeType::Rate,
             }
@@ -273,12 +278,17 @@ fn start_command_workloads(
             CommandTransactionWorkload::new(command_generator, signer.clone());
         let command_workload = CommandBatchWorkload::new(transaction_workload, signer.clone());
 
-        let rate = if target_rate_min < target_rate_max {
+        let rate = if target_rate_min == target_rate_max {
             target_rate_min
         } else {
-            let numeric = rng.gen_range(target_rate_min.to_milli()..=target_rate_max.to_milli());
+            // Calculate the amount of time, in milliseconds, to wait between batch submissions for
+            // the min and max target rates and generate a random number between the two times
+            let time_to_wait =
+                rng.gen_range(target_rate_max.to_milli()..=target_rate_min.to_milli());
+            // Calculate the number of batches that should be submitted per second with the new time
+            let numeric = 1000.0 / time_to_wait;
             Time {
-                numeric: numeric / 1000.0,
+                numeric,
                 unit: TimeUnit::Second,
                 time_type: TimeType::Rate,
             }


### PR DESCRIPTION
This PR fixes some of the calculations in the process of turning the rate, given with the `--target-rate` CLI option, into the amount of time to wait between batch submissions. Previously starting a workload with a rate of 2/s would make the workload wait 2s between submissions making the actual rate 0.5/s