### PR TITLE
Implement state traits v2 for kv::MerkleState

### DIFF
--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -18,6 +18,8 @@
 
 mod change_log;
 mod error;
+#[cfg(feature = "state-trait")]
+mod state_trait_impls;
 
 use std::cmp::Reverse;
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/libtransact/src/state/merkle/kv/state_trait_impls/committer.rs
+++ b/libtransact/src/state/merkle/kv/state_trait_impls/committer.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use crate::error::{InternalError, InvalidStateError};
+use crate::state::{Committer, StateChange, StateError};
+
+use crate::state::merkle::kv::{error::StateDatabaseError, MerkleRadixTree, MerkleState};
+
+impl Committer for MerkleState {
+    type StateChange = StateChange;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[Self::StateChange],
+    ) -> Result<Self::StateId, StateError> {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
+                StateDatabaseError::NotFound(msg) => {
+                    StateError::from(InvalidStateError::with_message(msg))
+                }
+                _ => StateError::from(InternalError::from_source(Box::new(err))),
+            })?;
+
+        merkle_tree
+            .update(state_changes, false)
+            .map_err(|err| StateError::from(InternalError::from_source(Box::new(err))))
+    }
+}

--- a/libtransact/src/state/merkle/kv/state_trait_impls/dry_run_committer.rs
+++ b/libtransact/src/state/merkle/kv/state_trait_impls/dry_run_committer.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use crate::error::{InternalError, InvalidStateError};
+use crate::state::{DryRunCommitter, StateChange, StateError};
+
+use crate::state::merkle::kv::{error::StateDatabaseError, MerkleRadixTree, MerkleState};
+
+impl DryRunCommitter for MerkleState {
+    type StateChange = StateChange;
+
+    fn dry_run_commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[Self::StateChange],
+    ) -> Result<Self::StateId, StateError> {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
+                StateDatabaseError::NotFound(msg) => {
+                    StateError::from(InvalidStateError::with_message(msg))
+                }
+                _ => StateError::from(InternalError::from_source(Box::new(err))),
+            })?;
+
+        merkle_tree
+            .update(state_changes, true)
+            .map_err(|err| StateError::from(InternalError::from_source(Box::new(err))))
+    }
+}

--- a/libtransact/src/state/merkle/kv/state_trait_impls/mod.rs
+++ b/libtransact/src/state/merkle/kv/state_trait_impls/mod.rs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+#[cfg(feature = "state-trait-committer")]
+mod committer;
+#[cfg(feature = "state-trait-dry-run-committer")]
+mod dry_run_committer;
+#[cfg(feature = "state-trait-pruner")]
+mod pruner;
+#[cfg(feature = "state-trait-reader")]
+mod reader;
+
+use super::MerkleState;
+
+impl crate::state::State for MerkleState {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+}

--- a/libtransact/src/state/merkle/kv/state_trait_impls/pruner.rs
+++ b/libtransact/src/state/merkle/kv/state_trait_impls/pruner.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use crate::error::{InternalError, InvalidStateError};
+use crate::state::{Pruner, StateError};
+
+use crate::state::merkle::kv::{error::StateDatabaseError, MerkleRadixTree, MerkleState};
+
+impl Pruner for MerkleState {
+    fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
+        state_ids
+            .iter()
+            .try_fold(Vec::new(), |mut result, state_id| {
+                result.extend(MerkleRadixTree::prune(&*self.db, state_id).map_err(
+                    |err| match err {
+                        StateDatabaseError::NotFound(msg) => {
+                            StateError::from(InvalidStateError::with_message(msg))
+                        }
+                        _ => StateError::from(InternalError::from_source(Box::new(err))),
+                    },
+                )?);
+                Ok(result)
+            })
+    }
+}

--- a/libtransact/src/state/merkle/kv/state_trait_impls/reader.rs
+++ b/libtransact/src/state/merkle/kv/state_trait_impls/reader.rs
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+
+use crate::error::{InternalError, InvalidStateError};
+use crate::state::{Reader, StateError, ValueIter, ValueIterResult};
+
+use crate::state::merkle::kv::{error::StateDatabaseError, MerkleRadixTree, MerkleState};
+
+impl Reader for MerkleState {
+    type Filter = str;
+
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, StateError> {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
+                StateDatabaseError::NotFound(msg) => {
+                    StateError::from(InvalidStateError::with_message(msg))
+                }
+                _ => StateError::from(InternalError::from_source(Box::new(err))),
+            })?;
+
+        keys.iter().try_fold(HashMap::new(), |mut result, key| {
+            let value = match merkle_tree.get_by_address(key) {
+                Ok(value) => value.value,
+                Err(err) => match err {
+                    StateDatabaseError::NotFound(_) => None,
+                    _ => return Err(InternalError::from_source(Box::new(err)).into()),
+                },
+            };
+            if let Some(value) = value {
+                result.insert(key.to_string(), value);
+            }
+            Ok(result)
+        })
+    }
+
+    fn filter_iter(
+        &self,
+        state_id: &Self::StateId,
+        filter: Option<&Self::Filter>,
+    ) -> ValueIterResult<ValueIter<(Self::Key, Self::Value)>> {
+        let merkle_tree =
+            MerkleRadixTree::new(self.db.clone(), Some(state_id)).map_err(|err| match err {
+                // the state ID doesn't exist
+                StateDatabaseError::NotFound(msg) => {
+                    StateError::from(InvalidStateError::with_message(msg))
+                }
+                _ => StateError::from(InternalError::from_source(Box::new(err))),
+            })?;
+
+        merkle_tree
+            .leaves(filter)
+            .map(|iter| {
+                Box::new(iter.map(|item| {
+                    item.map_err(|e| StateError::from(InternalError::from_source(Box::new(e))))
+                })) as Box<dyn Iterator<Item = _>>
+            })
+            .map_err(|e| match e {
+                // the subtree doesn't exist
+                StateDatabaseError::NotFound(msg) => {
+                    StateError::from(InvalidStateError::with_message(msg))
+                }
+                _ => StateError::from(InternalError::from_source(Box::new(e))),
+            })
+    }
+}


### PR DESCRIPTION
This change implements the "V2" state trait over the key-value MerkleState implementation.
