### PR TITLE
Update flexi_logger dependency to v0.20

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/main.rs"
 clap = "2"
 ctrlc = { version = "3.0", optional = true }
 cylinder = { version = "0.2.2", features = ["jwt", "key-load"], optional = true }
-flexi_logger = "0.19"
+flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
 hex = { version = "0.4", optional = true }
 log = "0.4"
 protobuf = { version = "2.23", optional = true }

--- a/examples/sabre_command_executor/Cargo.toml
+++ b/examples/sabre_command_executor/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 cylinder = "0.2"
-flexi_logger = "0.19"
+flexi_logger = { version = "0.20", features = ["use_chrono_for_offset"] }
 log = "0.4"
 protobuf = { version = "2.19" }
 sawtooth-sabre = "0.7"


### PR DESCRIPTION
This is intended as a non-functional change the track the latest
dependency.

Adds the "use_chrono_for_offset" feature as required to avoid warnings
from this version of flexi_logger; this is a flexi_logger problem and
can be safely removed when its no longer needed to avoid warnings from
flexi_logger.
