### PR TITLE
Move `CommandTransactionBuilder`

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -84,6 +84,7 @@ stable = [
     # The following features are stable:
     "contract-archive",
     "family-command",
+    "family-command-transaction-builder",
     "family-command-workload",
     "family-smallbank",
     "postgres",
@@ -137,13 +138,8 @@ contract-context-key-value = ["contract-context", "key-value-state"]
 database-lmdb = ["lmdb-zero"]
 execution = ["context", "handler", "log", "protocol-transaction", "scheduler"]
 family-command = ["handler"]
-family-command-workload = [
-    "cylinder",
-    "family-command",
-    "protocol-sabre",
-    "protocol-transaction-builder",
-    "workload",
-]
+family-command-transaction-builder = ["cylinder", "family-command", "protocol-transaction-builder"]
+family-command-workload = ["family-command", "protocol-sabre", "workload"]
 family-smallbank = ["handler"]
 family-smallbank-workload = [
     "family-smallbank",

--- a/libtransact/src/execution/adapter/static_adapter.rs
+++ b/libtransact/src/execution/adapter/static_adapter.rs
@@ -290,7 +290,7 @@ impl From<ContextManagerError> for ContextError {
     }
 }
 
-#[cfg(all(test, feature = "family-command-workload"))]
+#[cfg(all(test, feature = "family-command-transaction-builder"))]
 mod test {
     use super::*;
 
@@ -304,9 +304,7 @@ mod test {
     use cylinder::{secp256k1::Secp256k1Context, Context, Signer};
 
     use crate::context::ContextLifecycle;
-    use crate::families::command::{
-        workload::CommandTransactionBuilder, CommandTransactionHandler,
-    };
+    use crate::families::command::{CommandTransactionBuilder, CommandTransactionHandler};
     use crate::protocol::command::{
         AddEvent, AddReceiptData, BytesEntry, Command, DeleteState, GetState, ReturnInternalError,
         ReturnInvalid, SetState, Sleep, SleepType,

--- a/libtransact/src/families/command/mod.rs
+++ b/libtransact/src/families/command/mod.rs
@@ -16,7 +16,11 @@
  */
 
 mod handler;
+#[cfg(feature = "family-command-transaction-builder")]
+mod transaction_builder;
 #[cfg(feature = "family-command-workload")]
 pub mod workload;
 
 pub use self::handler::CommandTransactionHandler;
+#[cfg(feature = "family-command-transaction-builder")]
+pub use self::transaction_builder::CommandTransactionBuilder;

--- a/libtransact/src/families/command/transaction_builder.rs
+++ b/libtransact/src/families/command/transaction_builder.rs
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use cylinder::Signer;
+
+use crate::error::InvalidStateError;
+use crate::protocol::{
+    command::{Command, CommandPayload},
+    transaction::{HashMethod, TransactionBuilder, TransactionPair},
+};
+use crate::protos::IntoBytes;
+
+/// Builds a `command` tansaction with the list of commands stored in `commands`
+#[derive(Default)]
+pub struct CommandTransactionBuilder {
+    commands: Option<Vec<Command>>,
+}
+
+impl CommandTransactionBuilder {
+    /// Create a new [CommandTransactionBuilder]
+    pub fn new() -> Self {
+        CommandTransactionBuilder::default()
+    }
+
+    /// Set the `commands` field of the [CommandTransactionBuilder]
+    ///
+    /// # Arguments
+    ///
+    /// * `commands` - The list of commands that will in the final transaction
+    pub fn with_commands(mut self, commands: Vec<Command>) -> Self {
+        self.commands = Some(commands);
+        self
+    }
+
+    /// Create a `TransactionBuilder` with the list of commands stored in the `commands` field
+    pub fn into_transaction_builder(self) -> Result<TransactionBuilder, InvalidStateError> {
+        let commands_vec = self.commands.ok_or_else(|| {
+            InvalidStateError::with_message("'commands' field is required".to_string())
+        })?;
+
+        let commands = commands_vec.as_slice();
+
+        let command_payload = CommandPayload::new(commands.to_vec())
+            .into_bytes()
+            .map_err(|_| {
+                InvalidStateError::with_message(
+                    "Failed to convert command payload to bytes".to_string(),
+                )
+            })?;
+
+        Ok(TransactionBuilder::new()
+            .with_batcher_public_key(vec![0u8, 0u8, 0u8, 0u8])
+            .with_family_name(String::from("command"))
+            .with_family_version(String::from("1"))
+            .with_inputs(
+                commands
+                    .iter()
+                    .map(|cmd| match cmd {
+                        Command::SetState(set_state) => Some(
+                            set_state
+                                .state_writes()
+                                .iter()
+                                .flat_map(|b| b.key().as_bytes().to_vec())
+                                .collect(),
+                        ),
+                        Command::DeleteState(delete_state) => Some(
+                            delete_state
+                                .state_keys()
+                                .to_vec()
+                                .iter()
+                                .flat_map(|k| k.as_bytes().to_vec())
+                                .collect(),
+                        ),
+                        _ => None,
+                    })
+                    .filter(Option::is_some)
+                    .flatten()
+                    .collect(),
+            )
+            .with_outputs(
+                commands
+                    .iter()
+                    .map(|cmd| match cmd {
+                        Command::SetState(set_state) => Some(
+                            set_state
+                                .state_writes()
+                                .iter()
+                                .flat_map(|b| b.key().as_bytes().to_vec())
+                                .collect(),
+                        ),
+                        Command::DeleteState(delete_state) => Some(
+                            delete_state
+                                .state_keys()
+                                .to_vec()
+                                .iter()
+                                .flat_map(|k| k.as_bytes().to_vec())
+                                .collect(),
+                        ),
+                        _ => None,
+                    })
+                    .filter(Option::is_some)
+                    .flatten()
+                    .collect(),
+            )
+            .with_payload_hash_method(HashMethod::Sha512)
+            .with_payload(command_payload))
+    }
+
+    /// Create a `TransactionPair` signed by the given signer
+    pub fn build_pair(self, signer: &dyn Signer) -> Result<TransactionPair, InvalidStateError> {
+        self.into_transaction_builder()?
+            .build_pair(signer)
+            .map_err(|_| {
+                InvalidStateError::with_message("Failed build transaction pair".to_string())
+            })
+    }
+}

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -31,6 +31,9 @@ use crate::protocol::{
 use crate::protos::IntoBytes;
 use crate::workload::{BatchWorkload, ExpectedBatchResult, TransactionWorkload};
 
+#[cfg(feature = "family-command-transaction-builder")]
+use super::transaction_builder::CommandTransactionBuilder as CmdTransactionBuilder;
+
 pub use crate::families::command::workload::command_iter::CommandGeneratingIter;
 
 /// A transaction workload that generates signed `command` transactions.
@@ -158,3 +161,10 @@ impl BatchWorkload for CommandBatchWorkload {
         ))
     }
 }
+
+#[cfg(feature = "family-command-transaction-builder")]
+#[deprecated(
+    since = "0.4.1",
+    note = "Please use families::command::CommandTransactionBuilder"
+)]
+pub type CommandTransactionBuilder = CmdTransactionBuilder;

--- a/libtransact/src/families/command/workload/mod.rs
+++ b/libtransact/src/families/command/workload/mod.rs
@@ -26,7 +26,7 @@ use crate::protocol::{
     batch::{BatchBuilder, BatchPair},
     command::{Command, CommandPayload},
     sabre::ExecuteContractActionBuilder,
-    transaction::{HashMethod, TransactionBuilder, TransactionPair},
+    transaction::TransactionPair,
 };
 use crate::protos::IntoBytes;
 use crate::workload::{BatchWorkload, ExpectedBatchResult, TransactionWorkload};
@@ -156,111 +156,5 @@ impl BatchWorkload for CommandBatchWorkload {
                 })?,
             result,
         ))
-    }
-}
-
-/// Builds a `command` tansaction with the list of commands stored in `commands`
-#[derive(Default)]
-pub struct CommandTransactionBuilder {
-    commands: Option<Vec<Command>>,
-}
-
-impl CommandTransactionBuilder {
-    /// Create a new [CommandTransactionBuilder]
-    pub fn new() -> Self {
-        CommandTransactionBuilder::default()
-    }
-
-    /// Set the `commands` field of the [CommandTransactionBuilder]
-    ///
-    /// # Arguments
-    ///
-    /// * `commands` - The list of commands that will in the final transaction
-    pub fn with_commands(mut self, commands: Vec<Command>) -> Self {
-        self.commands = Some(commands);
-        self
-    }
-
-    /// Create a `TransactionBuilder` with the list of commands stored in the `commands` field
-    pub fn into_transaction_builder(self) -> Result<TransactionBuilder, InvalidStateError> {
-        let commands_vec = self.commands.ok_or_else(|| {
-            InvalidStateError::with_message("'commands' field is required".to_string())
-        })?;
-
-        let commands = commands_vec.as_slice();
-
-        let command_payload = CommandPayload::new(commands.to_vec())
-            .into_bytes()
-            .map_err(|_| {
-                InvalidStateError::with_message(
-                    "Failed to convert command payload to bytes".to_string(),
-                )
-            })?;
-
-        Ok(TransactionBuilder::new()
-            .with_batcher_public_key(vec![0u8, 0u8, 0u8, 0u8])
-            .with_family_name(String::from("command"))
-            .with_family_version(String::from("1"))
-            .with_inputs(
-                commands
-                    .iter()
-                    .map(|cmd| match cmd {
-                        Command::SetState(set_state) => Some(
-                            set_state
-                                .state_writes()
-                                .iter()
-                                .flat_map(|b| b.key().as_bytes().to_vec())
-                                .collect(),
-                        ),
-                        Command::DeleteState(delete_state) => Some(
-                            delete_state
-                                .state_keys()
-                                .to_vec()
-                                .iter()
-                                .flat_map(|k| k.as_bytes().to_vec())
-                                .collect(),
-                        ),
-                        _ => None,
-                    })
-                    .filter(Option::is_some)
-                    .flatten()
-                    .collect(),
-            )
-            .with_outputs(
-                commands
-                    .iter()
-                    .map(|cmd| match cmd {
-                        Command::SetState(set_state) => Some(
-                            set_state
-                                .state_writes()
-                                .iter()
-                                .flat_map(|b| b.key().as_bytes().to_vec())
-                                .collect(),
-                        ),
-                        Command::DeleteState(delete_state) => Some(
-                            delete_state
-                                .state_keys()
-                                .to_vec()
-                                .iter()
-                                .flat_map(|k| k.as_bytes().to_vec())
-                                .collect(),
-                        ),
-                        _ => None,
-                    })
-                    .filter(Option::is_some)
-                    .flatten()
-                    .collect(),
-            )
-            .with_payload_hash_method(HashMethod::Sha512)
-            .with_payload(command_payload))
-    }
-
-    /// Create a `TransactionPair` signed by the given signer
-    pub fn build_pair(self, signer: &dyn Signer) -> Result<TransactionPair, InvalidStateError> {
-        self.into_transaction_builder()?
-            .build_pair(signer)
-            .map_err(|_| {
-                InvalidStateError::with_message("Failed build transaction pair".to_string())
-            })
     }
 }


### PR DESCRIPTION
Move the `CommandTransactionBuilder`, from the `family::command::workload` module, to a new `family::command::transaction_builder` module behind a new feature "family-command-transaction-builder" and re-export it from `family::command`. Additionally, depreciate the builder in the workload module.