### PR TITLE
Revert "Merge pull request #318 from Cargill/pschwarz-prune-fixes"

### DIFF
--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -230,7 +230,7 @@ where
             match state_change {
                 StateChange::Set { key, value } => {
                     let mut set_path_map = self
-                        .get_path(key, false)
+                        .get_path(key)
                         .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
                     {
                         let node = set_path_map
@@ -245,7 +245,7 @@ where
                 }
                 StateChange::Delete { key } => {
                     let del_path_map = self
-                        .get_path(key, true)
+                        .get_path(key)
                         .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
                     path_map.extend(del_path_map);
                     delete_items.push(key);
@@ -326,8 +326,6 @@ where
             batch.push((key_hash_hex.clone(), node, path));
         }
 
-        deletions.insert(self.state_root_hash.to_string());
-
         Ok((
             key_hash_hex,
             TreeUpdate {
@@ -337,11 +335,7 @@ where
         ))
     }
 
-    fn get_path(
-        &self,
-        address: &str,
-        strict: bool,
-    ) -> Result<HashMap<String, Node>, InternalError> {
+    fn get_path(&self, address: &str) -> Result<HashMap<String, Node>, InternalError> {
         // Build up the address along the path, starting with the empty address for the root, and
         // finishing with the complete address.
         let addresses_along_path = (0..address.len())
@@ -353,21 +347,14 @@ where
             .inner
             .get_path(self.tree_id, self.state_root_hash, address)?
             .into_iter()
-            .map(|(_, node)| node);
-
-        let path_map = if strict {
-            addresses_along_path
-                .zip(node_path_iter)
-                .collect::<HashMap<_, _>>()
-        } else {
+            .map(|(_, node)| node)
             // include empty nodes after the queried path, to cover cases where the branch doesn't
             // exist.
-            addresses_along_path
-                .zip(node_path_iter.chain(std::iter::repeat_with(Node::default)))
-                .collect::<HashMap<_, _>>()
-        };
+            .chain(std::iter::repeat(Node::default()));
 
-        Ok(path_map)
+        Ok(addresses_along_path
+            .zip(node_path_iter)
+            .collect::<HashMap<_, _>>())
     }
 }
 

--- a/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
@@ -226,7 +226,8 @@ where
         change_additions
     } else {
         // we have one successor, based on our criteria, so we can safely unwrap
-        let (_successor_state_root, deletions) = successors.into_iter().next().unwrap();
+        let (_successor_state_root, mut deletions) = successors.into_iter().next().unwrap();
+        deletions.push(state_root.into());
         deletions
     };
 

--- a/libtransact/src/state/merkle/sql/store/operations/write_changes.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/write_changes.rs
@@ -128,10 +128,20 @@ impl<'a> MerkleRadixWriteChangesOperation for MerkleRadixOperations<'a, SqliteCo
                 .execute(self.conn)?;
 
             // Update the change log
-            let change_log_additions = update
+            let additions = update
                 .node_changes
                 .iter()
-                .map(|(hash, _, _)| NewMerkleRadixChangeLogAddition {
+                .map(|(hash, _, _)| hash.as_ref())
+                .collect::<Vec<_>>();
+            let deletions = update
+                .deletions
+                .iter()
+                .map(|s| s.as_ref())
+                .collect::<Vec<_>>();
+
+            let change_log_additions = additions
+                .iter()
+                .map(|hash| NewMerkleRadixChangeLogAddition {
                     state_root,
                     tree_id,
                     parent_state_root: Some(parent_state_root),
@@ -143,8 +153,7 @@ impl<'a> MerkleRadixWriteChangesOperation for MerkleRadixOperations<'a, SqliteCo
                 .values(change_log_additions)
                 .execute(self.conn)?;
 
-            let change_log_deletions = update
-                .deletions
+            let change_log_deletions = deletions
                 .iter()
                 .map(|hash| NewMerkleRadixChangeLogDeletion {
                     state_root: parent_state_root,

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -121,12 +121,6 @@ fn merkle_trie_prune_successor_duplicate_leaves() {
 }
 
 #[test]
-fn merkle_trie_prune_deep_successor_tree() {
-    let (state, orig_root) = new_btree_state_and_root();
-    test_merkle_trie_prune_deep_successor_tree(orig_root, state);
-}
-
-#[test]
 fn leaf_iteration() {
     let (state, orig_root) = new_btree_state_and_root();
     test_leaf_iteration(orig_root, state);

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -119,15 +119,6 @@ fn merkle_trie_prune_successor_duplicate_leaves() -> Result<(), Box<dyn Error>> 
 }
 
 #[test]
-fn merkle_trie_prune_deep_successor_tree() -> Result<(), Box<dyn Error>> {
-    run_test(|db_path| {
-        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
-        test_merkle_trie_prune_deep_successor_tree(orig_root, state);
-        Ok(())
-    })
-}
-
-#[test]
 fn leaf_iteration() -> Result<(), Box<dyn Error>> {
     run_test(|db_path| {
         let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;


### PR DESCRIPTION
This reverts commit 0913126135ba0e8826142493230a40c8ea6b9b8a, reversing
changes made to c4e489cc89f163da8465ddea80f50cb6a8aa4f8f.

These changes are suspected in LR failures.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>