### PR TITLE
Stabilize transact-cli `workload`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,7 @@ default = []
 stable = [
     # The stable feature extends default:
     "default",
+    "workload",
 ]
 
 experimental = [
@@ -60,7 +61,6 @@ experimental = [
     # The following features are experimental:
     "command",
     "playlist",
-    "workload",
     "workload-smallbank"
 ]
 


### PR DESCRIPTION
Stabilize the transact-cli `workload` feature by moving it from
experimental to stable.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>