### PR TITLE
`workload-batch-gen` stabilization updates

### DIFF
--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -145,7 +145,7 @@ pub struct BatchListFeeder<'a> {
 }
 
 /// Resulting BatchList or error.
-pub type BatchListResult = Result<BatchPair, BatchReadingError>;
+pub(super) type BatchListResult = Result<BatchPair, BatchReadingError>;
 
 impl<'a> BatchListFeeder<'a> {
     /// Creates a new `BatchListFeeder` with a given Batch source

--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -44,7 +44,7 @@ pub struct SignedBatchProducer<'a> {
 }
 
 /// Resulting batch or error.
-pub type BatchResult = Result<Batch, BatchingError>;
+type BatchResult = Result<Batch, BatchingError>;
 
 impl<'a> SignedBatchProducer<'a> {
     /// Creates a new `SignedBatchProducer` with a given Transaction source and

--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -137,39 +137,6 @@ fn batch_transactions(txns: Vec<Transaction>, signer: &dyn Signer) -> BatchResul
     }
 }
 
-pub struct SignedBatchIterator<'a> {
-    transaction_iterator: &'a mut dyn Iterator<Item = Transaction>,
-    max_batch_size: usize,
-    signer: &'a dyn Signer,
-}
-
-impl<'a> SignedBatchIterator<'a> {
-    pub fn new(
-        iterator: &'a mut dyn Iterator<Item = Transaction>,
-        max_batch_size: usize,
-        signer: &'a dyn Signer,
-    ) -> Self {
-        SignedBatchIterator {
-            transaction_iterator: iterator,
-            max_batch_size,
-            signer,
-        }
-    }
-}
-
-impl<'a> Iterator for SignedBatchIterator<'a> {
-    type Item = BatchResult;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let txns = self
-            .transaction_iterator
-            .take(self.max_batch_size)
-            .collect();
-
-        Some(batch_transactions(txns, self.signer))
-    }
-}
-
 type BatchSource<'a> = LengthDelimitedMessageSource<'a, Batch>;
 
 /// Produces batches from length-delimited source of Batches.

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -105,8 +105,6 @@ impl std::error::Error for BatchingError {
 #[derive(Debug)]
 pub enum BatchReadingError {
     Message(protobuf::ProtobufError),
-    Batching(BatchingError),
-    Unknown,
     ProtoConversion(ProtoConversionError),
 }
 
@@ -124,10 +122,6 @@ impl std::fmt::Display for BatchReadingError {
             BatchReadingError::Message(ref err) => {
                 write!(f, "Error occurred reading messages: {}", err)
             }
-            BatchReadingError::Batching(ref err) => {
-                write!(f, "Error creating the batch: {}", err)
-            }
-            BatchReadingError::Unknown => write!(f, "There was an unknown batching error."),
             BatchReadingError::ProtoConversion(ref err) => {
                 write!(f, "Error converting batch from proto: {}", err)
             }
@@ -140,8 +134,6 @@ impl std::error::Error for BatchReadingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             BatchReadingError::Message(ref err) => Some(err),
-            BatchReadingError::Batching(ref err) => Some(err),
-            BatchReadingError::Unknown => Some(&BatchReadingError::Unknown),
             BatchReadingError::ProtoConversion(ref err) => Some(err),
         }
     }

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -63,12 +63,14 @@ impl std::fmt::Display for WorkloadRunnerError {
 }
 
 // Errors that may occur during the generation of batches from a source.
+#[cfg(feature = "workload-batch-gen")]
 #[derive(Debug)]
 pub enum BatchingError {
     InternalError(InternalError),
     InvalidStateError(InvalidStateError),
 }
 
+#[cfg(feature = "workload-batch-gen")]
 impl std::fmt::Display for BatchingError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
@@ -78,6 +80,7 @@ impl std::fmt::Display for BatchingError {
     }
 }
 
+#[cfg(feature = "workload-batch-gen")]
 impl std::error::Error for BatchingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {


### PR DESCRIPTION
Stabilization updates for the "workload-batch-gen" feature

- Remove `SignedBatchIterator` because it isn't used
- Make `BatchListResult` type pub(super) 
- Remove unused variants from `BatchReadingError`
- Replace `generate_signed_batches` with a `write_to` function for `SignedBatchProducer` and update cli playlist to use it
- Make BatchResult type private
- Modify the `batch_transactions` function to use `BatchBuilder` to eliminate the need to use protobuf directly
- Add feature guards to `BatchingError` and replace the `BatchingError` variants with common errors `InternalError` and
`InvalidStateError`.