### PR TITLE
Remove `workload-batch-gen` from `workload-runner`

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -65,7 +65,7 @@ experimental = [
 ]
 
 command = ["cylinder", "hex", "protobuf", "reqwest", "serde", "serde_json"]
-playlist = ["cylinder", "serde_json"]
+playlist = ["cylinder", "serde_json", "transact/workload-batch-gen"]
 workload = ["ctrlc", "cylinder", "rand", "transact/family-command-workload"]
 workload-smallbank = ["workload", "transact/family-smallbank-workload"]
 

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -178,8 +178,7 @@ workload-runner = [
     "chrono",
     "reqwest",
     "serde",
-    "serde_derive",
-    "workload-batch-gen"
+    "serde_derive"
 ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
- Update `workload-runner` to no longer pull in the `workload-batch-gen` feature because `workload-runner` does not use any code in this feature.
- Update the playlist feature in transact-cli to pull in `transact/workload-batch-gen`.