### PR TITLE
Rename GHA workflow files

### DIFF
--- a/.github/workflows/0-3-build-docs.yaml
+++ b/.github/workflows/0-3-build-docs.yaml
@@ -1,4 +1,4 @@
-name: Lint Transact
+name: 0-3 Build Docs
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint_transact:
+  build_docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,5 +22,5 @@ jobs:
       - name: Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: Run Lint/Clippy on Transact
-        run: just ci-lint
+      - name: Build Docs
+        run: just ci-doc

--- a/.github/workflows/0-3-lint-transact.yaml
+++ b/.github/workflows/0-3-lint-transact.yaml
@@ -1,4 +1,4 @@
-name: Build Docs
+name: 0-3 Lint Transact
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_docs:
+  lint_transact:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,5 +22,5 @@ jobs:
       - name: Install Just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
-      - name: Build Docs
-        run: just ci-doc
+      - name: Run Lint/Clippy on Transact
+        run: just ci-lint

--- a/.github/workflows/0-3-merge.yaml
+++ b/.github/workflows/0-3-merge.yaml
@@ -1,4 +1,4 @@
-name: Merge
+name: 0-3 Merge
 
 on:
   push:

--- a/.github/workflows/0-3-test-transact.yaml
+++ b/.github/workflows/0-3-test-transact.yaml
@@ -1,4 +1,4 @@
-name: Test Transact
+name: 0-3 Test Transact
 
 on:
   pull_request:


### PR DESCRIPTION
If workflows share the name filename as an existing workflow in the main
branch, github will execute the workflow from main instead of the branch
appropriate instance.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>