### PR TITLE
Fix feature guard on static adapter tests

### DIFF
--- a/libtransact/src/execution/adapter/static_adapter.rs
+++ b/libtransact/src/execution/adapter/static_adapter.rs
@@ -290,7 +290,7 @@ impl From<ContextManagerError> for ContextError {
     }
 }
 
-#[cfg(all(test, feature = "family-command"))]
+#[cfg(all(test, feature = "family-command-workload"))]
 mod test {
     use super::*;
 


### PR DESCRIPTION
Change the feature guard on the tests in the `static_adapter` module from "family-command" to "family-command-workload", the tests use `CommandTransactionBuilder` which is behind the "family-command-workload" feature.