### PR TITLE
Alter column type for leaf address

### DIFF
--- a/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2022-01-06-101500-correct-column-type/down.sql
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2022-01-06-101500-correct-column-type/down.sql
@@ -1,0 +1,35 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE new_merkle_radix_leaf (
+    id INTEGER PRIMARY KEY,
+    tree_id INTEGER NOT NULL,
+    address STRING NOT NULL,
+    data BLOB,
+    FOREIGN KEY(tree_id) REFERENCES merkle_radix_tree (id)
+);
+
+INSERT INTO new_merkle_radix_leaf
+    (id, tree_id, address, data)
+    SELECT id, tree_id, address, data
+    FROM merkle_radix_leaf;
+
+DROP TABLE merkle_radix_leaf;
+
+ALTER TABLE new_merkle_radix_leaf RENAME TO merkle_radix_leaf;
+
+PRAGMA foreign_keys=ON;

--- a/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2022-01-06-101500-correct-column-type/up.sql
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/migrations/2022-01-06-101500-correct-column-type/up.sql
@@ -1,0 +1,39 @@
+-- Copyright 2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE new_merkle_radix_leaf (
+    id INTEGER PRIMARY KEY,
+    tree_id INTEGER NOT NULL,
+    address TEXT NOT NULL,
+    data BLOB,
+    FOREIGN KEY(tree_id) REFERENCES merkle_radix_tree (id)
+);
+
+INSERT INTO new_merkle_radix_leaf
+    (id, tree_id, address, data)
+    SELECT id, tree_id, address, data
+    FROM merkle_radix_leaf;
+
+UPDATE new_merkle_radix_leaf
+SET address = '0' || address
+WHERE length(address) % 2 = 1;
+
+DROP TABLE merkle_radix_leaf;
+
+ALTER TABLE new_merkle_radix_leaf RENAME TO merkle_radix_leaf;
+
+PRAGMA foreign_keys=ON;

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -307,6 +307,40 @@ mod test {
         Ok(())
     }
 
+    #[test]
+    fn test_list_leaves() -> Result<(), Box<dyn std::error::Error>> {
+        let backend = SqliteBackendBuilder::new().with_memory_database().build()?;
+
+        backend.run_migrations()?;
+
+        let tree_1 = SqlMerkleStateBuilder::new()
+            .with_backend(backend.clone())
+            .with_tree("test-1")
+            .create_tree_if_necessary()
+            .build()?;
+
+        let initial_state_root_hash = tree_1.initial_state_root_hash()?;
+
+        let state_change_set = StateChange::Set {
+            key: "012345".to_string(),
+            value: "state_value".as_bytes().to_vec(),
+        };
+
+        let new_root = tree_1
+            .commit(&initial_state_root_hash, &[state_change_set])
+            .unwrap();
+        assert_read_value_at_address(&tree_1, &new_root, "012345", Some("state_value"));
+
+        let entry = tree_1
+            .leaves(&new_root, None)?
+            .next()
+            .expect("A value should have been listed")?;
+
+        assert_eq!(("012345".to_string(), b"state_value".to_vec()), entry);
+
+        Ok(())
+    }
+
     fn assert_read_value_at_address<R>(
         merkle_read: &R,
         root_hash: &str,


### PR DESCRIPTION
Prior to this change, the column type for merkle_radix_leaf.address was specified as `"STRING"`. As this type is not one of the types automatically treated as `TEXT`, it defaults to being treated as a `NUMERIC` value.  With certain addresses, where all characters were valid decimal digits with a leading zero, the leading zero would be dropped. This would create
instances where the address value would not be returned, but not with the same address queried.

Changing the column type to `"TEXT"` fixes the problem.

The migration added will also correct all address that are missing a leading zero.

This change also adds several tests for both SQLite and Postgres to guard against this issue in the future, while also exercising the `list_leaves` trait function implementations of each.
