### PR TITLE
Stabilize state-merkle-sql-caching by removing it

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -114,7 +114,6 @@ experimental = [
     "family-smallbank-workload",
     "family-xo",
     "key-value-state",
-    "state-merkle-sql-caching",
     "state-merkle-sql-in-transaction",
     "state-trait",
     "state-trait-committer",
@@ -175,8 +174,7 @@ sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log"]
-state-merkle-sql = ["diesel", "diesel_migrations"]
-state-merkle-sql-caching = [ "lru" ]
+state-merkle-sql = ["diesel", "diesel_migrations", "lru"]
 state-merkle-sql-in-transaction = [
     "state-trait",
     "state-trait-committer",

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -50,7 +50,6 @@
 //! Available if the feature "state-merkle-sql" is enabled.
 
 pub mod backend;
-#[cfg(feature = "state-merkle-sql-caching")]
 mod cache;
 mod error;
 pub mod migration;
@@ -85,11 +84,9 @@ pub struct SqlMerkleStateBuilder<B: Backend> {
     create_tree: bool,
 
     // Minimum size of a cacheable state entry in bytes
-    #[cfg(feature = "state-merkle-sql-caching")]
     min_cached_data_size: Option<usize>,
 
     // Maximum number of items in the cache
-    #[cfg(feature = "state-merkle-sql-caching")]
     cache_size: Option<u16>,
 }
 
@@ -101,10 +98,8 @@ impl<B: Backend> SqlMerkleStateBuilder<B> {
             tree_name: None,
             create_tree: false,
 
-            #[cfg(feature = "state-merkle-sql-caching")]
             min_cached_data_size: None,
 
-            #[cfg(feature = "state-merkle-sql-caching")]
             cache_size: None,
         }
     }
@@ -130,14 +125,12 @@ impl<B: Backend> SqlMerkleStateBuilder<B> {
     /// Sets the minimum size of data in the cache
     ///
     /// Any data values smaller than this limit won't be cached in memory.
-    #[cfg(feature = "state-merkle-sql-caching")]
     pub fn with_min_cached_data_size(mut self, size: usize) -> Self {
         self.min_cached_data_size = Some(size);
         self
     }
 
     /// Sets the size of the cache
-    #[cfg(feature = "state-merkle-sql-caching")]
     pub fn with_cache_size(mut self, size: u16) -> Self {
         self.cache_size = Some(size);
         self
@@ -151,7 +144,6 @@ impl<B: Backend> SqlMerkleStateBuilder<B> {
 pub struct SqlMerkleState<B: Backend> {
     backend: B,
     tree_id: i64,
-    #[cfg(feature = "state-merkle-sql-caching")]
     cache: cache::DataCache,
 }
 
@@ -174,7 +166,6 @@ where
         Self {
             backend: self.backend.clone(),
             tree_id: self.tree_id,
-            #[cfg(feature = "state-merkle-sql-caching")]
             cache: self.cache.clone(),
         }
     }

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -35,9 +35,7 @@ use super::{
     SqlMerkleStateBuilder,
 };
 
-#[cfg(feature = "state-merkle-sql-caching")]
 const DEFAULT_MIN_CACHED_DATA_SIZE: usize = 100 * 1024; // 100KB
-#[cfg(feature = "state-merkle-sql-caching")]
 const DEFAULT_CACHE_SIZE: u16 = 512; // number of entries in cache
 
 impl SqlMerkleStateBuilder<PostgresBackend> {
@@ -86,7 +84,6 @@ where
         .tree_name
         .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     let cache = {
         super::cache::DataCache::new(
             builder
@@ -110,7 +107,6 @@ where
     Ok(SqlMerkleState {
         backend,
         tree_id,
-        #[cfg(feature = "state-merkle-sql-caching")]
         cache,
     })
 }
@@ -126,14 +122,8 @@ impl SqlMerkleState<PostgresBackend> {
         Ok(())
     }
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     fn new_store(&self) -> SqlMerkleRadixStore<PostgresBackend, PgConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
-    }
-
-    #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<PostgresBackend, PgConnection> {
-        SqlMerkleRadixStore::new(&self.backend)
     }
 }
 
@@ -256,18 +246,10 @@ impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
         Ok(())
     }
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     fn new_store(
         &self,
     ) -> SqlMerkleRadixStore<InTransactionPostgresBackend<'a>, diesel::pg::PgConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
-    }
-
-    #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(
-        &self,
-    ) -> SqlMerkleRadixStore<InTransactionPostgresBackend<'a>, diesel::pg::PgConnection> {
-        SqlMerkleRadixStore::new(&self.backend)
     }
 }
 

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -33,9 +33,7 @@ use super::{
     SqlMerkleStateBuilder,
 };
 
-#[cfg(feature = "state-merkle-sql-caching")]
 const DEFAULT_MIN_CACHED_DATA_SIZE: usize = 100 * 1024; // 100KB
-#[cfg(feature = "state-merkle-sql-caching")]
 const DEFAULT_CACHE_SIZE: u16 = 512; // number of entries in cache
 
 impl SqlMerkleStateBuilder<SqliteBackend> {
@@ -84,7 +82,6 @@ where
         .tree_name
         .ok_or_else(|| InvalidStateError::with_message("must provide a tree name".into()))?;
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     let cache = {
         super::cache::DataCache::new(
             builder
@@ -108,7 +105,6 @@ where
     Ok(SqlMerkleState {
         backend,
         tree_id,
-        #[cfg(feature = "state-merkle-sql-caching")]
         cache,
     })
 }
@@ -124,14 +120,8 @@ impl SqlMerkleState<SqliteBackend> {
         Ok(())
     }
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     fn new_store(&self) -> SqlMerkleRadixStore<SqliteBackend, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
-    }
-
-    #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(&self) -> SqlMerkleRadixStore<SqliteBackend, diesel::SqliteConnection> {
-        SqlMerkleRadixStore::new(&self.backend)
     }
 }
 
@@ -230,18 +220,10 @@ impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
         Ok(())
     }
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     fn new_store(
         &self,
     ) -> SqlMerkleRadixStore<InTransactionSqliteBackend<'a>, diesel::SqliteConnection> {
         SqlMerkleRadixStore::new_with_cache(&self.backend, &self.cache)
-    }
-
-    #[cfg(not(feature = "state-merkle-sql-caching"))]
-    fn new_store(
-        &self,
-    ) -> SqlMerkleRadixStore<InTransactionSqliteBackend<'a>, diesel::SqliteConnection> {
-        SqlMerkleRadixStore::new(&self.backend)
     }
 }
 

--- a/libtransact/src/state/merkle/sql/store/mod.rs
+++ b/libtransact/src/state/merkle/sql/store/mod.rs
@@ -29,7 +29,6 @@ mod sqlite;
 use std::collections::HashSet;
 
 use crate::error::InternalError;
-#[cfg(feature = "state-merkle-sql-caching")]
 use crate::state::merkle::sql::cache::DataCache;
 use crate::state::merkle::{
     node::Node,
@@ -239,7 +238,6 @@ pub trait MerkleRadixStore {
 pub struct SqlMerkleRadixStore<'b, B: Backend, C> {
     pub backend: &'b B,
     _conn: std::marker::PhantomData<C>,
-    #[cfg(feature = "state-merkle-sql-caching")]
     pub cache: Option<&'b DataCache>,
 }
 
@@ -253,12 +251,10 @@ where
         Self {
             backend,
             _conn: std::marker::PhantomData,
-            #[cfg(feature = "state-merkle-sql-caching")]
             cache: None,
         }
     }
 
-    #[cfg(feature = "state-merkle-sql-caching")]
     pub(crate) fn new_with_cache(backend: &'b B, cache: &'b DataCache) -> Self {
         Self {
             backend,

--- a/libtransact/src/state/merkle/sql/store/postgres.rs
+++ b/libtransact/src/state/merkle/sql/store/postgres.rs
@@ -106,7 +106,6 @@ where
                 tree_id,
                 state_root_hash,
                 read_keys.iter().map(String::as_str).collect(),
-                #[cfg(feature = "state-merkle-sql-caching")]
                 self.cache,
             )
         })

--- a/libtransact/src/state/merkle/sql/store/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/store/sqlite.rs
@@ -106,7 +106,6 @@ where
                 tree_id,
                 state_root_hash,
                 read_keys.iter().map(String::as_str).collect(),
-                #[cfg(feature = "state-merkle-sql-caching")]
                 self.cache,
             )
         })


### PR DESCRIPTION
This change stabilizes the "state-merkle-sql-caching" feature by removing it.  This means that the caching capability is available by default with the use of the "state-merkle-sql" feature.
