### PR TITLE
Update sha2 dependency to 0.10

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0.8", optional = true }
-sha2 = "0.9"
+sha2 = "0.10"
 tar = { version = "0.4", optional = true }
 uuid = { version = "0.8", optional = true, features = ["v4"] }
 yaml-rust =  { version = "0.4", optional = true }


### PR DESCRIPTION
This update is meant to track the latest release and
does not require any updates.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>