### PR TITLE
`workload-runner` stabilization updates - fix batch status check

### DIFF
--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -31,6 +31,8 @@ pub enum WorkloadRunnerError {
     WorkloadAddError(String),
     /// Error raised when removing workload from the runner
     WorkloadRemoveError(String),
+    /// Error raised when retrieving a batch status
+    BatchStatusError(String),
 }
 
 #[cfg(feature = "workload-runner")]
@@ -51,6 +53,9 @@ impl std::fmt::Display for WorkloadRunnerError {
             }
             WorkloadRunnerError::WorkloadRemoveError(ref err) => {
                 write!(f, "Unable to remove workload: {}", err)
+            }
+            WorkloadRunnerError::BatchStatusError(ref err) => {
+                write!(f, "Error occurred while retrieving batch status: {}", err)
             }
         }
     }

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -128,6 +128,10 @@ impl WorkloadRunner {
                     )));
                 }
             }
+
+            if let Some(mut batch_status_checker) = worker.batch_status_checker {
+                batch_status_checker.remove_batch_status_checker()?;
+            }
         } else {
             return Err(WorkloadRunnerError::WorkloadRemoveError(format!(
                 "Workload with ID {} does not exist",

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -153,7 +153,7 @@ impl WorkloadRunner {
         }
     }
 
-    /// Block until for the thread has shutdown.
+    /// Block until the threads have shutdown.
     pub fn wait_for_shutdown(self) -> Result<(), WorkloadRunnerError> {
         for (_, mut worker) in &mut self.workloads.into_iter() {
             if let Some(mut batch_status_checker) = worker.batch_status_checker {

--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -609,6 +609,7 @@ fn slow_rate(
     loop {
         if let Some(end_time) = end_time {
             if time::Instant::now() > end_time {
+                shutdown = true;
                 break;
             }
         }


### PR DESCRIPTION
This PR modifies the process in which batch statuses are checked when running a workload.

Previously the process to check the statuses of submitted batches was to call the `check_batch_status` function at the end of each loop in the `Worker` thread. However, because it takes a while for batches to be processed and return their status, the list of batch status links that needed to be checked each loop got very long after running a workload for a short period of time and slowed down the workload substantially. 

This PR changes this process to use a thread instead. This way the process can run in parallel with the worker thread and doesn't require the worker thread to wait for the statuses to be checked each iteration of the loop. The worker thread and the batch status checker thread share a `ExpectedBatchResults` hashmap so that the worker can add links to the list as batches are submitted and the batch status checker can check the links and then remove them once the status of a batch has been confirmed.