### PR TITLE
Move `command` and `workload` features to default

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -47,13 +47,14 @@ transact = {path = "../libtransact", features=["family-smallbank-workload", "fam
 
 
 [features]
-default = []
+default = [
+    "command",
+    "workload",
+]
 
 stable = [
     # The stable feature extends default:
-    "command",
     "default",
-    "workload",
 ]
 
 experimental = [


### PR DESCRIPTION
Move `command` and `workload` features to default 