### PR TITLE
`family-command-workload` stabilization updates - API docs

### DIFF
--- a/libtransact/src/families/command/workload/command_iter.rs
+++ b/libtransact/src/families/command/workload/command_iter.rs
@@ -22,6 +22,7 @@ use sha2::{Digest, Sha512};
 
 use crate::protocol::command;
 
+/// An iterator that generates `command`s
 pub struct CommandGeneratingIter {
     rng: StdRng,
     addresses: Vec<String>,
@@ -29,6 +30,11 @@ pub struct CommandGeneratingIter {
 }
 
 impl CommandGeneratingIter {
+    /// Create a new [CommandGeneratingIter]
+    ///
+    /// # Arguments
+    ///
+    /// * `seed` - Used to create a new `SeedableRng`
     pub fn new(seed: u64) -> Self {
         CommandGeneratingIter {
             rng: SeedableRng::seed_from_u64(seed),
@@ -37,12 +43,22 @@ impl CommandGeneratingIter {
         }
     }
 
+    /// Add an address to `set_addresses`, this is a list of all addresses currently set
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The address to add to the `set_addresses` list
     pub fn add_set_address(&mut self, address: String) {
         if !self.set_addresses.contains(&address) {
             self.set_addresses.push(address);
         }
     }
 
+    /// Remove an address from `set_addresses`, this is a list of all addresses currently set
+    ///
+    /// # Arguments
+    ///
+    /// * `address` - The address to remove from the `set_addresses` list
     pub fn remove_set_address(&mut self, index: usize) {
         self.set_addresses.remove(index);
     }

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -117,12 +117,20 @@ impl TransactionWorkload for CommandTransactionWorkload {
     }
 }
 
+/// A batch workload that generates signed batches that contain `command` transactions.
 pub struct CommandBatchWorkload {
     transaction_workload: CommandTransactionWorkload,
     signer: Box<dyn Signer>,
 }
 
 impl CommandBatchWorkload {
+    /// Create a new [CommandBatchWorkload]
+    ///
+    /// # Arguments
+    ///
+    /// * `transaction_workload` - A [CommandTransactionWorkload] that generates command
+    ///   transactions
+    /// * `signer` - Used to sign the generated batches
     pub fn new(transaction_workload: CommandTransactionWorkload, signer: Box<dyn Signer>) -> Self {
         Self {
             transaction_workload,
@@ -131,7 +139,10 @@ impl CommandBatchWorkload {
     }
 }
 
+/// An implementation of the `BatchWorkload` trait for command family.
 impl BatchWorkload for CommandBatchWorkload {
+    /// Create a new signed `command` batch. Returns the `BatchPair` and the expected result after
+    /// the batch is submitted.
     fn next_batch(
         &mut self,
     ) -> Result<(BatchPair, Option<ExpectedBatchResult>), InvalidStateError> {

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -33,18 +33,28 @@ use crate::workload::{BatchWorkload, ExpectedBatchResult, TransactionWorkload};
 
 pub use crate::families::command::workload::command_iter::CommandGeneratingIter;
 
+/// A transaction workload that generates signed `command` transactions.
 pub struct CommandTransactionWorkload {
     generator: CommandGeneratingIter,
     signer: Box<dyn Signer>,
 }
 
 impl CommandTransactionWorkload {
+    /// Create a new [CommandTransactionWorkload]
+    ///
+    /// # Arguments
+    ///
+    /// * `generator` - An iterator that generates `command`s from the command family
+    /// * `signer` - Used to sign the generated transactions
     pub fn new(generator: CommandGeneratingIter, signer: Box<dyn Signer>) -> Self {
         Self { generator, signer }
     }
 }
 
+/// An implementation of the `TransactionWorkload` trait for command family.
 impl TransactionWorkload for CommandTransactionWorkload {
+    /// Create a new signed `command` transaction. Returns the `TransactionPair` and the expected
+    /// result after the transaction is executed.
     fn next_transaction(
         &mut self,
     ) -> Result<(TransactionPair, Option<ExpectedBatchResult>), InvalidStateError> {

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -159,21 +159,29 @@ impl BatchWorkload for CommandBatchWorkload {
     }
 }
 
+/// Builds a `command` tansaction with the list of commands stored in `commands`
 #[derive(Default)]
 pub struct CommandTransactionBuilder {
     commands: Option<Vec<Command>>,
 }
 
 impl CommandTransactionBuilder {
+    /// Create a new [CommandTransactionBuilder]
     pub fn new() -> Self {
         CommandTransactionBuilder::default()
     }
 
+    /// Set the `commands` field of the [CommandTransactionBuilder]
+    ///
+    /// # Arguments
+    ///
+    /// * `commands` - The list of commands that will in the final transaction
     pub fn with_commands(mut self, commands: Vec<Command>) -> Self {
         self.commands = Some(commands);
         self
     }
 
+    /// Create a `TransactionBuilder` with the list of commands stored in the `commands` field
     pub fn into_transaction_builder(self) -> Result<TransactionBuilder, InvalidStateError> {
         let commands_vec = self.commands.ok_or_else(|| {
             InvalidStateError::with_message("'commands' field is required".to_string())
@@ -247,6 +255,7 @@ impl CommandTransactionBuilder {
             .with_payload(command_payload))
     }
 
+    /// Create a `TransactionPair` signed by the given signer
     pub fn build_pair(self, signer: &dyn Signer) -> Result<TransactionPair, InvalidStateError> {
         self.into_transaction_builder()?
             .build_pair(signer)


### PR DESCRIPTION
Add API doc for CommandGeneratingIter, CommandTransactionWorkload, CommandBatchWorkload, and CommandTransactionBuilder 