### PR TITLE
Stabilize `family-command-workload`

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -85,6 +85,7 @@ stable = [
     # The following features are stable:
     "contract-archive",
     "family-command",
+    "family-command-workload",
     "family-smallbank",
     "postgres",
     "protocol-sabre",
@@ -104,7 +105,6 @@ experimental = [
     "contract-address-triple-key-hash",
     "contract-context",
     "contract-context-key-value",
-    "family-command-workload",
     "family-smallbank-workload",
     "family-xo",
     "key-value-state",


### PR DESCRIPTION
Stabilize the `family-command-workload` feature by moving it from
experimental to stable.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>