### PR TITLE
Back-port 0-3: Add list trees to MerkleRadixStore

### DIFF
--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -56,7 +56,7 @@ pub mod migration;
 mod postgres;
 #[cfg(feature = "sqlite")]
 mod sqlite;
-mod store;
+pub mod store;
 
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet};

--- a/libtransact/src/state/merkle/sql/store/mod.rs
+++ b/libtransact/src/state/merkle/sql/store/mod.rs
@@ -34,30 +34,113 @@ use crate::state::merkle::{node::Node, sql::backend::Backend};
 // (Hash, packed bytes, path address)
 type NodeChanges = Vec<(String, Node, String)>;
 
+/// A set of updates to apply to the tree.
+///
+/// This updates include all of the new nodes and a list of all node hashes that have been not been
+/// included in the resulting state root hash.
 #[derive(Default)]
 pub struct TreeUpdate {
+    /// The new nodes to be applied to the tree.
+    ///
+    /// These are a tuple of (hash, packed bytes, path address).
     pub node_changes: NodeChanges,
+
+    /// The hashes that will not be carried over to the new state root.
     pub deletions: HashSet<String>,
 }
 
+/// Low-level store operations for interacting with Merkle-Radix tree storage.
 pub trait MerkleRadixStore {
+    /// Returns a merkle tree ID, if it exists, or initialize a tree if not.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_name`: the name of the tree to either look up or create if not found
+    /// * `initial_state_root_hash`: the initial state root hash to initialize the tree with, if it
+    ///   requires creation
+    ///
+    /// # Returns
+    ///
+    /// The ID of the tree, either the existing tree or the newly created tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn get_or_create_tree(
         &self,
         tree_name: &str,
         initial_state_root_hash: &str,
     ) -> Result<i64, InternalError>;
 
+    /// Returns a merkle tree ID by name.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_name`: the name of the tree to look up
+    ///
+    /// # Returns
+    ///
+    /// The ID of the tree, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn get_tree_id_by_name(&self, tree_name: &str) -> Result<Option<i64>, InternalError>;
 
+    /// Delete a specific tree, by ID.
+    ///
+    /// This should delete all underlying data associated with the given tree ID.
+    ///
+    /// The implementation should be idempotent.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be deleted
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn delete_tree(&self, tree_id: i64) -> Result<(), InternalError>;
 
-    /// Lists the names of available trees.
+    /// Lists the names of all available trees.
+    ///
+    /// # Returns
+    ///
+    /// An fallable iterator over the names of the trees.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn list_trees(
         &self,
     ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>;
 
+    /// Query whether or not a given state root hash exists in a particular tree.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be queried
+    /// * `state_root_hash`: the state root hash to validate its existence
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError>;
 
+    /// Query whether or not a given state root hash exists in a particular tree.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be queried
+    /// * `state_root_hash`: the state root hash to validate its existence
+    ///
+    /// # Returns
+    ///
+    /// The ID of the tree, if it exists.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn get_path(
         &self,
         tree_id: i64,
@@ -65,6 +148,21 @@ pub trait MerkleRadixStore {
         address: &str,
     ) -> Result<Vec<(String, Node)>, InternalError>;
 
+    /// Return entries given set of addresses on a given state root.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be queried
+    /// * `state_root_hash`: the state root hash under which the entries should be queried
+    /// * `keys`: the list of addresses to be read
+    ///
+    /// # Returns
+    ///
+    /// The list of (address, byte) pairs found.  This may be a subset of the addresses requested.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn get_entries(
         &self,
         tree_id: i64,
@@ -72,6 +170,24 @@ pub trait MerkleRadixStore {
         keys: Vec<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
 
+    /// Return entries given under a given state root, with an optional address prefix
+    ///
+    /// This returns all the entries under a given state root.  Optionally, this can be provided an
+    /// address prefix to only list the entries under a specific subtree.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be queried
+    /// * `state_root_hash`: the state root hash under which the entries should be queried
+    /// * `prefix`: an optional address prefix
+    ///
+    /// # Returns
+    ///
+    /// The list of (address, byte) pairs found.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn list_entries(
         &self,
         tree_id: i64,
@@ -79,6 +195,20 @@ pub trait MerkleRadixStore {
         prefix: Option<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError>;
 
+    /// Write a set of tree updates.
+    ///
+    /// This is a rather low-level operation that writes the updates to a given tree.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be updated
+    /// * `state_root_hash`: the state root hash to be applied
+    /// * `parent_state_root_hash`: the previous state root hash being built upon
+    /// * `tree_update`: the update to the tree.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn write_changes(
         &self,
         tree_id: i64,
@@ -87,14 +217,26 @@ pub trait MerkleRadixStore {
         tree_update: TreeUpdate,
     ) -> Result<(), InternalError>;
 
+    /// Prunes a state root hash from a given tree.
+    ///
+    /// # Parameters
+    ///
+    /// * `tree_id`: the ID of the tree to be pruned
+    /// * `state_root_hash`: the state root hash to pruned
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`InternalError`] if there is an issue with the underlying storage.
     fn prune(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError>;
 }
 
+/// A MerkleRadixStore backed by a SQL back-end.
 pub struct SqlMerkleRadixStore<'b, B: Backend> {
     pub backend: &'b B,
 }
 
 impl<'b, B: Backend> SqlMerkleRadixStore<'b, B> {
+    /// Constructs a new store for a given back-end.
     pub fn new(backend: &'b B) -> Self {
         Self { backend }
     }

--- a/libtransact/src/state/merkle/sql/store/mod.rs
+++ b/libtransact/src/state/merkle/sql/store/mod.rs
@@ -35,12 +35,12 @@ use crate::state::merkle::{node::Node, sql::backend::Backend};
 type NodeChanges = Vec<(String, Node, String)>;
 
 #[derive(Default)]
-pub(in crate::state::merkle::sql) struct TreeUpdate {
+pub struct TreeUpdate {
     pub node_changes: NodeChanges,
     pub deletions: HashSet<String>,
 }
 
-pub(in crate::state::merkle::sql) trait MerkleRadixStore {
+pub trait MerkleRadixStore {
     fn get_or_create_tree(
         &self,
         tree_name: &str,
@@ -90,12 +90,12 @@ pub(in crate::state::merkle::sql) trait MerkleRadixStore {
     fn prune(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError>;
 }
 
-pub(in crate::state::merkle::sql) struct SqlMerkleRadixStore<'b, B: Backend> {
+pub struct SqlMerkleRadixStore<'b, B: Backend> {
     pub backend: &'b B,
 }
 
 impl<'b, B: Backend> SqlMerkleRadixStore<'b, B> {
-    pub(in crate::state::merkle::sql) fn new(backend: &'b B) -> Self {
+    pub fn new(backend: &'b B) -> Self {
         Self { backend }
     }
 }

--- a/libtransact/src/state/merkle/sql/store/mod.rs
+++ b/libtransact/src/state/merkle/sql/store/mod.rs
@@ -51,6 +51,11 @@ pub(in crate::state::merkle::sql) trait MerkleRadixStore {
 
     fn delete_tree(&self, tree_id: i64) -> Result<(), InternalError>;
 
+    /// Lists the names of available trees.
+    fn list_trees(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>;
+
     fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError>;
 
     fn get_path(

--- a/libtransact/src/state/merkle/sql/store/operations/list_trees.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/list_trees.rs
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Text};
+
+use crate::error::InternalError;
+use crate::state::merkle::sql::store::models::MerkleRadixTree;
+use crate::state::merkle::sql::store::schema::merkle_radix_tree;
+
+use super::MerkleRadixOperations;
+
+pub trait MerkleRadixListTreesOperation {
+    fn list_trees(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>;
+}
+
+impl<'a, C> MerkleRadixListTreesOperation for MerkleRadixOperations<'a, C>
+where
+    C: Connection,
+    String: diesel::deserialize::FromSql<Text, C::Backend>,
+    i64: diesel::deserialize::FromSql<BigInt, C::Backend>,
+{
+    fn list_trees(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>
+    {
+        let trees: Vec<MerkleRadixTree> = merkle_radix_tree::table
+            .get_results(self.conn)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        Ok(Box::new(trees.into_iter().map(|tree| Ok(tree.name))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use diesel::dsl::insert_into;
+
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    use crate::state::merkle::sql::backend::postgres::test::run_postgres_test;
+    #[cfg(feature = "sqlite")]
+    use crate::state::merkle::sql::migration;
+    use crate::state::merkle::sql::store::models::NewMerkleRadixTree;
+
+    /// This tests that trees names can be listed.
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_list_trees() -> Result<(), Box<dyn std::error::Error>> {
+        let conn = SqliteConnection::establish(":memory:")?;
+        migration::sqlite::run_migrations(&conn)?;
+
+        let operations = MerkleRadixOperations::new(&conn);
+
+        let trees = operations.list_trees()?.collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(vec!["default".to_string()], trees);
+
+        insert_into(merkle_radix_tree::table)
+            .values(NewMerkleRadixTree { name: "test" })
+            .execute(&conn)?;
+
+        let trees = operations.list_trees()?.collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(vec!["default".to_string(), "test".to_string()], trees);
+
+        Ok(())
+    }
+
+    /// This tests that trees names can be listed.
+    #[cfg(feature = "state-merkle-sql-postgres-tests")]
+    #[test]
+    fn postgres_list_trees() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|url| {
+            let conn = PgConnection::establish(&url)?;
+
+            let operations = MerkleRadixOperations::new(&conn);
+
+            let trees = operations.list_trees()?.collect::<Result<Vec<_>, _>>()?;
+            assert_eq!(vec!["default".to_string()], trees);
+
+            insert_into(merkle_radix_tree::table)
+                .values(NewMerkleRadixTree { name: "test" })
+                .execute(&conn)?;
+
+            let trees = operations.list_trees()?.collect::<Result<Vec<_>, _>>()?;
+            assert_eq!(vec!["default".to_string(), "test".to_string()], trees);
+
+            Ok(())
+        })
+    }
+}

--- a/libtransact/src/state/merkle/sql/store/operations/mod.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/mod.rs
@@ -22,6 +22,7 @@ pub(super) mod get_path;
 pub(super) mod get_tree_by_name;
 pub(super) mod has_root;
 pub(super) mod list_leaves;
+pub(super) mod list_trees;
 pub(super) mod prune_entries;
 pub(super) mod write_changes;
 

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -26,6 +26,7 @@ use super::operations::get_path::MerkleRadixGetPathOperation as _;
 use super::operations::get_tree_by_name::MerkleRadixGetTreeByNameOperation as _;
 use super::operations::has_root::MerkleRadixHasRootOperation as _;
 use super::operations::list_leaves::MerkleRadixListLeavesOperation as _;
+use super::operations::list_trees::MerkleRadixListTreesOperation as _;
 use super::operations::prune_entries::MerkleRadixPruneEntriesOperation as _;
 use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
@@ -53,6 +54,15 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
 
         let operations = MerkleRadixOperations::new(conn.as_inner());
         operations.delete_tree(tree_id)
+    }
+
+    fn list_trees(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>
+    {
+        let conn = self.backend.connection()?;
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.list_trees()
     }
 
     fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError> {

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -26,6 +26,7 @@ use super::operations::get_path::MerkleRadixGetPathOperation as _;
 use super::operations::get_tree_by_name::MerkleRadixGetTreeByNameOperation as _;
 use super::operations::has_root::MerkleRadixHasRootOperation as _;
 use super::operations::list_leaves::MerkleRadixListLeavesOperation as _;
+use super::operations::list_trees::MerkleRadixListTreesOperation as _;
 use super::operations::prune_entries::MerkleRadixPruneEntriesOperation as _;
 use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
@@ -53,6 +54,15 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend> {
 
         let operations = MerkleRadixOperations::new(conn.as_inner());
         operations.delete_tree(tree_id)
+    }
+
+    fn list_trees(
+        &self,
+    ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>
+    {
+        let conn = self.backend.connection()?;
+        let operations = MerkleRadixOperations::new(conn.as_inner());
+        operations.list_trees()
     }
 
     fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError> {


### PR DESCRIPTION
back-port of #270 into the 0-3 branch