### PR TITLE
`workload-batch-gen` stabilization updates - fix protobuf use

### DIFF
--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -31,7 +31,7 @@ use crate::protos::FromNative;
 use crate::protos::FromProto;
 use crate::protos::batch::Batch as ProtobufBatch;
 
-use super::error::{BatchReadingError, BatchingError};
+use super::error::BatchingError;
 use super::source::LengthDelimitedMessageSource;
 
 type TransactionSource<'a> = LengthDelimitedMessageSource<'a, Transaction>;
@@ -132,7 +132,7 @@ pub struct BatchListFeeder<'a> {
 }
 
 /// Resulting BatchList or error.
-pub(super) type BatchListResult = Result<BatchPair, BatchReadingError>;
+pub(super) type BatchListResult = Result<BatchPair, BatchingError>;
 
 impl<'a> BatchListFeeder<'a> {
     /// Creates a new `BatchListFeeder` with a given Batch source
@@ -150,7 +150,7 @@ impl<'a> Iterator for BatchListFeeder<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let batches = match self.batch_source.next(1) {
             Ok(batches) => batches,
-            Err(err) => return Some(Err(BatchReadingError::Message(err))),
+            Err(err) => return Some(Err(BatchingError::InternalError(err))),
         };
 
         let batch_proto = match batches.get(0) {

--- a/libtransact/src/workload/batch_gen.rs
+++ b/libtransact/src/workload/batch_gen.rs
@@ -30,6 +30,10 @@ use crate::protocol::transaction::Transaction;
 use crate::protos::FromNative;
 use crate::protos::FromProto;
 use crate::protos::batch::Batch as ProtobufBatch;
+use crate::workload::{
+    batch_reader::{protobuf::ProtobufBatchReader, BatchReader},
+    transaction_reader::{protobuf::ProtobufTransactionReader, TransactionReader},
+};
 
 use super::error::BatchingError;
 use super::source::LengthDelimitedMessageSource;

--- a/libtransact/src/workload/batch_reader/mod.rs
+++ b/libtransact/src/workload/batch_reader/mod.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Trait for reading batches from a source
+
+pub mod protobuf;
+
+use crate::error::InternalError;
+use crate::protocol::batch::BatchPair;
+
+/// `BatchReader` provides an API for reading batches from a source
+pub trait BatchReader {
+    /// Returns a vec with at least max_batches `Batches` in it
+    fn next(&mut self, max_batches: usize) -> Result<Vec<BatchPair>, InternalError>;
+}

--- a/libtransact/src/workload/batch_reader/protobuf.rs
+++ b/libtransact/src/workload/batch_reader/protobuf.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Tools for reading length-delimited protobuf batches from a file
+
+use std::io::Read;
+
+use protobuf::Message;
+
+use crate::error::InternalError;
+use crate::protocol::batch::BatchPair;
+use crate::protos::FromProto;
+
+use super::BatchReader;
+
+/// Decodes Protocol Buffer `Batches` from a length-delimited input reader.
+pub struct ProtobufBatchReader<'a> {
+    source: protobuf::CodedInputStream<'a>,
+}
+
+impl<'a> ProtobufBatchReader<'a> {
+    pub fn new(source: &'a mut dyn Read) -> Self {
+        let source = protobuf::CodedInputStream::new(source);
+        ProtobufBatchReader { source }
+    }
+}
+
+impl BatchReader for ProtobufBatchReader<'_> {
+    /// Returns the next set of `Batches`.
+    /// The vector of `Batches` will contain up to `max_batches` number of
+    /// `Batches`. An empty vector indicates that the source has been consumed.
+    fn next(&mut self, max_batches: usize) -> Result<Vec<BatchPair>, InternalError> {
+        let mut results = Vec::with_capacity(max_batches);
+        for _ in 0..max_batches {
+            let eof = self
+                .source
+                .eof()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            if eof {
+                break;
+            }
+
+            // read the delimited length
+            let next_len = self
+                .source
+                .read_raw_varint32()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            let buf = self
+                .source
+                .read_raw_bytes(next_len)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            let msg = Message::parse_from_bytes(&buf)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            let batch = BatchPair::from_proto(msg)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            results.push(batch);
+        }
+        Ok(results)
+    }
+}

--- a/libtransact/src/workload/error.rs
+++ b/libtransact/src/workload/error.rs
@@ -19,9 +19,6 @@
 #[cfg(feature = "workload-batch-gen")]
 use crate::error::{InternalError, InvalidStateError};
 
-#[cfg(feature = "workload-batch-gen")]
-use crate::protos::ProtoConversionError;
-
 #[cfg(feature = "workload-runner")]
 #[derive(Debug, PartialEq)]
 pub enum WorkloadRunnerError {
@@ -86,45 +83,6 @@ impl std::error::Error for BatchingError {
         match self {
             BatchingError::InternalError(ref err) => Some(err),
             BatchingError::InvalidStateError(ref err) => Some(err),
-        }
-    }
-}
-
-/// Errors that may occur during the reading of batches.
-#[cfg(feature = "workload-batch-gen")]
-#[derive(Debug)]
-pub enum BatchReadingError {
-    Message(protobuf::ProtobufError),
-    ProtoConversion(ProtoConversionError),
-}
-
-#[cfg(feature = "workload-batch-gen")]
-impl From<protobuf::ProtobufError> for BatchReadingError {
-    fn from(err: protobuf::ProtobufError) -> Self {
-        BatchReadingError::Message(err)
-    }
-}
-
-#[cfg(feature = "workload-batch-gen")]
-impl std::fmt::Display for BatchReadingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            BatchReadingError::Message(ref err) => {
-                write!(f, "Error occurred reading messages: {}", err)
-            }
-            BatchReadingError::ProtoConversion(ref err) => {
-                write!(f, "Error converting batch from proto: {}", err)
-            }
-        }
-    }
-}
-
-#[cfg(feature = "workload-batch-gen")]
-impl std::error::Error for BatchReadingError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match *self {
-            BatchReadingError::Message(ref err) => Some(err),
-            BatchReadingError::ProtoConversion(ref err) => Some(err),
         }
     }
 }

--- a/libtransact/src/workload/mod.rs
+++ b/libtransact/src/workload/mod.rs
@@ -20,11 +20,13 @@
 
 #[cfg(feature = "workload-batch-gen")]
 pub mod batch_gen;
+#[cfg(feature = "workload-batch-gen")]
+mod batch_reader;
 mod error;
 #[cfg(feature = "workload-runner")]
 mod runner;
 #[cfg(feature = "workload-batch-gen")]
-mod source;
+mod transaction_reader;
 
 use crate::error::InvalidStateError;
 use crate::protocol::batch::BatchPair;

--- a/libtransact/src/workload/transaction_reader/mod.rs
+++ b/libtransact/src/workload/transaction_reader/mod.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+//! Trait for reading transactions from a source
+
+pub mod protobuf;
+
+use crate::error::InternalError;
+use crate::protocol::transaction::Transaction;
+
+/// `TransactionReader` provides an API for reading transactions from a source
+pub trait TransactionReader {
+    /// Returns a vec with at least max_txns `Transactions` in it
+    fn next(&mut self, max_txns: usize) -> Result<Vec<Transaction>, InternalError>;
+}

--- a/libtransact/src/workload/transaction_reader/protobuf.rs
+++ b/libtransact/src/workload/transaction_reader/protobuf.rs
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Tools for reading length-delimited protobuf transactions from a file
+
+use std::io::Read;
+
+use protobuf::Message;
+
+use crate::error::InternalError;
+use crate::protocol::transaction::Transaction;
+use crate::protos::FromProto;
+
+use super::TransactionReader;
+
+/// Decodes Protocol Buffer `Transactions` from a length-delimited input reader.
+pub struct ProtobufTransactionReader<'a> {
+    source: protobuf::CodedInputStream<'a>,
+}
+
+impl<'a> ProtobufTransactionReader<'a> {
+    pub fn new(source: &'a mut dyn Read) -> Self {
+        let source = protobuf::CodedInputStream::new(source);
+        ProtobufTransactionReader { source }
+    }
+}
+
+impl TransactionReader for ProtobufTransactionReader<'_> {
+    /// Returns the next set of `Transactions`.
+    /// The vector of `Transactions` will contain up to `max_txns` number of
+    /// `Transactions`. An empty vector indicates that the source has been consumed.
+    fn next(&mut self, max_txns: usize) -> Result<Vec<Transaction>, InternalError> {
+        let mut results = Vec::with_capacity(max_txns);
+        for _ in 0..max_txns {
+            let eof = self
+                .source
+                .eof()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            if eof {
+                break;
+            }
+
+            // read the delimited length
+            let next_len = self
+                .source
+                .read_raw_varint32()
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            let buf = self
+                .source
+                .read_raw_bytes(next_len)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+
+            let msg = Message::parse_from_bytes(&buf)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            let txn = Transaction::from_proto(msg)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            results.push(txn);
+        }
+        Ok(results)
+    }
+}


### PR DESCRIPTION
Stabilization updates for the libtransact `workload-batch-gen` feature, this PR limits the use of Protobuf in the `workload-batch-gen` feature.

- Add two traits `BatchReader` and `TransactionReader`, which provide an API for reading batches and reading transactions from a source.
- Replace the `LengthDelimitedMessageSource` with `ProtobufTransactionReader` and `ProtobufBatchReader` which implement`TransactionReader` and `BatchReader`.
- Update tests to use `ProtobufTransactionReader` and `ProtobufBatchReader`.
- Limit the direct use of protobuf in tests to only the function that writes length delimited protobuf.