### PR TITLE
InTransaction Back-end implementations for both Postgres and Sqlite 

### DIFF
--- a/libtransact/src/context/manager/mod.rs
+++ b/libtransact/src/context/manager/mod.rs
@@ -26,13 +26,13 @@ pub use crate::context::error::ContextManagerError;
 use crate::context::{Context, ContextId, ContextLifecycle};
 use crate::error::InternalError;
 use crate::protocol::receipt::{Event, StateChange, TransactionReceipt, TransactionReceiptBuilder};
-use crate::state::Read;
+use crate::state::SyncRead;
 
 #[derive(Clone)]
 pub struct ContextManager {
     contexts: HashMap<ContextId, Context>,
     context_refs: RefMap<ContextId>,
-    database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>,
+    database: Box<dyn SyncRead<StateId = String, Key = String, Value = Vec<u8>>>,
 }
 
 impl ContextLifecycle for ContextManager {
@@ -92,7 +92,9 @@ impl ContextLifecycle for ContextManager {
 }
 
 impl ContextManager {
-    pub fn new(database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>) -> Self {
+    pub fn new(
+        database: Box<dyn SyncRead<StateId = String, Key = String, Value = Vec<u8>>>,
+    ) -> Self {
         ContextManager {
             contexts: HashMap::new(),
             context_refs: RefMap::new(),

--- a/libtransact/src/context/manager/sync.rs
+++ b/libtransact/src/context/manager/sync.rs
@@ -26,7 +26,7 @@ use crate::context::error::ContextManagerError;
 use crate::context::{manager, ContextId, ContextLifecycle};
 use crate::error::InternalError;
 use crate::protocol::receipt::{Event, TransactionReceipt};
-use crate::state::Read;
+use crate::state::SyncRead;
 
 /// A thread-safe ContextManager.
 #[derive(Clone)]
@@ -38,7 +38,9 @@ impl ContextManager {
     /// Constructs a new Context Manager around a given state Read.
     ///
     /// The Read defines the state on which the context built.
-    pub fn new(database: Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>>) -> Self {
+    pub fn new(
+        database: Box<dyn SyncRead<StateId = String, Key = String, Value = Vec<u8>>>,
+    ) -> Self {
         ContextManager {
             internal_manager: Arc::new(Mutex::new(manager::ContextManager::new(database))),
         }

--- a/libtransact/src/state/hashmap.rs
+++ b/libtransact/src/state/hashmap.rs
@@ -18,7 +18,7 @@
 //! Provides a simple, in-memory implementation of backed by `std::collections::HashMap`.
 
 use super::error::{StateReadError, StateWriteError};
-use super::{Read, StateChange, Write};
+use super::{Read, StateChange, SyncRead, Write};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -133,8 +133,10 @@ impl Read for HashMapState {
             .filter_map(|k| state.get(&k).cloned().map(|v| (k, v)))
             .collect())
     }
+}
 
-    fn clone_box(&self) -> Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>> {
+impl SyncRead for HashMapState {
+    fn clone_box(&self) -> Box<dyn SyncRead<StateId = String, Key = String, Value = Vec<u8>>> {
         Box::new(Clone::clone(self))
     }
 }

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -28,7 +28,7 @@ use crate::database::error::DatabaseError;
 use crate::database::{Database, DatabaseReader, DatabaseWriter};
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::error::{StatePruneError, StateReadError, StateWriteError};
-use crate::state::{Prune, Read, StateChange, Write};
+use crate::state::{Prune, Read, StateChange, SyncRead, Write};
 
 use super::node::Node;
 use super::{MerkleRadixLeafReadError, MerkleRadixLeafReader};
@@ -123,8 +123,10 @@ impl Read for MerkleState {
             Ok(result)
         })
     }
+}
 
-    fn clone_box(&self) -> Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>> {
+impl SyncRead for MerkleState {
+    fn clone_box(&self) -> Box<dyn SyncRead<StateId = String, Key = String, Value = Vec<u8>>> {
         Box::new(Clone::clone(self))
     }
 }

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -29,7 +29,9 @@ use crate::error::InternalError;
 #[cfg(feature = "state-merkle-sql-postgres-tests")]
 pub use postgres::test::run_postgres_test;
 #[cfg(feature = "postgres")]
-pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
+pub use postgres::{
+    InTransactionPostgresBackend, PostgresBackend, PostgresBackendBuilder, PostgresConnection,
+};
 #[cfg(feature = "sqlite")]
 pub use sqlite::{
     InTransactionSqliteBackend, JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection,

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -50,6 +50,10 @@ pub trait Backend: Sync + Send {
     type Connection: Connection;
 
     /// Acquire a database connection.
+    ///
+    /// This method is soft-deprecated, as it is no longer used internally, and has been superseded
+    /// by use with the execute trait.  It may be strongly deprecated in a future release, to be
+    /// removed in a follow-up release.
     fn connection(&self) -> Result<Self::Connection, InternalError>;
 }
 

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -45,7 +45,7 @@ pub trait Connection {
 /// A database backend.
 ///
 /// A Backend provides a light-weight abstraction over database connections.
-pub trait Backend: Sync + Send {
+pub trait Backend {
     /// The database connection.
     type Connection: Connection;
 

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -31,7 +31,10 @@ pub use postgres::test::run_postgres_test;
 #[cfg(feature = "postgres")]
 pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
 #[cfg(feature = "sqlite")]
-pub use sqlite::{JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection, Synchronous};
+pub use sqlite::{
+    InTransactionSqliteBackend, JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection,
+    Synchronous,
+};
 
 /// A database connection.
 pub trait Connection {

--- a/libtransact/src/state/merkle/sql/migration/postgres/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/postgres/mod.rs
@@ -20,7 +20,7 @@
 embed_migrations!("./src/state/merkle/sql/migration/postgres/migrations");
 
 use crate::error::InternalError;
-use crate::state::merkle::sql::backend::{Backend, Connection, PostgresBackend};
+use crate::state::merkle::sql::backend::{Connection, Execute, PostgresBackend};
 
 use super::MigrationManager;
 
@@ -41,6 +41,6 @@ pub fn run_migrations(conn: &diesel::pg::PgConnection) -> Result<(), InternalErr
 
 impl MigrationManager for PostgresBackend {
     fn run_migrations(&self) -> Result<(), InternalError> {
-        run_migrations(self.connection()?.as_inner())
+        self.execute(|conn| run_migrations(conn.as_inner()))
     }
 }

--- a/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
@@ -20,7 +20,7 @@
 embed_migrations!("./src/state/merkle/sql/migration/sqlite/migrations");
 
 use crate::error::InternalError;
-use crate::state::merkle::sql::backend::{Backend, Connection, SqliteBackend};
+use crate::state::merkle::sql::backend::{Connection, SqliteBackend, WriteExclusiveExecute};
 
 use super::MigrationManager;
 
@@ -40,6 +40,6 @@ pub fn run_migrations(conn: &diesel::sqlite::SqliteConnection) -> Result<(), Int
 
 impl MigrationManager for SqliteBackend {
     fn run_migrations(&self) -> Result<(), InternalError> {
-        run_migrations(self.connection()?.as_inner())
+        self.execute_write(|conn| run_migrations(conn.as_inner()))
     }
 }

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -79,7 +79,7 @@ const TOKEN_SIZE: usize = 2;
 
 /// Builds a new SqlMerkleState with a specific backend.
 #[derive(Default)]
-pub struct SqlMerkleStateBuilder<B: Backend + Clone> {
+pub struct SqlMerkleStateBuilder<B: Backend> {
     backend: Option<B>,
     tree_name: Option<String>,
     create_tree: bool,
@@ -90,7 +90,7 @@ pub struct SqlMerkleStateBuilder<B: Backend + Clone> {
     cache_size: Option<u16>,
 }
 
-impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
+impl<B: Backend> SqlMerkleStateBuilder<B> {
     /// Constructs a new builder
     pub fn new() -> Self {
         Self {
@@ -145,15 +145,14 @@ impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
 ///
 /// Databases are implemented using a Backend to provide connections. Note that the database must
 /// have the correct set of tables applied via migrations before this struct may be usable.
-#[derive(Clone)]
-pub struct SqlMerkleState<B: Backend + Clone> {
+pub struct SqlMerkleState<B: Backend> {
     backend: B,
     tree_id: i64,
     #[cfg(feature = "state-merkle-sql-caching")]
     cache: cache::DataCache,
 }
 
-impl<B: Backend + Clone> SqlMerkleState<B> {
+impl<B: Backend> SqlMerkleState<B> {
     /// Returns the initial state root.
     ///
     /// This value is the state root that applies to a empty merkle radix tree.
@@ -161,6 +160,20 @@ impl<B: Backend + Clone> SqlMerkleState<B> {
         let (hash, _) = encode_and_hash(Node::default())?;
 
         Ok(hex::encode(&hash))
+    }
+}
+
+impl<B> Clone for SqlMerkleState<B>
+where
+    B: Backend + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            backend: self.backend.clone(),
+            tree_id: self.tree_id,
+            #[cfg(feature = "state-merkle-sql-caching")]
+            cache: self.cache.clone(),
+        }
     }
 }
 

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -17,6 +17,8 @@
 
 use std::collections::HashMap;
 
+use diesel::pg::PgConnection;
+
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
 use crate::state::{
@@ -91,12 +93,12 @@ impl SqlMerkleState<backend::PostgresBackend> {
     }
 
     #[cfg(feature = "state-merkle-sql-caching")]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
     }
 
     #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new(&self.backend)
     }
 }

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
 use crate::state::{
-    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
+    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, SyncRead, Write,
 };
 
 use super::backend;
@@ -176,10 +176,12 @@ impl Read for SqlMerkleState<backend::PostgresBackend> {
             .get_entries(keys)
             .map_err(|e| StateReadError::StorageError(Box::new(e)))
     }
+}
 
+impl SyncRead for SqlMerkleState<backend::PostgresBackend> {
     fn clone_box(
         &self,
-    ) -> Box<dyn Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>> {
+    ) -> Box<dyn SyncRead<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>> {
         Box::new(self.clone())
     }
 }

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -89,12 +89,12 @@ impl SqlMerkleState<backend::SqliteBackend> {
     }
 
     #[cfg(feature = "state-merkle-sql-caching")]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
     }
 
     #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new(&self.backend)
     }
 }

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
 use crate::state::{
-    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
+    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, SyncRead, Write,
 };
 
 use super::backend;
@@ -160,10 +160,10 @@ impl Read for SqlMerkleState<backend::SqliteBackend> {
             .get_entries(keys)
             .map_err(|e| StateReadError::StorageError(Box::new(e)))
     }
+}
 
-    fn clone_box(
-        &self,
-    ) -> Box<dyn Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>> {
+impl SyncRead for SqlMerkleState<backend::SqliteBackend> {
+    fn clone_box(&self) -> Box<dyn SyncRead<StateId = String, Key = String, Value = Vec<u8>>> {
         Box::new(self.clone())
     }
 }

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -19,7 +19,7 @@ use diesel::pg::PgConnection;
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{Connection, Execute, PostgresBackend};
+use crate::state::merkle::sql::backend::{Backend, Connection, Execute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -34,7 +34,11 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, PostgresBackend, PgConnection> {
+impl<'b, B> MerkleRadixStore for SqlMerkleRadixStore<'b, B, PgConnection>
+where
+    B: Backend + Execute,
+    <B as Backend>::Connection: Connection<ConnectionType = PgConnection>,
+{
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -15,9 +15,11 @@
  * -----------------------------------------------------------------------------
  */
 
+use diesel::pg::PgConnection;
+
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Connection, Execute};
+use crate::state::merkle::sql::backend::{Connection, Execute, PostgresBackend};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -32,7 +34,7 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> {
+impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, PostgresBackend, PgConnection> {
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -17,7 +17,7 @@
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Backend, Connection};
+use crate::state::merkle::sql::backend::{self, Connection, Execute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -38,38 +38,41 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         tree_name: &str,
         initial_state_root_hash: &str,
     ) -> Result<i64, InternalError> {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_or_create_tree(tree_name, initial_state_root_hash)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_or_create_tree(tree_name, initial_state_root_hash)
+        })
     }
 
     fn get_tree_id_by_name(&self, tree_name: &str) -> Result<Option<i64>, InternalError> {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_tree_id_by_name(tree_name)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_tree_id_by_name(tree_name)
+        })
     }
 
     fn delete_tree(&self, tree_id: i64) -> Result<(), InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.delete_tree(tree_id)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.delete_tree(tree_id)
+        })
     }
 
     fn list_trees(
         &self,
     ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>
     {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.list_trees()
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.list_trees()
+        })
     }
 
     fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.has_root(tree_id, state_root_hash)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.has_root(tree_id, state_root_hash)
+        })
     }
 
     fn get_path(
@@ -78,10 +81,10 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         state_root_hash: &str,
         address: &str,
     ) -> Result<Vec<(String, Node)>, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_path(tree_id, state_root_hash, address)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_path(tree_id, state_root_hash, address)
+        })
     }
 
     fn get_entries(
@@ -90,16 +93,17 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         state_root_hash: &str,
         keys: Vec<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_leaves(
-            tree_id,
-            state_root_hash,
-            keys,
-            #[cfg(feature = "state-merkle-sql-caching")]
-            self.cache,
-        )
+        let read_keys = keys.into_iter().map(String::from).collect::<Vec<_>>();
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_leaves(
+                tree_id,
+                state_root_hash,
+                read_keys.iter().map(String::as_str).collect(),
+                #[cfg(feature = "state-merkle-sql-caching")]
+                self.cache,
+            )
+        })
     }
 
     fn list_entries(
@@ -108,10 +112,10 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         state_root_hash: &str,
         prefix: Option<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.list_leaves(tree_id, state_root_hash, prefix)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.list_leaves(tree_id, state_root_hash, prefix)
+        })
     }
 
     fn write_changes(
@@ -121,22 +125,23 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         parent_state_root_hash: &str,
         tree_update: TreeUpdate,
     ) -> Result<(), InternalError> {
-        let conn = self.backend.connection()?;
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
 
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-
-        operations.write_changes(
-            tree_id,
-            state_root_hash,
-            parent_state_root_hash,
-            &tree_update,
-        )?;
-        Ok(())
+            operations.write_changes(
+                tree_id,
+                state_root_hash,
+                parent_state_root_hash,
+                &tree_update,
+            )?;
+            Ok(())
+        })
     }
 
     fn prune(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError> {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.prune_entries(tree_id, state_root)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.prune_entries(tree_id, state_root)
+        })
     }
 }

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -17,7 +17,7 @@
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Connection};
+use crate::state::merkle::sql::backend::{self, Connection, WriteExclusiveExecute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -19,7 +19,7 @@ use diesel::SqliteConnection;
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Connection, WriteExclusiveExecute};
+use crate::state::merkle::sql::backend::{Backend, Connection, WriteExclusiveExecute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -34,7 +34,11 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend, SqliteConnection> {
+impl<'b, B> MerkleRadixStore for SqlMerkleRadixStore<'b, B, SqliteConnection>
+where
+    B: Backend + WriteExclusiveExecute,
+    <B as Backend>::Connection: Connection<ConnectionType = SqliteConnection>,
+{
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -15,6 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+use diesel::SqliteConnection;
+
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
 use crate::state::merkle::sql::backend::{self, Connection, WriteExclusiveExecute};
@@ -32,7 +34,7 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend> {
+impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend, SqliteConnection> {
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -156,7 +156,7 @@ pub trait Prune: Sync + Send {
 /// It provides the ability to read values from an underlying storage
 ///
 /// Implementations are expected to be thread-safe.
-pub trait Read: Send + Send {
+pub trait Read {
     /// A reference to a checkpoint in state. It could be a merkle hash for
     /// a merkle database.
     type StateId;
@@ -180,14 +180,16 @@ pub trait Read: Send + Send {
         state_id: &Self::StateId,
         keys: &[Self::Key],
     ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError>;
-
-    fn clone_box(
-        &self,
-    ) -> Box<dyn Read<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>>;
 }
 
-impl<S, K, V> Clone for Box<dyn Read<StateId = S, Key = K, Value = V>> {
-    fn clone(&self) -> Box<dyn Read<StateId = S, Key = K, Value = V>> {
+pub trait SyncRead: Read + Sync + Send {
+    fn clone_box(
+        &self,
+    ) -> Box<dyn SyncRead<StateId = Self::StateId, Key = Self::Key, Value = Self::Value>>;
+}
+
+impl<S, K, V> Clone for Box<dyn SyncRead<StateId = S, Key = K, Value = V>> {
+    fn clone(&self) -> Self {
         self.clone_box()
     }
 }

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -76,7 +76,7 @@ impl StateChange {
 /// ordered set of changes to be applied onto the given `StateId`.
 ///
 /// Implementations are expected to be thread-safe.
-pub trait Write: Sync + Send {
+pub trait Write {
     /// A reference to a checkpoint in state. It could be a merkle hash for
     /// a merkle database.
     type StateId;
@@ -125,7 +125,7 @@ pub trait Write: Sync + Send {
 ///
 /// Removing `StateIds` and the associated state makes it so the state storage
 /// system does not grow unbounded.
-pub trait Prune: Sync + Send {
+pub trait Prune {
     /// A reference to a checkpoint in state. It could be a merkle hash for
     /// a merkle database.
     type StateId;

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -34,7 +34,7 @@ use transact::{
     protos::merkle::ChangeLogEntry,
     state::{
         merkle::{MerkleRadixLeafReader, MerkleRadixTree, MerkleState, CHANGE_LOG_INDEX},
-        Prune, Read, StateChange, StateReadError, Write,
+        Prune, Read, StateChange, StateReadError, SyncRead, Write,
     },
 };
 
@@ -154,7 +154,7 @@ where
 /// 4. In each thread, validate that you can still read the original value
 fn test_merkle_trie_multithread_read<M>(initial_state_root: String, merkle_state: M)
 where
-    M: Read<StateId = String, Key = String, Value = Vec<u8>>
+    M: SyncRead<StateId = String, Key = String, Value = Vec<u8>>
         + Write<StateId = String, Key = String, Value = Vec<u8>>
         + Clone
         + 'static,


### PR DESCRIPTION
This change requires a number of changes on trait constraits, removing many Sync, Send and Clone constraints, but does require a new trait, split out from Read, to cover a Read implementation that is sync and send.  This is necessary, as the ContextManager requires Sync/Send Read impls.