### PR TITLE
Add default key location

### DIFF
--- a/cli/src/action/command.rs
+++ b/cli/src/action/command.rs
@@ -35,10 +35,7 @@ impl Action for CommandSetStateAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
-        let key_path = args
-            .value_of("key")
-            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
-        let (auth, signer) = create_cylinder_jwt_auth_signer_key(key_path)?;
+        let (auth, signer) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
 
         let target = args
             .value_of("target")
@@ -194,10 +191,7 @@ impl Action for CommandGetStateAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
-        let key_path = args
-            .value_of("key")
-            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
-        let (auth, signer) = create_cylinder_jwt_auth_signer_key(key_path)?;
+        let (auth, signer) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
 
         let target = args
             .value_of("target")
@@ -343,10 +337,7 @@ impl Action for CommandShowStateAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
-        let key_path = args
-            .value_of("key")
-            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
-        let (auth, _) = create_cylinder_jwt_auth_signer_key(key_path)?;
+        let (auth, _) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
 
         let target = args
             .value_of("target")

--- a/cli/src/action/playlist.rs
+++ b/cli/src/action/playlist.rs
@@ -210,10 +210,7 @@ impl Action for SubmitPlaylistAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
-        let key_path = args
-            .value_of("key")
-            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
-        let (auth, _) = create_cylinder_jwt_auth_signer_key(key_path)?;
+        let (auth, _) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
 
         let rate_string = args.value_of("rate").unwrap_or(DEFAULT_RATE);
         let rate: Duration = if let Ok(interval) = rate_string.parse::<Time>() {

--- a/cli/src/action/workload.rs
+++ b/cli/src/action/workload.rs
@@ -39,10 +39,7 @@ impl Action for WorkloadAction {
     fn run<'a>(&mut self, arg_matches: Option<&ArgMatches<'a>>) -> Result<(), CliError> {
         let args = arg_matches.ok_or(CliError::RequiresArgs)?;
 
-        let key_path = args
-            .value_of("key")
-            .ok_or_else(|| CliError::ActionError("'key' is required".into()))?;
-        let (auth, signer) = create_cylinder_jwt_auth_signer_key(key_path)?;
+        let (auth, signer) = create_cylinder_jwt_auth_signer_key(args.value_of("key"))?;
 
         let targets_vec: Vec<String> = args
             .values_of("targets")


### PR DESCRIPTION
- Update the `create_cylinder_jwt_auth_signer_key` function to check the default location, ~/.cylinder/keys, if no `--key` argument is given.
- Update the following CLI commands to not require the `--key` arg: `command set-state`, `command get-state`, `command show-state`, `playlist submit` and `workload`