### PR TITLE
Add sleep in `BatchStatusChecker` loop

### DIFF
--- a/libtransact/src/workload/runner.rs
+++ b/libtransact/src/workload/runner.rs
@@ -866,6 +866,7 @@ impl BatchStatusChecker {
                                         }
                                     }
                                 }
+                                thread::sleep(Duration::from_millis(250));
                             }
                             Err(TryRecvError::Disconnected) => {
                                 error!("Channel has disconnected");


### PR DESCRIPTION
Add a 0.25 second sleep to the end of the loop in the `BatchStatusChecker` thread to lower the command workload CPU usage.

Comparison test:
1. Started two splinter nodes locally, created a circuit and uploaded the command smart contract
2. Started a transact workload from the transact main branch
``` 
cargo run --manifest-path cli/Cargo.toml workload \
--target-rate 5/s \
--workload command \
-vv \
--targets 'http://localhost:28080/scabbard/<circuit_id>/<service_id>' \
```
3. Use top to check cpu% of transact - peak was around 53.8% after running the workload for 20 minutes
4. Stopped the workload and started a new workload with the change in this branch, using the same workload command as above
5. Use top to check cpu% of transact - peak was around 5.2% after running the workload for 20 minutes