### PR TITLE
InTransaction Back-end implementations for both Postgres and Sqlite

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -177,7 +177,13 @@ sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
 state-merkle-sql-caching = [ "lru" ]
-state-merkle-sql-in-transaction = []
+state-merkle-sql-in-transaction = [
+    "state-trait",
+    "state-trait-committer",
+    "state-trait-dry-run-committer",
+    "state-trait-pruner",
+    "state-trait-reader",
+]
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -115,6 +115,7 @@ experimental = [
     "family-xo",
     "key-value-state",
     "state-merkle-sql-caching",
+    "state-merkle-sql-in-transaction",
     "state-trait",
     "state-trait-committer",
     "state-trait-dry-run-committer",
@@ -176,6 +177,7 @@ sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations"]
 state-merkle-sql-caching = [ "lru" ]
+state-merkle-sql-in-transaction = []
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -50,6 +50,10 @@ pub trait Backend: Sync + Send {
     type Connection: Connection;
 
     /// Acquire a database connection.
+    ///
+    /// This method is soft-deprecated, as it is no longer used internally, and has been superseded
+    /// by use with the execute trait.  It may be strongly deprecated in a future release, to be
+    /// removed in a follow-up release.
     fn connection(&self) -> Result<Self::Connection, InternalError>;
 }
 

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -30,6 +30,8 @@ use crate::error::InternalError;
 pub use postgres::test::run_postgres_test;
 #[cfg(feature = "postgres")]
 pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
+#[cfg(all(feature = "sqlite", feature = "state-merkle-sql-in-transaction"))]
+pub use sqlite::InTransactionSqliteBackend;
 #[cfg(feature = "sqlite")]
 pub use sqlite::{JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection, Synchronous};
 

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -28,6 +28,8 @@ use crate::error::InternalError;
 
 #[cfg(feature = "state-merkle-sql-postgres-tests")]
 pub use postgres::test::run_postgres_test;
+#[cfg(all(feature = "postgres", feature = "state-merkle-sql-in-transaction"))]
+pub use postgres::InTransactionPostgresBackend;
 #[cfg(feature = "postgres")]
 pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
 #[cfg(all(feature = "sqlite", feature = "state-merkle-sql-in-transaction"))]

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -45,7 +45,7 @@ pub trait Connection {
 /// A database backend.
 ///
 /// A Backend provides a light-weight abstraction over database connections.
-pub trait Backend: Sync + Send {
+pub trait Backend {
     /// The database connection.
     type Connection: Connection;
 

--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -84,6 +84,65 @@ impl From<Pool<ConnectionManager<diesel::pg::PgConnection>>> for PostgresBackend
     }
 }
 
+/// A borrowed Postgres connection.
+///
+/// Available if the features "state-merkle-sql-in-transaction" "postgres" are enabled.
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+pub struct BorrowedPostgresConnection<'a>(&'a diesel::pg::PgConnection);
+
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> Connection for BorrowedPostgresConnection<'a> {
+    type ConnectionType = diesel::pg::PgConnection;
+
+    fn as_inner(&self) -> &Self::ConnectionType {
+        self.0
+    }
+}
+
+/// A Postgres Backend that wraps a borrowed connection.
+///
+/// This backend is neither `Sync` nor `Send`.
+///
+/// Available if the features "state-merkle-sql-in-transaction" "postgres" are enabled.
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+pub struct InTransactionPostgresBackend<'a> {
+    connection: &'a diesel::pg::PgConnection,
+}
+
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> InTransactionPostgresBackend<'a> {
+    /// Wrap a reference to a [`diesel::pg::PgConnection`].
+    pub fn new(connection: &'a diesel::pg::PgConnection) -> Self {
+        Self { connection }
+    }
+}
+
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> Backend for InTransactionPostgresBackend<'a> {
+    type Connection = BorrowedPostgresConnection<'a>;
+
+    fn connection(&self) -> Result<Self::Connection, InternalError> {
+        Ok(BorrowedPostgresConnection(self.connection))
+    }
+}
+
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> Execute for InTransactionPostgresBackend<'a> {
+    fn execute<F, T>(&self, f: F) -> Result<T, InternalError>
+    where
+        F: Fn(&Self::Connection) -> Result<T, InternalError>,
+    {
+        f(&BorrowedPostgresConnection(self.connection))
+    }
+}
+
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> From<&'a diesel::pg::PgConnection> for InTransactionPostgresBackend<'a> {
+    fn from(conn: &'a diesel::pg::PgConnection) -> Self {
+        Self::new(conn)
+    }
+}
+
 /// A Builder for the PostgresBackend.
 ///
 /// Available if the feature "postgres" is enabled.

--- a/libtransact/src/state/merkle/sql/migration/postgres/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/postgres/mod.rs
@@ -20,7 +20,7 @@
 embed_migrations!("./src/state/merkle/sql/migration/postgres/migrations");
 
 use crate::error::InternalError;
-use crate::state::merkle::sql::backend::{Backend, Connection, PostgresBackend};
+use crate::state::merkle::sql::backend::{Connection, Execute, PostgresBackend};
 
 use super::MigrationManager;
 
@@ -41,6 +41,6 @@ pub fn run_migrations(conn: &diesel::pg::PgConnection) -> Result<(), InternalErr
 
 impl MigrationManager for PostgresBackend {
     fn run_migrations(&self) -> Result<(), InternalError> {
-        run_migrations(self.connection()?.as_inner())
+        self.execute(|conn| run_migrations(conn.as_inner()))
     }
 }

--- a/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
+++ b/libtransact/src/state/merkle/sql/migration/sqlite/mod.rs
@@ -20,7 +20,7 @@
 embed_migrations!("./src/state/merkle/sql/migration/sqlite/migrations");
 
 use crate::error::InternalError;
-use crate::state::merkle::sql::backend::{Backend, Connection, SqliteBackend};
+use crate::state::merkle::sql::backend::{Connection, SqliteBackend, WriteExclusiveExecute};
 
 use super::MigrationManager;
 
@@ -40,6 +40,6 @@ pub fn run_migrations(conn: &diesel::sqlite::SqliteConnection) -> Result<(), Int
 
 impl MigrationManager for SqliteBackend {
     fn run_migrations(&self) -> Result<(), InternalError> {
-        run_migrations(self.connection()?.as_inner())
+        self.execute_write(|conn| run_migrations(conn.as_inner()))
     }
 }

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -79,7 +79,7 @@ const TOKEN_SIZE: usize = 2;
 
 /// Builds a new SqlMerkleState with a specific backend.
 #[derive(Default)]
-pub struct SqlMerkleStateBuilder<B: Backend + Clone> {
+pub struct SqlMerkleStateBuilder<B: Backend> {
     backend: Option<B>,
     tree_name: Option<String>,
     create_tree: bool,
@@ -90,7 +90,7 @@ pub struct SqlMerkleStateBuilder<B: Backend + Clone> {
     cache_size: Option<u16>,
 }
 
-impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
+impl<B: Backend> SqlMerkleStateBuilder<B> {
     /// Constructs a new builder
     pub fn new() -> Self {
         Self {
@@ -145,15 +145,14 @@ impl<B: Backend + Clone> SqlMerkleStateBuilder<B> {
 ///
 /// Databases are implemented using a Backend to provide connections. Note that the database must
 /// have the correct set of tables applied via migrations before this struct may be usable.
-#[derive(Clone)]
-pub struct SqlMerkleState<B: Backend + Clone> {
+pub struct SqlMerkleState<B: Backend> {
     backend: B,
     tree_id: i64,
     #[cfg(feature = "state-merkle-sql-caching")]
     cache: cache::DataCache,
 }
 
-impl<B: Backend + Clone> SqlMerkleState<B> {
+impl<B: Backend> SqlMerkleState<B> {
     /// Returns the initial state root.
     ///
     /// This value is the state root that applies to a empty merkle radix tree.
@@ -161,6 +160,20 @@ impl<B: Backend + Clone> SqlMerkleState<B> {
         let (hash, _) = encode_and_hash(Node::default())?;
 
         Ok(hex::encode(&hash))
+    }
+}
+
+impl<B> Clone for SqlMerkleState<B>
+where
+    B: Backend + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            backend: self.backend.clone(),
+            tree_id: self.tree_id,
+            #[cfg(feature = "state-merkle-sql-caching")]
+            cache: self.cache.clone(),
+        }
     }
 }
 

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -17,6 +17,8 @@
 
 use std::collections::HashMap;
 
+use diesel::pg::PgConnection;
+
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
 use crate::state::{
@@ -91,12 +93,12 @@ impl SqlMerkleState<backend::PostgresBackend> {
     }
 
     #[cfg(feature = "state-merkle-sql-caching")]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
     }
 
     #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new(&self.backend)
     }
 }

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -25,7 +25,9 @@ use crate::state::{
     Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
 };
 
-use super::backend;
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+use super::backend::InTransactionPostgresBackend;
+use super::backend::{Backend, Connection, Execute, PostgresBackend};
 use super::encode_and_hash;
 use super::{
     store::{MerkleRadixStore, SqlMerkleRadixStore},
@@ -33,7 +35,22 @@ use super::{
     SqlMerkleStateBuilder,
 };
 
-impl SqlMerkleStateBuilder<backend::PostgresBackend> {
+impl SqlMerkleStateBuilder<PostgresBackend> {
+    /// Construct the final SqlMerkleState instance
+    ///
+    /// # Errors
+    ///
+    /// An error may be returned under the following circumstances:
+    /// * If a Backend has not been provided
+    /// * If a tree name has not been provided
+    /// * If an internal error occurs while trying to create or lookup the tree
+    pub fn build(self) -> Result<SqlMerkleState<PostgresBackend>, SqlMerkleStateBuildError> {
+        do_build(self)
+    }
+}
+
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> SqlMerkleStateBuilder<InTransactionPostgresBackend<'a>> {
     /// Construct the final SqlMerkleState instance
     ///
     /// # Errors
@@ -44,44 +61,54 @@ impl SqlMerkleStateBuilder<backend::PostgresBackend> {
     /// * If an internal error occurs while trying to create or lookup the tree
     pub fn build(
         self,
-    ) -> Result<SqlMerkleState<backend::PostgresBackend>, SqlMerkleStateBuildError> {
-        let backend = self
-            .backend
-            .ok_or_else(|| InvalidStateError::with_message("must provide a backend".into()))?;
-
-        let tree_name = self
-            .tree_name
-            .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
-
-        #[cfg(feature = "state-merkle-sql-caching")]
-        let cache = {
-            super::cache::DataCache::new(
-                self.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
-                self.cache_size.unwrap_or(512),
-            )
-        };
-
-        let store = SqlMerkleRadixStore::new(&backend);
-
-        let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
-        let tree_id: i64 = if self.create_tree {
-            store.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
-        } else {
-            store.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
-                InvalidStateError::with_message("must provide the name of an existing tree".into())
-            })?
-        };
-
-        Ok(SqlMerkleState {
-            backend,
-            tree_id,
-            #[cfg(feature = "state-merkle-sql-caching")]
-            cache,
-        })
+    ) -> Result<SqlMerkleState<InTransactionPostgresBackend<'a>>, SqlMerkleStateBuildError> {
+        do_build(self)
     }
 }
 
-impl SqlMerkleState<backend::PostgresBackend> {
+fn do_build<B>(
+    builder: SqlMerkleStateBuilder<B>,
+) -> Result<SqlMerkleState<B>, SqlMerkleStateBuildError>
+where
+    B: Backend + Execute,
+    <B as Backend>::Connection: Connection<ConnectionType = diesel::pg::PgConnection>,
+{
+    let backend = builder
+        .backend
+        .ok_or_else(|| InvalidStateError::with_message("must provide a backend".into()))?;
+
+    let tree_name = builder
+        .tree_name
+        .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
+
+    #[cfg(feature = "state-merkle-sql-caching")]
+    let cache = {
+        super::cache::DataCache::new(
+            builder.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
+            builder.cache_size.unwrap_or(512),
+        )
+    };
+
+    let store = SqlMerkleRadixStore::new(&backend);
+
+    let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
+    let tree_id: i64 = if builder.create_tree {
+        store.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
+    } else {
+        store.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
+            InvalidStateError::with_message("must provide the name of an existing tree".into())
+        })?
+    };
+
+    Ok(SqlMerkleState {
+        backend,
+        tree_id,
+        #[cfg(feature = "state-merkle-sql-caching")]
+        cache,
+    })
+}
+
+impl SqlMerkleState<PostgresBackend> {
     /// Deletes the complete tree
     ///
     /// After calling this method, no data associated with the tree name will remain in the
@@ -93,17 +120,17 @@ impl SqlMerkleState<backend::PostgresBackend> {
     }
 
     #[cfg(feature = "state-merkle-sql-caching")]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend, PgConnection> {
+    fn new_store(&self) -> SqlMerkleRadixStore<PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
     }
 
     #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::PostgresBackend, PgConnection> {
+    fn new_store(&self) -> SqlMerkleRadixStore<PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new(&self.backend)
     }
 }
 
-impl Write for SqlMerkleState<backend::PostgresBackend> {
+impl Write for SqlMerkleState<PostgresBackend> {
     type StateId = String;
     type Key = String;
     type Value = Vec<u8>;
@@ -141,7 +168,7 @@ impl Write for SqlMerkleState<backend::PostgresBackend> {
     }
 }
 
-impl Prune for SqlMerkleState<backend::PostgresBackend> {
+impl Prune for SqlMerkleState<PostgresBackend> {
     type StateId = String;
     type Key = String;
     type Value = Vec<u8>;
@@ -155,7 +182,7 @@ impl Prune for SqlMerkleState<backend::PostgresBackend> {
     }
 }
 
-impl Read for SqlMerkleState<backend::PostgresBackend> {
+impl Read for SqlMerkleState<PostgresBackend> {
     type StateId = String;
     type Key = String;
     type Value = Vec<u8>;
@@ -189,7 +216,7 @@ impl Read for SqlMerkleState<backend::PostgresBackend> {
 type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
 type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
-impl MerkleRadixLeafReader for SqlMerkleState<backend::PostgresBackend> {
+impl MerkleRadixLeafReader for SqlMerkleState<PostgresBackend> {
     /// Returns an iterator over the leaves of a merkle radix tree.
     /// By providing an optional address prefix, the caller can limit the iteration
     /// over the leaves in a specific subtree.
@@ -210,12 +237,152 @@ impl MerkleRadixLeafReader for SqlMerkleState<backend::PostgresBackend> {
     }
 }
 
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
+    /// Deletes the complete tree
+    ///
+    /// After calling this method, no data associated with the tree name will remain in the
+    /// database.
+    pub fn delete_tree(self) -> Result<(), InternalError> {
+        let store = self.new_store();
+        store.delete_tree(self.tree_id)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "state-merkle-sql-caching")]
+    fn new_store(
+        &self,
+    ) -> SqlMerkleRadixStore<InTransactionPostgresBackend<'a>, diesel::pg::PgConnection> {
+        SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
+    }
+
+    #[cfg(not(feature = "state-merkle-sql-caching"))]
+    fn new_store(
+        &self,
+    ) -> SqlMerkleRadixStore<InTransactionPostgresBackend<'a>, diesel::pg::PgConnection> {
+        SqlMerkleRadixStore::new(&self.backend)
+    }
+}
+
+#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+impl<'a> crate::state::State for SqlMerkleState<InTransactionPostgresBackend<'a>> {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-reader"
+))]
+impl<'a> crate::state::Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
+    type Filter = str;
+
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, crate::state::StateError> {
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
+
+        if !overlay.has_root()? {
+            return Err(InvalidStateError::with_message(state_id.into()).into());
+        }
+
+        Ok(overlay.get_entries(keys)?)
+    }
+
+    fn filter_iter(
+        &self,
+        state_id: &Self::StateId,
+        filter: Option<&Self::Filter>,
+    ) -> crate::state::ValueIterResult<crate::state::ValueIter<(Self::Key, Self::Value)>> {
+        if &self.initial_state_root_hash()? == state_id {
+            return Ok(Box::new(std::iter::empty()));
+        }
+
+        let leaves = self
+            .new_store()
+            .list_entries(self.tree_id, state_id, filter)?;
+
+        Ok(Box::new(leaves.into_iter().map(Ok)))
+    }
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-committer"
+))]
+impl<'a> crate::state::Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
+    type StateChange = StateChange;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[Self::StateChange],
+    ) -> Result<Self::StateId, crate::state::StateError> {
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
+
+        let (next_state_id, tree_update) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        overlay.write_updates(&next_state_id, tree_update)?;
+
+        Ok(next_state_id)
+    }
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-dry-run-committer"
+))]
+impl<'a> crate::state::DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
+    type StateChange = StateChange;
+
+    fn dry_run_commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[Self::StateChange],
+    ) -> Result<Self::StateId, crate::state::StateError> {
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
+
+        let (next_state_id, _) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        Ok(next_state_id)
+    }
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-pruner"
+))]
+impl<'a> crate::state::Pruner for SqlMerkleState<InTransactionPostgresBackend<'a>> {
+    fn prune(
+        &self,
+        state_ids: Vec<Self::StateId>,
+    ) -> Result<Vec<Self::Key>, crate::state::StateError> {
+        let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
+
+        overlay
+            .prune(&state_ids)
+            .map_err(crate::state::StateError::from)
+    }
+}
+
 #[cfg(feature = "state-merkle-sql-postgres-tests")]
 #[cfg(test)]
 mod test {
     use super::*;
 
-    use crate::state::merkle::sql::backend::{run_postgres_test, PostgresBackendBuilder};
+    use crate::state::merkle::sql::backend::{run_postgres_test, Execute, PostgresBackendBuilder};
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-trait-committer"
+    ))]
+    use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
     /// added to one are not added to the other.
@@ -348,6 +515,47 @@ mod test {
                 .expect("A value should have been listed")?;
 
             assert_eq!(("012345".to_string(), b"state_value".to_vec()), entry);
+
+            Ok(())
+        })
+    }
+
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-trait-committer"
+    ))]
+    #[test]
+    fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
+        run_postgres_test(|db_url| {
+            let backend = PostgresBackendBuilder::new().with_url(db_url).build()?;
+
+            let new_root = backend.execute(|conn| {
+                let in_txn_backend: InTransactionPostgresBackend = conn.as_inner().into();
+
+                let tree = SqlMerkleStateBuilder::new()
+                    .with_backend(in_txn_backend)
+                    .with_tree("test-1")
+                    .create_tree_if_necessary()
+                    .build()
+                    .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+                let initial_state_root_hash = tree.initial_state_root_hash()?;
+
+                let state_change_set = StateChange::Set {
+                    key: "012345".to_string(),
+                    value: "state_value".as_bytes().to_vec(),
+                };
+
+                tree.commit(&initial_state_root_hash, &[state_change_set])
+                    .map_err(|e| InternalError::from_source(Box::new(e)))
+            })?;
+
+            let tree = SqlMerkleStateBuilder::new()
+                .with_backend(backend.clone())
+                .with_tree("test-1")
+                .build()?;
+
+            assert_read_value_at_address(&tree, &new_root, "012345", Some("state_value"));
 
             Ok(())
         })

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -89,12 +89,12 @@ impl SqlMerkleState<backend::SqliteBackend> {
     }
 
     #[cfg(feature = "state-merkle-sql-caching")]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
     }
 
     #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend> {
+    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new(&self.backend)
     }
 }

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -23,7 +23,9 @@ use crate::state::{
     Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
 };
 
-use super::backend;
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+use super::backend::InTransactionSqliteBackend;
+use super::backend::{Backend, Connection, SqliteBackend, WriteExclusiveExecute};
 use super::encode_and_hash;
 use super::{
     store::{MerkleRadixStore, SqlMerkleRadixStore},
@@ -31,7 +33,7 @@ use super::{
     SqlMerkleStateBuilder,
 };
 
-impl SqlMerkleStateBuilder<backend::SqliteBackend> {
+impl SqlMerkleStateBuilder<SqliteBackend> {
     /// Construct the final SqlMerkleState instance
     ///
     /// # Errors
@@ -40,44 +42,71 @@ impl SqlMerkleStateBuilder<backend::SqliteBackend> {
     /// * If a Backend has not been provided
     /// * If a tree name has not been provided
     /// * If an internal error occurs while trying to create or lookup the tree
-    pub fn build(self) -> Result<SqlMerkleState<backend::SqliteBackend>, SqlMerkleStateBuildError> {
-        let backend = self
-            .backend
-            .ok_or_else(|| InvalidStateError::with_message("must provide a backend".into()))?;
-
-        let tree_name = self
-            .tree_name
-            .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
-
-        #[cfg(feature = "state-merkle-sql-caching")]
-        let cache = {
-            super::cache::DataCache::new(
-                self.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
-                self.cache_size.unwrap_or(512),
-            )
-        };
-
-        let store = SqlMerkleRadixStore::new(&backend);
-
-        let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
-        let tree_id: i64 = if self.create_tree {
-            store.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
-        } else {
-            store.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
-                InvalidStateError::with_message("must provide the name of an existing tree".into())
-            })?
-        };
-
-        Ok(SqlMerkleState {
-            backend,
-            tree_id,
-            #[cfg(feature = "state-merkle-sql-caching")]
-            cache,
-        })
+    pub fn build(self) -> Result<SqlMerkleState<SqliteBackend>, SqlMerkleStateBuildError> {
+        do_build(self)
     }
 }
 
-impl SqlMerkleState<backend::SqliteBackend> {
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> SqlMerkleStateBuilder<InTransactionSqliteBackend<'a>> {
+    /// Construct the final SqlMerkleState instance
+    ///
+    /// # Errors
+    ///
+    /// An error may be returned under the following circumstances:
+    /// * If a Backend has not been provided
+    /// * If a tree name has not been provided
+    /// * If an internal error occurs while trying to create or lookup the tree
+    pub fn build(
+        self,
+    ) -> Result<SqlMerkleState<InTransactionSqliteBackend<'a>>, SqlMerkleStateBuildError> {
+        do_build(self)
+    }
+}
+
+fn do_build<B>(
+    builder: SqlMerkleStateBuilder<B>,
+) -> Result<SqlMerkleState<B>, SqlMerkleStateBuildError>
+where
+    B: Backend + WriteExclusiveExecute,
+    <B as Backend>::Connection: Connection<ConnectionType = diesel::SqliteConnection>,
+{
+    let backend = builder
+        .backend
+        .ok_or_else(|| InvalidStateError::with_message("must provide a backend".into()))?;
+
+    let tree_name = builder
+        .tree_name
+        .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
+
+    #[cfg(feature = "state-merkle-sql-caching")]
+    let cache = {
+        super::cache::DataCache::new(
+            builder.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
+            builder.cache_size.unwrap_or(512),
+        )
+    };
+
+    let store = SqlMerkleRadixStore::new(&backend);
+
+    let (initial_state_root_hash, _) = encode_and_hash(Node::default())?;
+    let tree_id: i64 = if builder.create_tree {
+        store.get_or_create_tree(&tree_name, &hex::encode(&initial_state_root_hash))?
+    } else {
+        store.get_tree_id_by_name(&tree_name)?.ok_or_else(|| {
+            InvalidStateError::with_message("must provide the name of an existing tree".into())
+        })?
+    };
+
+    Ok(SqlMerkleState {
+        backend,
+        tree_id,
+        #[cfg(feature = "state-merkle-sql-caching")]
+        cache,
+    })
+}
+
+impl SqlMerkleState<SqliteBackend> {
     /// Deletes the complete tree
     ///
     /// After calling this method, no data associated with the tree name will remain in the
@@ -89,17 +118,17 @@ impl SqlMerkleState<backend::SqliteBackend> {
     }
 
     #[cfg(feature = "state-merkle-sql-caching")]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend, diesel::SqliteConnection> {
+    fn new_store(&self) -> SqlMerkleRadixStore<SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
     }
 
     #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<backend::SqliteBackend, diesel::SqliteConnection> {
+    fn new_store(&self) -> SqlMerkleRadixStore<SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new(&self.backend)
     }
 }
 
-impl Write for SqlMerkleState<backend::SqliteBackend> {
+impl Write for SqlMerkleState<SqliteBackend> {
     type StateId = String;
     type Key = String;
     type Value = Vec<u8>;
@@ -137,7 +166,7 @@ impl Write for SqlMerkleState<backend::SqliteBackend> {
     }
 }
 
-impl Read for SqlMerkleState<backend::SqliteBackend> {
+impl Read for SqlMerkleState<SqliteBackend> {
     type StateId = String;
     type Key = String;
     type Value = Vec<u8>;
@@ -168,7 +197,7 @@ impl Read for SqlMerkleState<backend::SqliteBackend> {
     }
 }
 
-impl Prune for SqlMerkleState<backend::SqliteBackend> {
+impl Prune for SqlMerkleState<SqliteBackend> {
     type StateId = String;
     type Key = String;
     type Value = Vec<u8>;
@@ -182,10 +211,145 @@ impl Prune for SqlMerkleState<backend::SqliteBackend> {
     }
 }
 
+#[cfg(feature = "state-merkle-sql-in-transaction")]
+impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
+    /// Deletes the complete tree
+    ///
+    /// After calling this method, no data associated with the tree name will remain in the
+    /// database.
+    pub fn delete_tree(self) -> Result<(), InternalError> {
+        let store = self.new_store();
+        store.delete_tree(self.tree_id)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "state-merkle-sql-caching")]
+    fn new_store(
+        &self,
+    ) -> SqlMerkleRadixStore<InTransactionSqliteBackend<'a>, diesel::SqliteConnection> {
+        SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
+    }
+
+    #[cfg(not(feature = "state-merkle-sql-caching"))]
+    fn new_store(
+        &self,
+    ) -> SqlMerkleRadixStore<InTransactionSqliteBackend<'a>, diesel::SqliteConnection> {
+        SqlMerkleRadixStore::new(&self.backend)
+    }
+}
+
+#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+impl<'a> crate::state::State for SqlMerkleState<InTransactionSqliteBackend<'a>> {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-reader"
+))]
+impl<'a> crate::state::Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
+    type Filter = str;
+
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, crate::state::StateError> {
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
+
+        if !overlay.has_root()? {
+            return Err(InvalidStateError::with_message(state_id.into()).into());
+        }
+
+        Ok(overlay.get_entries(keys)?)
+    }
+
+    fn filter_iter(
+        &self,
+        state_id: &Self::StateId,
+        filter: Option<&Self::Filter>,
+    ) -> crate::state::ValueIterResult<crate::state::ValueIter<(Self::Key, Self::Value)>> {
+        if &self.initial_state_root_hash()? == state_id {
+            return Ok(Box::new(std::iter::empty()));
+        }
+
+        let leaves = self
+            .new_store()
+            .list_entries(self.tree_id, state_id, filter)?;
+
+        Ok(Box::new(leaves.into_iter().map(Ok)))
+    }
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-committer"
+))]
+impl<'a> crate::state::Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
+    type StateChange = StateChange;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[Self::StateChange],
+    ) -> Result<Self::StateId, crate::state::StateError> {
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
+
+        let (next_state_id, tree_update) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        overlay.write_updates(&next_state_id, tree_update)?;
+
+        Ok(next_state_id)
+    }
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-dry-run-committer"
+))]
+impl<'a> crate::state::DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
+    type StateChange = StateChange;
+
+    fn dry_run_commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[Self::StateChange],
+    ) -> Result<Self::StateId, crate::state::StateError> {
+        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
+
+        let (next_state_id, _) = overlay
+            .generate_updates(state_changes)
+            .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+        Ok(next_state_id)
+    }
+}
+
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-trait-pruner"
+))]
+impl<'a> crate::state::Pruner for SqlMerkleState<InTransactionSqliteBackend<'a>> {
+    fn prune(
+        &self,
+        state_ids: Vec<Self::StateId>,
+    ) -> Result<Vec<Self::Key>, crate::state::StateError> {
+        let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
+
+        overlay
+            .prune(&state_ids)
+            .map_err(crate::state::StateError::from)
+    }
+}
+
 type IterResult<T> = Result<T, MerkleRadixLeafReadError>;
 type LeafIter<T> = Box<dyn Iterator<Item = IterResult<T>>>;
 
-impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
+impl MerkleRadixLeafReader for SqlMerkleState<SqliteBackend> {
     /// Returns an iterator over the leaves of a merkle radix tree.
     /// By providing an optional address prefix, the caller can limit the iteration
     /// over the leaves in a specific subtree.
@@ -210,8 +374,13 @@ impl MerkleRadixLeafReader for SqlMerkleState<backend::SqliteBackend> {
 mod test {
     use super::*;
 
-    use crate::state::merkle::sql::backend::SqliteBackendBuilder;
+    use crate::state::merkle::sql::backend::{self, SqliteBackendBuilder};
     use crate::state::merkle::sql::migration::MigrationManager;
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-trait-committer"
+    ))]
+    use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
     /// added to one are not added to the other.
@@ -346,6 +515,47 @@ mod test {
             .expect("A value should have been listed")?;
 
         assert_eq!(("012345".to_string(), b"state_value".to_vec()), entry);
+
+        Ok(())
+    }
+
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-trait-committer"
+    ))]
+    #[test]
+    fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
+        let backend = SqliteBackendBuilder::new().with_memory_database().build()?;
+
+        backend.run_migrations()?;
+
+        let new_root = backend.execute_write(|conn| {
+            let in_txn_backend: backend::InTransactionSqliteBackend = conn.as_inner().into();
+
+            let tree = SqlMerkleStateBuilder::new()
+                .with_backend(in_txn_backend)
+                .with_tree("test-1")
+                .create_tree_if_necessary()
+                .build()
+                .map_err(|e| InternalError::from_source(Box::new(e)))?;
+
+            let initial_state_root_hash = tree.initial_state_root_hash()?;
+
+            let state_change_set = StateChange::Set {
+                key: "012345".to_string(),
+                value: "state_value".as_bytes().to_vec(),
+            };
+
+            tree.commit(&initial_state_root_hash, &[state_change_set])
+                .map_err(|e| InternalError::from_source(Box::new(e)))
+        })?;
+
+        let tree = SqlMerkleStateBuilder::new()
+            .with_backend(backend.clone())
+            .with_tree("test-1")
+            .build()?;
+
+        assert_read_value_at_address(&tree, &new_root, "012345", Some("state_value"));
 
         Ok(())
     }

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -19,7 +19,7 @@ use diesel::pg::PgConnection;
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{Connection, Execute, PostgresBackend};
+use crate::state::merkle::sql::backend::{Backend, Connection, Execute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -34,7 +34,11 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, PostgresBackend, PgConnection> {
+impl<'b, B> MerkleRadixStore for SqlMerkleRadixStore<'b, B, PgConnection>
+where
+    B: Backend + Execute,
+    <B as Backend>::Connection: Connection<ConnectionType = PgConnection>,
+{
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -15,9 +15,11 @@
  * -----------------------------------------------------------------------------
  */
 
+use diesel::pg::PgConnection;
+
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Connection, Execute};
+use crate::state::merkle::sql::backend::{Connection, Execute, PostgresBackend};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -32,7 +34,7 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> {
+impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, PostgresBackend, PgConnection> {
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -17,7 +17,7 @@
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Backend, Connection};
+use crate::state::merkle::sql::backend::{self, Connection, Execute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -38,38 +38,41 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         tree_name: &str,
         initial_state_root_hash: &str,
     ) -> Result<i64, InternalError> {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_or_create_tree(tree_name, initial_state_root_hash)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_or_create_tree(tree_name, initial_state_root_hash)
+        })
     }
 
     fn get_tree_id_by_name(&self, tree_name: &str) -> Result<Option<i64>, InternalError> {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_tree_id_by_name(tree_name)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_tree_id_by_name(tree_name)
+        })
     }
 
     fn delete_tree(&self, tree_id: i64) -> Result<(), InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.delete_tree(tree_id)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.delete_tree(tree_id)
+        })
     }
 
     fn list_trees(
         &self,
     ) -> Result<Box<dyn ExactSizeIterator<Item = Result<String, InternalError>>>, InternalError>
     {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.list_trees()
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.list_trees()
+        })
     }
 
     fn has_root(&self, tree_id: i64, state_root_hash: &str) -> Result<bool, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.has_root(tree_id, state_root_hash)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.has_root(tree_id, state_root_hash)
+        })
     }
 
     fn get_path(
@@ -78,10 +81,10 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         state_root_hash: &str,
         address: &str,
     ) -> Result<Vec<(String, Node)>, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_path(tree_id, state_root_hash, address)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_path(tree_id, state_root_hash, address)
+        })
     }
 
     fn get_entries(
@@ -90,16 +93,17 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         state_root_hash: &str,
         keys: Vec<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.get_leaves(
-            tree_id,
-            state_root_hash,
-            keys,
-            #[cfg(feature = "state-merkle-sql-caching")]
-            self.cache,
-        )
+        let read_keys = keys.into_iter().map(String::from).collect::<Vec<_>>();
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.get_leaves(
+                tree_id,
+                state_root_hash,
+                read_keys.iter().map(String::as_str).collect(),
+                #[cfg(feature = "state-merkle-sql-caching")]
+                self.cache,
+            )
+        })
     }
 
     fn list_entries(
@@ -108,10 +112,10 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         state_root_hash: &str,
         prefix: Option<&str>,
     ) -> Result<Vec<(String, Vec<u8>)>, InternalError> {
-        let conn = self.backend.connection()?;
-
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.list_leaves(tree_id, state_root_hash, prefix)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.list_leaves(tree_id, state_root_hash, prefix)
+        })
     }
 
     fn write_changes(
@@ -121,22 +125,23 @@ impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::PostgresBackend> 
         parent_state_root_hash: &str,
         tree_update: TreeUpdate,
     ) -> Result<(), InternalError> {
-        let conn = self.backend.connection()?;
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
 
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-
-        operations.write_changes(
-            tree_id,
-            state_root_hash,
-            parent_state_root_hash,
-            &tree_update,
-        )?;
-        Ok(())
+            operations.write_changes(
+                tree_id,
+                state_root_hash,
+                parent_state_root_hash,
+                &tree_update,
+            )?;
+            Ok(())
+        })
     }
 
     fn prune(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError> {
-        let conn = self.backend.connection()?;
-        let operations = MerkleRadixOperations::new(conn.as_inner());
-        operations.prune_entries(tree_id, state_root)
+        self.backend.execute(|conn| {
+            let operations = MerkleRadixOperations::new(conn.as_inner());
+            operations.prune_entries(tree_id, state_root)
+        })
     }
 }

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -17,7 +17,7 @@
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Connection};
+use crate::state::merkle::sql::backend::{self, Connection, WriteExclusiveExecute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -19,7 +19,7 @@ use diesel::SqliteConnection;
 
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
-use crate::state::merkle::sql::backend::{self, Connection, WriteExclusiveExecute};
+use crate::state::merkle::sql::backend::{Backend, Connection, WriteExclusiveExecute};
 
 use super::operations::delete_tree::MerkleRadixDeleteTreeOperation as _;
 use super::operations::get_leaves::MerkleRadixGetLeavesOperation as _;
@@ -34,7 +34,11 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend, SqliteConnection> {
+impl<'b, B> MerkleRadixStore for SqlMerkleRadixStore<'b, B, SqliteConnection>
+where
+    B: Backend + WriteExclusiveExecute,
+    <B as Backend>::Connection: Connection<ConnectionType = SqliteConnection>,
+{
     fn get_or_create_tree(
         &self,
         tree_name: &str,

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -15,6 +15,8 @@
  * -----------------------------------------------------------------------------
  */
 
+use diesel::SqliteConnection;
+
 use crate::error::InternalError;
 use crate::state::merkle::node::Node;
 use crate::state::merkle::sql::backend::{self, Connection, WriteExclusiveExecute};
@@ -32,7 +34,7 @@ use super::operations::write_changes::MerkleRadixWriteChangesOperation as _;
 use super::operations::MerkleRadixOperations;
 use super::{MerkleRadixStore, SqlMerkleRadixStore, TreeUpdate};
 
-impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend> {
+impl<'b> MerkleRadixStore for SqlMerkleRadixStore<'b, backend::SqliteBackend, SqliteConnection> {
     fn get_or_create_tree(
         &self,
         tree_name: &str,


### PR DESCRIPTION
Implements Sql backends that wrap connection references, instead of owning a connection pool.  This requires that the SqlMerkleState for these backends can only implement the state traits v2, as they cannot be sync or send.


 
(Replaces PR #325)