### PR TITLE
Use const values for hard-coded cache defaults

### DIFF
--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -35,6 +35,11 @@ use super::{
     SqlMerkleStateBuilder,
 };
 
+#[cfg(feature = "state-merkle-sql-caching")]
+const DEFAULT_MIN_CACHED_DATA_SIZE: usize = 100 * 1024; // 100KB
+#[cfg(feature = "state-merkle-sql-caching")]
+const DEFAULT_CACHE_SIZE: u16 = 512; // number of entries in cache
+
 impl SqlMerkleStateBuilder<PostgresBackend> {
     /// Construct the final SqlMerkleState instance
     ///
@@ -84,8 +89,10 @@ where
     #[cfg(feature = "state-merkle-sql-caching")]
     let cache = {
         super::cache::DataCache::new(
-            builder.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
-            builder.cache_size.unwrap_or(512),
+            builder
+                .min_cached_data_size
+                .unwrap_or(DEFAULT_MIN_CACHED_DATA_SIZE),
+            builder.cache_size.unwrap_or(DEFAULT_CACHE_SIZE),
         )
     };
 

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -33,6 +33,11 @@ use super::{
     SqlMerkleStateBuilder,
 };
 
+#[cfg(feature = "state-merkle-sql-caching")]
+const DEFAULT_MIN_CACHED_DATA_SIZE: usize = 100 * 1024; // 100KB
+#[cfg(feature = "state-merkle-sql-caching")]
+const DEFAULT_CACHE_SIZE: u16 = 512; // number of entries in cache
+
 impl SqlMerkleStateBuilder<SqliteBackend> {
     /// Construct the final SqlMerkleState instance
     ///
@@ -82,8 +87,10 @@ where
     #[cfg(feature = "state-merkle-sql-caching")]
     let cache = {
         super::cache::DataCache::new(
-            builder.min_cached_data_size.unwrap_or(100 * 1024), // 100KB
-            builder.cache_size.unwrap_or(512),
+            builder
+                .min_cached_data_size
+                .unwrap_or(DEFAULT_MIN_CACHED_DATA_SIZE),
+            builder.cache_size.unwrap_or(DEFAULT_CACHE_SIZE),
         )
     };
 

--- a/libtransact/src/state/merkle/sql/store/operations/get_leaves.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/get_leaves.rs
@@ -304,13 +304,18 @@ mod tests {
     use crate::state::merkle::sql::store::operations::last_insert_rowid;
     use crate::state::merkle::sql::store::schema::merkle_radix_leaf;
 
+    #[cfg(feature = "state-merkle-sql-caching")]
+    const MIN_CACHED_DATA_SIZE: usize = 10; // 10 bytes
+    #[cfg(feature = "state-merkle-sql-caching")]
+    const CACHE_SIZE: u16 = 16; // number of entries in cache
+
     /// Test that the get entries on a non-existent root returns a empty entries.
     #[cfg(feature = "sqlite")]
     #[test]
     fn sqlite_get_entries_empty_tree() -> Result<(), Box<dyn std::error::Error>> {
         let conn = SqliteConnection::establish(":memory:")?;
         #[cfg(feature = "state-merkle-sql-caching")]
-        let cache = DataCache::new(10, 16);
+        let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
 
         migration::sqlite::run_migrations(&conn)?;
 
@@ -334,7 +339,7 @@ mod tests {
         run_postgres_test(|url| {
             let conn = PgConnection::establish(&url)?;
             #[cfg(feature = "state-merkle-sql-caching")]
-            let cache = DataCache::new(10, 16);
+            let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
 
             let entries = MerkleRadixOperations::new(&conn).get_leaves(
                 1,
@@ -357,7 +362,7 @@ mod tests {
     fn sqlite_get_entries_single_entry() -> Result<(), Box<dyn std::error::Error>> {
         let conn = SqliteConnection::establish(":memory:")?;
         #[cfg(feature = "state-merkle-sql-caching")]
-        let cache = DataCache::new(10, 16);
+        let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
 
         migration::sqlite::run_migrations(&conn)?;
 
@@ -422,7 +427,7 @@ mod tests {
         run_postgres_test(|url| {
             let conn = PgConnection::establish(&url)?;
             #[cfg(feature = "state-merkle-sql-caching")]
-            let cache = DataCache::new(10, 16);
+            let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
 
             let leaf_id = 1;
             insert_into(merkle_radix_leaf::table)
@@ -486,7 +491,7 @@ mod tests {
     #[test]
     fn sqlite_get_entries_single_entry_cached() -> Result<(), Box<dyn std::error::Error>> {
         let conn = SqliteConnection::establish(":memory:")?;
-        let cache = DataCache::new(10, 16);
+        let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
         cache.insert(
             "000000".into(),
             "000000-hash".into(),
@@ -563,7 +568,7 @@ mod tests {
     fn postgres_get_entries_single_entry_cached() -> Result<(), Box<dyn std::error::Error>> {
         run_postgres_test(|url| {
             let conn = PgConnection::establish(&url)?;
-            let cache = DataCache::new(10, 16);
+            let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
             cache.insert(
                 "000000".into(),
                 "000000-hash".into(),
@@ -631,7 +636,7 @@ mod tests {
     #[test]
     fn sqlite_get_entries_single_large_entry_cached() -> Result<(), Box<dyn std::error::Error>> {
         let conn = SqliteConnection::establish(":memory:")?;
-        let cache = DataCache::new(10, 16);
+        let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
 
         migration::sqlite::run_migrations(&conn)?;
 
@@ -704,7 +709,7 @@ mod tests {
     fn postgres_get_entries_single_large_entry_cached() -> Result<(), Box<dyn std::error::Error>> {
         run_postgres_test(|url| {
             let conn = PgConnection::establish(&url)?;
-            let cache = DataCache::new(10, 16);
+            let cache = DataCache::new(MIN_CACHED_DATA_SIZE, CACHE_SIZE);
 
             let leaf_id = 1;
             insert_into(merkle_radix_leaf::table)


### PR DESCRIPTION
Within the implementation, adding const moves the special values to the
top of the module; also adds some doc comments and gives the values
a name.

Within the tests, the const values help differentiate between two
numbers which are provided as parameters next to each other.