### PR TITLE
Stabilize transact-cli `command`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,6 +51,7 @@ default = []
 
 stable = [
     # The stable feature extends default:
+    "command",
     "default",
     "workload",
 ]
@@ -59,7 +60,6 @@ experimental = [
     # The experimental feature extends stable:
     "stable",
     # The following features are experimental:
-    "command",
     "playlist",
     "workload-smallbank"
 ]


### PR DESCRIPTION
Stabilize the transact-cli `command` feature by moving it from
experimental to stable.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>