### PR TITLE
Cache "large" reads in SqlMerkleState

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -40,6 +40,7 @@ lazy_static = { version = "1.4.0", optional = true }
 libc = ">=0.2.35"
 lmdb-zero = { version = ">=0.4.1", optional = true }
 log = { version = "0.4", optional = true, features = ["std"] }
+lru = { version = "0.7", optional = true }
 protobuf = "2.23"
 rand = { version = "0.8", optional = true }
 reqwest = { version = "0.11", features = ["blocking", "json"], optional = true}
@@ -169,7 +170,7 @@ scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
-state-merkle-sql-caching = []
+state-merkle-sql-caching = [ "lru" ]
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -112,7 +112,8 @@ experimental = [
     "contract-context-key-value",
     "family-smallbank-workload",
     "family-xo",
-    "key-value-state"
+    "key-value-state",
+    "state-merkle-sql-caching",
 ]
 
 # stable features in support of wasm
@@ -168,6 +169,7 @@ scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
+state-merkle-sql-caching = []
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.

--- a/libtransact/src/state/merkle/sql/cache.rs
+++ b/libtransact/src/state/merkle/sql/cache.rs
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::sync::{Arc, RwLock};
+
+use lru::LruCache;
+
+use crate::error::InternalError;
+
+/// A cache for data values of at least a minimum size.
+///
+/// This cache provides LRU behavior for the values.
+#[derive(Clone)]
+pub struct DataCache {
+    min_data_size: usize,
+    inner: Arc<RwLock<Inner>>,
+}
+
+impl DataCache {
+    /// Construct a new `DataCache` with a minimum cacheable data size and a max cache size.
+    pub fn new(min_data_size: usize, cache_size: u16) -> Self {
+        Self {
+            min_data_size,
+            inner: Arc::new(RwLock::new(Inner {
+                cache: LruCache::new(cache_size as usize),
+            })),
+        }
+    }
+
+    /// Return whether or not the given data is worth caching
+    pub fn cacheable(&self, data: &[u8]) -> bool {
+        data.len() >= self.min_data_size
+    }
+
+    /// Insert a new (address, data_hash, data) tuple into the cache.
+    ///
+    /// Given this is an LRU cache, this may result in the oldest entry being dropped from the
+    /// cache.
+    pub fn insert(
+        &self,
+        address: String,
+        data_hash: String,
+        data: Vec<u8>,
+    ) -> Result<(), InternalError> {
+        if !self.cacheable(&data) {
+            return Ok(());
+        }
+
+        let mut inner = self
+            .inner
+            .write()
+            .map_err(|_| InternalError::with_message("DataCache lock was poisoned".into()))?;
+
+        inner.cache.put(address, (data_hash, data));
+
+        Ok(())
+    }
+
+    /// Peek at the last known data for a given address.
+    ///
+    /// This does not update the LRU status for an entry, if it exists.
+    pub fn peek_last_known_data_for_address(
+        &self,
+        address: &str,
+    ) -> Result<Option<(String, Vec<u8>)>, InternalError> {
+        let inner = self
+            .inner
+            .read()
+            .map_err(|_| InternalError::with_message("DataCache lock was poisoned".into()))?;
+
+        Ok(inner
+            .cache
+            .peek(address)
+            .map(|(hash, data)| (hash.clone(), data.clone())))
+    }
+
+    /// Touch an entry for the given address
+    ///
+    /// This method updates the given entries LRU status. It has no effect if there is no entry at
+    /// the given address.
+    pub fn touch_entry(&self, address: &str) -> Result<(), InternalError> {
+        self.inner
+            .write()
+            .map_err(|_| InternalError::with_message("DataCache lock was poisoned".into()))?
+            .cache
+            .get(address);
+
+        Ok(())
+    }
+}
+
+struct Inner {
+    cache: LruCache<String, (String, Vec<u8>)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use sha2::{Digest, Sha512};
+
+    /// Test that a given set of values are cacheable
+    #[test]
+    fn test_cacheable() {
+        let cache = DataCache::new(10, 16);
+
+        assert!(!cache.cacheable(b"hello"));
+        assert!(cache.cacheable(b"hello world"));
+    }
+
+    #[test]
+    fn test_peek_last_known_data_hash_for_address() -> Result<(), InternalError> {
+        let cache = DataCache::new(10, 16);
+
+        let data = b"hello world".to_vec();
+        let hash = hash(&data);
+        cache.insert("abc01234".into(), hash.clone(), data.clone())?;
+
+        assert_eq!(
+            Some((hash, data)),
+            cache.peek_last_known_data_for_address("abc01234")?
+        );
+
+        Ok(())
+    }
+
+    /// Test that a set of values of cacheable size are stored, but only the most recent subset of
+    /// the values are retained after the cache's size limit is exceeded.
+    #[test]
+    fn test_cache_limits() -> Result<(), InternalError> {
+        let values = (0..20)
+            .map(|i| {
+                (
+                    format!("0000{:02x}", i),
+                    hash(format!("hello-world-{}", i).as_bytes()),
+                    format!("hello-world-{}", i).as_bytes().to_vec(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let cache = DataCache::new(10, 16);
+        for (addr, hash, data) in values.iter().cloned() {
+            cache.insert(addr, hash, data)?;
+        }
+
+        // These items should have been evicted from the cache
+        for i in 0..4 {
+            assert_eq!(
+                None,
+                cache.peek_last_known_data_for_address(&format!("0000{:02x}", i))?
+            );
+        }
+
+        // the remainder should still be in the cache
+        for (addr, hash, data) in &values[4..] {
+            assert_eq!(
+                Some((hash.clone(), data.clone())),
+                cache.peek_last_known_data_for_address(&addr)?,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Test that a value that is "touched" will be retained in the cache.
+    #[test]
+    fn test_cache_limits_with_touch() -> Result<(), InternalError> {
+        let values = (0..20)
+            .map(|i| {
+                (
+                    format!("0000{:02x}", i),
+                    hash(format!("hello-world-{}", i).as_bytes()),
+                    format!("hello-world-{}", i).as_bytes().to_vec(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let cache = DataCache::new(10, 16);
+        for (addr, hash, data) in values.iter().cloned() {
+            cache.insert(addr, hash, data)?;
+            cache.touch_entry("000000")?;
+        }
+
+        // entry 0 should still be in the map
+        assert_eq!(
+            Some((
+                hash("hello-world-0".as_bytes()),
+                "hello-world-0".as_bytes().to_vec()
+            )),
+            cache.peek_last_known_data_for_address("000000")?,
+        );
+
+        for i in 1..5 {
+            assert_eq!(
+                None,
+                cache.peek_last_known_data_for_address(&format!("0000{:02x}", i))?
+            );
+        }
+
+        // the remainder should still be in the cache
+        for (addr, hash, data) in &values[5..] {
+            assert_eq!(
+                Some((hash.clone(), data.clone())),
+                cache.peek_last_known_data_for_address(&addr)?,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn hash(bytes: &[u8]) -> String {
+        Sha512::digest(bytes)
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect()
+    }
+}

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -149,6 +149,8 @@ impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
 pub struct SqlMerkleState<B: Backend + Clone> {
     backend: B,
     tree_id: i64,
+    #[cfg(feature = "state-merkle-sql-caching")]
+    cache: cache::DataCache,
 }
 
 impl<B: Backend + Clone> SqlMerkleState<B> {

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -50,6 +50,8 @@
 //! Available if the feature "state-merkle-sql" is enabled.
 
 pub mod backend;
+#[cfg(feature = "state-merkle-sql-caching")]
+mod cache;
 mod error;
 pub mod migration;
 #[cfg(feature = "postgres")]

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -83,6 +83,11 @@ pub struct SqlMerkleStateBuilder<B: Backend + Clone> {
     backend: Option<B>,
     tree_name: Option<String>,
     create_tree: bool,
+    #[cfg(feature = "state-merkle-sql-caching")]
+    min_cached_data_size: Option<usize>,
+
+    #[cfg(feature = "state-merkle-sql-caching")]
+    cache_size: Option<u16>,
 }
 
 impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
@@ -92,6 +97,12 @@ impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
             backend: None,
             tree_name: None,
             create_tree: false,
+
+            #[cfg(feature = "state-merkle-sql-caching")]
+            min_cached_data_size: None,
+
+            #[cfg(feature = "state-merkle-sql-caching")]
+            cache_size: None,
         }
     }
 
@@ -110,6 +121,22 @@ impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
     /// Create the specified tree if it does not exist
     pub fn create_tree_if_necessary(mut self) -> Self {
         self.create_tree = true;
+        self
+    }
+
+    /// Sets the minimum size of data in the cache
+    ///
+    /// Any data values smaller than this limit won't be cached in memory.
+    #[cfg(feature = "state-merkle-sql-caching")]
+    pub fn with_min_cached_data_size(mut self, size: usize) -> Self {
+        self.min_cached_data_size = Some(size);
+        self
+    }
+
+    /// Sets the size of the cache
+    #[cfg(feature = "state-merkle-sql-caching")]
+    pub fn with_cache_size(mut self, size: u16) -> Self {
+        self.cache_size = Some(size);
         self
     }
 }

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -51,6 +51,14 @@ impl SqlMerkleStateBuilder<backend::PostgresBackend> {
             .tree_name
             .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
 
+        #[cfg(feature = "state-merkle-sql-caching")]
+        let cache = {
+            super::cache::DataCache::new(
+                self.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
+                self.cache_size.unwrap_or(512),
+            )
+        };
+
         let store = SqlMerkleRadixStore::new(&backend);
 
         let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
@@ -62,7 +70,12 @@ impl SqlMerkleStateBuilder<backend::PostgresBackend> {
             })?
         };
 
-        Ok(SqlMerkleState { backend, tree_id })
+        Ok(SqlMerkleState {
+            backend,
+            tree_id,
+            #[cfg(feature = "state-merkle-sql-caching")]
+            cache,
+        })
     }
 }
 

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -90,6 +90,12 @@ impl SqlMerkleState<backend::PostgresBackend> {
         Ok(())
     }
 
+    #[cfg(feature = "state-merkle-sql-caching")]
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend> {
+        SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
+    }
+
+    #[cfg(not(feature = "state-merkle-sql-caching"))]
     fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend> {
         SqlMerkleRadixStore::new(&self.backend)
     }

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -49,6 +49,14 @@ impl SqlMerkleStateBuilder<backend::SqliteBackend> {
             .tree_name
             .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
 
+        #[cfg(feature = "state-merkle-sql-caching")]
+        let cache = {
+            super::cache::DataCache::new(
+                self.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
+                self.cache_size.unwrap_or(512),
+            )
+        };
+
         let store = SqlMerkleRadixStore::new(&backend);
 
         let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
@@ -60,7 +68,12 @@ impl SqlMerkleStateBuilder<backend::SqliteBackend> {
             })?
         };
 
-        Ok(SqlMerkleState { backend, tree_id })
+        Ok(SqlMerkleState {
+            backend,
+            tree_id,
+            #[cfg(feature = "state-merkle-sql-caching")]
+            cache,
+        })
     }
 }
 

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -88,6 +88,12 @@ impl SqlMerkleState<backend::SqliteBackend> {
         Ok(())
     }
 
+    #[cfg(feature = "state-merkle-sql-caching")]
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
+        SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
+    }
+
+    #[cfg(not(feature = "state-merkle-sql-caching"))]
     fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
         SqlMerkleRadixStore::new(&self.backend)
     }

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -70,9 +70,13 @@ impl SqlMerkleState<backend::SqliteBackend> {
     /// After calling this method, no data associated with the tree name will remain in the
     /// database.
     pub fn delete_tree(self) -> Result<(), InternalError> {
-        let store = SqlMerkleRadixStore::new(&self.backend);
+        let store = self.new_store();
         store.delete_tree(self.tree_id)?;
         Ok(())
+    }
+
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
+        SqlMerkleRadixStore::new(&self.backend)
     }
 }
 
@@ -86,11 +90,7 @@ impl Write for SqlMerkleState<backend::SqliteBackend> {
         state_id: &Self::StateId,
         state_changes: &[StateChange],
     ) -> Result<Self::StateId, StateWriteError> {
-        let overlay = MerkleRadixOverlay::new(
-            self.tree_id,
-            &*state_id,
-            SqlMerkleRadixStore::new(&self.backend),
-        );
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
 
         let (next_state_id, tree_update) = overlay
             .generate_updates(state_changes)
@@ -108,11 +108,7 @@ impl Write for SqlMerkleState<backend::SqliteBackend> {
         state_id: &Self::StateId,
         state_changes: &[StateChange],
     ) -> Result<Self::StateId, StateWriteError> {
-        let overlay = MerkleRadixOverlay::new(
-            self.tree_id,
-            &*state_id,
-            SqlMerkleRadixStore::new(&self.backend),
-        );
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
 
         let (next_state_id, _) = overlay
             .generate_updates(state_changes)
@@ -132,11 +128,7 @@ impl Read for SqlMerkleState<backend::SqliteBackend> {
         state_id: &Self::StateId,
         keys: &[Self::Key],
     ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
-        let overlay = MerkleRadixOverlay::new(
-            self.tree_id,
-            &*state_id,
-            SqlMerkleRadixStore::new(&self.backend),
-        );
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
 
         if !overlay
             .has_root()
@@ -163,7 +155,7 @@ impl Prune for SqlMerkleState<backend::SqliteBackend> {
     type Value = Vec<u8>;
 
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StatePruneError> {
-        let overlay = MerkleRadixPruner::new(self.tree_id, SqlMerkleRadixStore::new(&self.backend));
+        let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
 
         overlay
             .prune(&state_ids)
@@ -187,11 +179,9 @@ impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
             return Ok(Box::new(std::iter::empty()));
         }
 
-        let leaves = SqlMerkleRadixStore::new(&self.backend).list_entries(
-            self.tree_id,
-            state_id,
-            subtree,
-        )?;
+        let leaves = self
+            .new_store()
+            .list_entries(self.tree_id, state_id, subtree)?;
 
         Ok(Box::new(leaves.into_iter().map(Ok)))
     }

--- a/libtransact/src/state/merkle/sql/store/mod.rs
+++ b/libtransact/src/state/merkle/sql/store/mod.rs
@@ -29,6 +29,8 @@ mod sqlite;
 use std::collections::HashSet;
 
 use crate::error::InternalError;
+#[cfg(feature = "state-merkle-sql-caching")]
+use crate::state::merkle::sql::cache::DataCache;
 use crate::state::merkle::{node::Node, sql::backend::Backend};
 
 // (Hash, packed bytes, path address)
@@ -233,11 +235,25 @@ pub trait MerkleRadixStore {
 /// A MerkleRadixStore backed by a SQL back-end.
 pub struct SqlMerkleRadixStore<'b, B: Backend> {
     pub backend: &'b B,
+    #[cfg(feature = "state-merkle-sql-caching")]
+    pub cache: Option<&'b DataCache>,
 }
 
 impl<'b, B: Backend> SqlMerkleRadixStore<'b, B> {
     /// Constructs a new store for a given back-end.
     pub fn new(backend: &'b B) -> Self {
-        Self { backend }
+        Self {
+            backend,
+            #[cfg(feature = "state-merkle-sql-caching")]
+            cache: None,
+        }
+    }
+
+    #[cfg(feature = "state-merkle-sql-caching")]
+    pub(crate) fn new_with_cache(backend: &'b B, cache: &'b DataCache) -> Self {
+        Self {
+            backend,
+            cache: Some(cache),
+        }
     }
 }

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -93,7 +93,13 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         let conn = self.backend.connection()?;
 
         let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_leaves(tree_id, state_root_hash, keys)
+        operations.get_leaves(
+            tree_id,
+            state_root_hash,
+            keys,
+            #[cfg(feature = "state-merkle-sql-caching")]
+            self.cache,
+        )
     }
 
     fn list_entries(

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -100,6 +100,8 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend> {
                 tree_id,
                 state_root_hash,
                 read_keys.iter().map(String::as_str).collect(),
+                #[cfg(feature = "state-merkle-sql-caching")]
+                self.cache,
             )
         })
     }


### PR DESCRIPTION
This change introduces a data cache used to cache the data values for "large" (where "large" is a configurable value) during the "get_leaves" store operation.

This cache mitigates issues when used with large state values and postgres, where the frequent return of large data (for example, when smart contracts are in play) causes a cloud instance to throttle bandwidth.

It is currently available under the experimental feature `"state-merkle-sql-caching"`.