### PR TITLE
Stabilize feature "state-trait"

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -94,7 +94,6 @@ stable = [
     "postgres",
     "protocol-sabre",
     "sqlite",
-    "state-in-transaction",
     "state-merkle-sql",
     "workload",
     "workload-batch-gen",
@@ -169,12 +168,9 @@ sabre-compat = ["sabre-sdk"]
 sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
-state-in-transaction= []
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations", "lru"]
-state-merkle-sql-in-transaction = [
-    "state-in-transaction",
-]
+state-merkle-sql-in-transaction = []
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -94,6 +94,7 @@ stable = [
     "postgres",
     "protocol-sabre",
     "sqlite",
+    "state-in-transaction",
     "state-merkle-sql",
     "workload",
     "workload-batch-gen",
@@ -114,7 +115,6 @@ experimental = [
     "family-smallbank-workload",
     "family-xo",
     "key-value-state",
-    "state-in-transaction",
     "state-merkle-sql-in-transaction",
 ]
 

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -114,8 +114,8 @@ experimental = [
     "family-smallbank-workload",
     "family-xo",
     "key-value-state",
+    "state-in-transaction",
     "state-merkle-sql-in-transaction",
-    "state-trait",
 ]
 
 # stable features in support of wasm
@@ -169,16 +169,16 @@ sabre-compat = ["sabre-sdk"]
 sawtooth-compat = ["sawtooth-sdk"]
 scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
+state-in-transaction= []
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations", "lru"]
 state-merkle-sql-in-transaction = [
-    "state-trait",
+    "state-in-transaction",
 ]
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.
 state-merkle-sql-postgres-tests = ["postgres", "lazy_static"]
-state-trait = []
 workload = []
 workload-batch-gen = ["workload"]
 workload-runner = [

--- a/libtransact/src/state/committer.rs
+++ b/libtransact/src/state/committer.rs
@@ -24,8 +24,6 @@ use super::{State, StateError};
 ///
 /// All operations are made using `StateChange` instances. These are the ordered set of changes to
 /// be applied onto the given `StateId`.
-///
-/// Available with the feature `"state-in-transaction"` enabled.
 pub trait Committer: State {
     /// Defines the type of change to apply
     type StateChange;

--- a/libtransact/src/state/committer.rs
+++ b/libtransact/src/state/committer.rs
@@ -25,7 +25,7 @@ use super::{State, StateError};
 /// All operations are made using `StateChange` instances. These are the ordered set of changes to
 /// be applied onto the given `StateId`.
 ///
-/// Available with the feature `"state-trait"` enabled.
+/// Available with the feature `"state-in-transaction"` enabled.
 pub trait Committer: State {
     /// Defines the type of change to apply
     type StateChange;

--- a/libtransact/src/state/dry_run_committer.rs
+++ b/libtransact/src/state/dry_run_committer.rs
@@ -18,8 +18,6 @@
 use super::{State, StateError};
 
 /// Predicts future state checkpoints.
-///
-/// Available with the feature `"state-in-transaction"` enabled.
 pub trait DryRunCommitter: State {
     /// Defines the type of change to use for the prediction.
     type StateChange;

--- a/libtransact/src/state/dry_run_committer.rs
+++ b/libtransact/src/state/dry_run_committer.rs
@@ -19,7 +19,7 @@ use super::{State, StateError};
 
 /// Predicts future state checkpoints.
 ///
-/// Available with the feature `"state-trait"` enabled.
+/// Available with the feature `"state-in-transaction"` enabled.
 pub trait DryRunCommitter: State {
     /// Defines the type of change to use for the prediction.
     type StateChange;

--- a/libtransact/src/state/error.rs
+++ b/libtransact/src/state/error.rs
@@ -18,7 +18,6 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "state-in-transaction")]
 use crate::error::{InternalError, InvalidStateError};
 
 /// An error that may occur on state writes.
@@ -107,14 +106,12 @@ impl Error for StatePruneError {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 #[derive(Debug)]
 pub enum StateError {
     Internal(InternalError),
     InvalidState(InvalidStateError),
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl fmt::Display for StateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -124,7 +121,6 @@ impl fmt::Display for StateError {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl Error for StateError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -134,14 +130,12 @@ impl Error for StateError {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl From<InternalError> for StateError {
     fn from(err: InternalError) -> Self {
         Self::Internal(err)
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl From<InvalidStateError> for StateError {
     fn from(err: InvalidStateError) -> Self {
         Self::InvalidState(err)

--- a/libtransact/src/state/error.rs
+++ b/libtransact/src/state/error.rs
@@ -18,7 +18,7 @@
 use std::error::Error;
 use std::fmt;
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 use crate::error::{InternalError, InvalidStateError};
 
 /// An error that may occur on state writes.
@@ -107,14 +107,14 @@ impl Error for StatePruneError {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 #[derive(Debug)]
 pub enum StateError {
     Internal(InternalError),
     InvalidState(InvalidStateError),
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl fmt::Display for StateError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -124,7 +124,7 @@ impl fmt::Display for StateError {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Error for StateError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -134,14 +134,14 @@ impl Error for StateError {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl From<InternalError> for StateError {
     fn from(err: InternalError) -> Self {
         Self::Internal(err)
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl From<InvalidStateError> for StateError {
     fn from(err: InvalidStateError) -> Self {
         Self::InvalidState(err)

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -18,7 +18,7 @@
 
 mod change_log;
 mod error;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 mod state_trait_impls;
 
 use std::cmp::Reverse;

--- a/libtransact/src/state/merkle/kv/mod.rs
+++ b/libtransact/src/state/merkle/kv/mod.rs
@@ -18,7 +18,6 @@
 
 mod change_log;
 mod error;
-#[cfg(feature = "state-in-transaction")]
 mod state_trait_impls;
 
 use std::cmp::Reverse;

--- a/libtransact/src/state/merkle/kv/state_trait_impls/mod.rs
+++ b/libtransact/src/state/merkle/kv/state_trait_impls/mod.rs
@@ -15,13 +15,9 @@
  * -----------------------------------------------------------------------------
  */
 
-#[cfg(feature = "state-trait")]
 mod committer;
-#[cfg(feature = "state-trait")]
 mod dry_run_committer;
-#[cfg(feature = "state-trait")]
 mod pruner;
-#[cfg(feature = "state-trait")]
 mod reader;
 
 use super::MerkleState;

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -66,7 +66,7 @@ use sha2::{Digest, Sha512};
 
 use crate::error::InternalError;
 use crate::state::error::StateWriteError;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 use crate::state::State;
 use crate::state::StateChange;
 
@@ -173,7 +173,7 @@ where
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl<B: Backend> State for SqlMerkleState<B> {
     type StateId = String;
     type Key = String;

--- a/libtransact/src/state/merkle/sql/mod.rs
+++ b/libtransact/src/state/merkle/sql/mod.rs
@@ -66,7 +66,6 @@ use sha2::{Digest, Sha512};
 
 use crate::error::InternalError;
 use crate::state::error::StateWriteError;
-#[cfg(feature = "state-in-transaction")]
 use crate::state::State;
 use crate::state::StateChange;
 
@@ -173,7 +172,6 @@ where
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl<B: Backend> State for SqlMerkleState<B> {
     type StateId = String;
     type Key = String;

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -21,12 +21,9 @@ use diesel::pg::PgConnection;
 
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
-#[cfg(feature = "state-in-transaction")]
 use crate::state::{
-    Committer, DryRunCommitter, Pruner, Reader, StateError, ValueIter, ValueIterResult,
-};
-use crate::state::{
-    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
+    Committer, DryRunCommitter, Prune, Pruner, Read, Reader, StateChange, StateError,
+    StatePruneError, StateReadError, StateWriteError, ValueIter, ValueIterResult, Write,
 };
 
 #[cfg(feature = "state-merkle-sql-in-transaction")]
@@ -238,7 +235,6 @@ impl MerkleRadixLeafReader for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl Reader for SqlMerkleState<PostgresBackend> {
     type Filter = str;
 
@@ -272,7 +268,6 @@ impl Reader for SqlMerkleState<PostgresBackend> {
         Ok(Box::new(leaves.into_iter().map(Ok)))
     }
 }
-#[cfg(feature = "state-in-transaction")]
 impl Committer for SqlMerkleState<PostgresBackend> {
     type StateChange = StateChange;
 
@@ -293,7 +288,6 @@ impl Committer for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl DryRunCommitter for SqlMerkleState<PostgresBackend> {
     type StateChange = StateChange;
 
@@ -312,7 +306,6 @@ impl DryRunCommitter for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl Pruner for SqlMerkleState<PostgresBackend> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -340,10 +333,7 @@ impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type Filter = str;
 
@@ -378,10 +368,7 @@ impl<'a> Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type StateChange = StateChange;
 
@@ -402,10 +389,7 @@ impl<'a> Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type StateChange = StateChange;
 
@@ -424,10 +408,7 @@ impl<'a> DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Pruner for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -442,10 +423,7 @@ mod test {
     use super::*;
 
     use crate::state::merkle::sql::backend::{run_postgres_test, Execute, PostgresBackendBuilder};
-    #[cfg(all(
-        feature = "state-merkle-sql-in-transaction",
-        feature = "state-in-transaction"
-    ))]
+    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
@@ -582,10 +560,7 @@ mod test {
         })
     }
 
-    #[cfg(all(
-        feature = "state-merkle-sql-in-transaction",
-        feature = "state-in-transaction"
-    ))]
+    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     #[test]
     fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
         run_postgres_test(|db_url| {

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -21,7 +21,7 @@ use diesel::pg::PgConnection;
 
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 use crate::state::{
     Committer, DryRunCommitter, Pruner, Reader, StateError, ValueIter, ValueIterResult,
 };
@@ -238,7 +238,7 @@ impl MerkleRadixLeafReader for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Reader for SqlMerkleState<PostgresBackend> {
     type Filter = str;
 
@@ -272,7 +272,7 @@ impl Reader for SqlMerkleState<PostgresBackend> {
         Ok(Box::new(leaves.into_iter().map(Ok)))
     }
 }
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Committer for SqlMerkleState<PostgresBackend> {
     type StateChange = StateChange;
 
@@ -293,7 +293,7 @@ impl Committer for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl DryRunCommitter for SqlMerkleState<PostgresBackend> {
     type StateChange = StateChange;
 
@@ -312,7 +312,7 @@ impl DryRunCommitter for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Pruner for SqlMerkleState<PostgresBackend> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -340,7 +340,10 @@ impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type Filter = str;
 
@@ -375,7 +378,10 @@ impl<'a> Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type StateChange = StateChange;
 
@@ -396,7 +402,10 @@ impl<'a> Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type StateChange = StateChange;
 
@@ -415,7 +424,10 @@ impl<'a> DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> Pruner for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -430,7 +442,10 @@ mod test {
     use super::*;
 
     use crate::state::merkle::sql::backend::{run_postgres_test, Execute, PostgresBackendBuilder};
-    #[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-in-transaction"
+    ))]
     use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
@@ -567,7 +582,10 @@ mod test {
         })
     }
 
-    #[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-in-transaction"
+    ))]
     #[test]
     fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
         run_postgres_test(|db_url| {

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -19,12 +19,9 @@ use std::collections::HashMap;
 
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
-#[cfg(feature = "state-in-transaction")]
 use crate::state::{
-    Committer, DryRunCommitter, Pruner, Reader, StateError, ValueIter, ValueIterResult,
-};
-use crate::state::{
-    Prune, Read, StateChange, StatePruneError, StateReadError, StateWriteError, Write,
+    Committer, DryRunCommitter, Prune, Pruner, Read, Reader, StateChange, StateError,
+    StatePruneError, StateReadError, StateWriteError, ValueIter, ValueIterResult, Write,
 };
 
 #[cfg(feature = "state-merkle-sql-in-transaction")]
@@ -212,7 +209,6 @@ impl Prune for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl Reader for SqlMerkleState<SqliteBackend> {
     type Filter = str;
 
@@ -246,7 +242,7 @@ impl Reader for SqlMerkleState<SqliteBackend> {
         Ok(Box::new(leaves.into_iter().map(Ok)))
     }
 }
-#[cfg(feature = "state-in-transaction")]
+
 impl Committer for SqlMerkleState<SqliteBackend> {
     type StateChange = StateChange;
 
@@ -267,7 +263,6 @@ impl Committer for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl DryRunCommitter for SqlMerkleState<SqliteBackend> {
     type StateChange = StateChange;
 
@@ -286,7 +281,6 @@ impl DryRunCommitter for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-in-transaction")]
 impl Pruner for SqlMerkleState<SqliteBackend> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -314,10 +308,7 @@ impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type Filter = str;
 
@@ -352,10 +343,7 @@ impl<'a> Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type StateChange = StateChange;
 
@@ -376,10 +364,7 @@ impl<'a> Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type StateChange = StateChange;
 
@@ -398,10 +383,7 @@ impl<'a> DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(
-    feature = "state-merkle-sql-in-transaction",
-    feature = "state-in-transaction"
-))]
+#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Pruner for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -438,17 +420,11 @@ impl MerkleRadixLeafReader for SqlMerkleState<SqliteBackend> {
 mod test {
     use super::*;
 
-    #[cfg(all(
-        feature = "state-merkle-sql-in-transaction",
-        feature = "state-in-transaction"
-    ))]
+    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     use crate::state::merkle::sql::backend;
     use crate::state::merkle::sql::backend::SqliteBackendBuilder;
     use crate::state::merkle::sql::migration::MigrationManager;
-    #[cfg(all(
-        feature = "state-merkle-sql-in-transaction",
-        feature = "state-in-transaction"
-    ))]
+    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
@@ -586,10 +562,7 @@ mod test {
         Ok(())
     }
 
-    #[cfg(all(
-        feature = "state-merkle-sql-in-transaction",
-        feature = "state-in-transaction"
-    ))]
+    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     #[test]
     fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
         let backend = SqliteBackendBuilder::new().with_memory_database().build()?;

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use crate::error::{InternalError, InvalidStateError};
 use crate::state::merkle::{node::Node, MerkleRadixLeafReadError, MerkleRadixLeafReader};
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 use crate::state::{
     Committer, DryRunCommitter, Pruner, Reader, StateError, ValueIter, ValueIterResult,
 };
@@ -212,7 +212,7 @@ impl Prune for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Reader for SqlMerkleState<SqliteBackend> {
     type Filter = str;
 
@@ -246,7 +246,7 @@ impl Reader for SqlMerkleState<SqliteBackend> {
         Ok(Box::new(leaves.into_iter().map(Ok)))
     }
 }
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Committer for SqlMerkleState<SqliteBackend> {
     type StateChange = StateChange;
 
@@ -267,7 +267,7 @@ impl Committer for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl DryRunCommitter for SqlMerkleState<SqliteBackend> {
     type StateChange = StateChange;
 
@@ -286,7 +286,7 @@ impl DryRunCommitter for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 impl Pruner for SqlMerkleState<SqliteBackend> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -314,7 +314,10 @@ impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type Filter = str;
 
@@ -349,7 +352,10 @@ impl<'a> Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type StateChange = StateChange;
 
@@ -370,7 +376,10 @@ impl<'a> Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type StateChange = StateChange;
 
@@ -389,7 +398,10 @@ impl<'a> DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+#[cfg(all(
+    feature = "state-merkle-sql-in-transaction",
+    feature = "state-in-transaction"
+))]
 impl<'a> Pruner for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -426,11 +438,17 @@ impl MerkleRadixLeafReader for SqlMerkleState<SqliteBackend> {
 mod test {
     use super::*;
 
-    #[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-in-transaction"
+    ))]
     use crate::state::merkle::sql::backend;
     use crate::state::merkle::sql::backend::SqliteBackendBuilder;
     use crate::state::merkle::sql::migration::MigrationManager;
-    #[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-in-transaction"
+    ))]
     use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
@@ -568,7 +586,10 @@ mod test {
         Ok(())
     }
 
-    #[cfg(all(feature = "state-merkle-sql-in-transaction", feature = "state-trait"))]
+    #[cfg(all(
+        feature = "state-merkle-sql-in-transaction",
+        feature = "state-in-transaction"
+    ))]
     #[test]
     fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
         let backend = SqliteBackendBuilder::new().with_memory_database().build()?;

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -22,35 +22,35 @@
 //! `Write`, `Read`, and `Prune`.  These provide commit, read access,
 //! and a way to purge old state, respectively, to an underlying storage mechanism.
 
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 mod committer;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 mod dry_run_committer;
 pub mod error;
 pub mod hashmap;
 #[cfg(feature = "state-merkle")]
 pub mod merkle;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 mod pruner;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 mod reader;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 mod state_trait;
 
 use std::collections::HashMap;
 
 pub use crate::state::error::{StatePruneError, StateReadError, StateWriteError};
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 pub use committer::Committer;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 pub use dry_run_committer::DryRunCommitter;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 pub use error::StateError;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 pub use pruner::Pruner;
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 pub use reader::{Reader, ValueIter, ValueIterResult};
-#[cfg(feature = "state-trait")]
+#[cfg(feature = "state-in-transaction")]
 pub use state_trait::State;
 
 /// A change to be applied to state, in terms of keys and values.

--- a/libtransact/src/state/mod.rs
+++ b/libtransact/src/state/mod.rs
@@ -22,35 +22,24 @@
 //! `Write`, `Read`, and `Prune`.  These provide commit, read access,
 //! and a way to purge old state, respectively, to an underlying storage mechanism.
 
-#[cfg(feature = "state-in-transaction")]
 mod committer;
-#[cfg(feature = "state-in-transaction")]
 mod dry_run_committer;
 pub mod error;
 pub mod hashmap;
 #[cfg(feature = "state-merkle")]
 pub mod merkle;
-#[cfg(feature = "state-in-transaction")]
 mod pruner;
-#[cfg(feature = "state-in-transaction")]
 mod reader;
-#[cfg(feature = "state-in-transaction")]
 mod state_trait;
 
 use std::collections::HashMap;
 
 pub use crate::state::error::{StatePruneError, StateReadError, StateWriteError};
-#[cfg(feature = "state-in-transaction")]
 pub use committer::Committer;
-#[cfg(feature = "state-in-transaction")]
 pub use dry_run_committer::DryRunCommitter;
-#[cfg(feature = "state-in-transaction")]
 pub use error::StateError;
-#[cfg(feature = "state-in-transaction")]
 pub use pruner::Pruner;
-#[cfg(feature = "state-in-transaction")]
 pub use reader::{Reader, ValueIter, ValueIterResult};
-#[cfg(feature = "state-in-transaction")]
 pub use state_trait::State;
 
 /// A change to be applied to state, in terms of keys and values.

--- a/libtransact/src/state/pruner.rs
+++ b/libtransact/src/state/pruner.rs
@@ -21,8 +21,6 @@ use super::{State, StateError};
 ///
 /// Removing `StateIds` and the associated state makes it so the state storage system does not grow
 /// unbounded.
-///
-/// Available with the feature `"state-in-transaction"` enabled.
 pub trait Pruner: State {
     /// Prune keys from state for a given set of state IDs.
     ///

--- a/libtransact/src/state/pruner.rs
+++ b/libtransact/src/state/pruner.rs
@@ -22,7 +22,7 @@ use super::{State, StateError};
 /// Removing `StateIds` and the associated state makes it so the state storage system does not grow
 /// unbounded.
 ///
-/// Available with the feature `"state-trait"` enabled.
+/// Available with the feature `"state-in-transaction"` enabled.
 pub trait Pruner: State {
     /// Prune keys from state for a given set of state IDs.
     ///

--- a/libtransact/src/state/reader.rs
+++ b/libtransact/src/state/reader.rs
@@ -27,7 +27,7 @@ pub type ValueIter<T> = Box<dyn Iterator<Item = ValueIterResult<T>>>;
 /// This trait provides similar behaviour to the [`Read`](super::Read) trait, without the
 /// explicit requirements about thread safety.
 ///
-/// Available with the feature `"state-trait"` enabled.
+/// Available with the feature `"state-in-transaction"` enabled.
 pub trait Reader: State {
     /// The filter used for the iterating over state values.
     type Filter: ?Sized;

--- a/libtransact/src/state/reader.rs
+++ b/libtransact/src/state/reader.rs
@@ -26,8 +26,6 @@ pub type ValueIter<T> = Box<dyn Iterator<Item = ValueIterResult<T>>>;
 ///
 /// This trait provides similar behaviour to the [`Read`](super::Read) trait, without the
 /// explicit requirements about thread safety.
-///
-/// Available with the feature `"state-in-transaction"` enabled.
 pub trait Reader: State {
     /// The filter used for the iterating over state values.
     type Filter: ?Sized;

--- a/libtransact/src/state/state_trait.rs
+++ b/libtransact/src/state/state_trait.rs
@@ -24,7 +24,7 @@
 /// For example, a `State` defined over a merkle database would prove the root merkle hash as its
 /// state ID.
 ///
-/// Available with the feature `"state-trait"` enabled.
+/// Available with the feature `"state-in-transaction"` enabled.
 pub trait State {
     /// A reference to a checkpoint in state. It could be a merkle hash for a merkle database.
     type StateId;

--- a/libtransact/src/state/state_trait.rs
+++ b/libtransact/src/state/state_trait.rs
@@ -23,8 +23,6 @@
 ///
 /// For example, a `State` defined over a merkle database would prove the root merkle hash as its
 /// state ID.
-///
-/// Available with the feature `"state-in-transaction"` enabled.
 pub trait State {
     /// A reference to a checkpoint in state. It could be a merkle hash for a merkle database.
     type StateId;


### PR DESCRIPTION
This PR stabilizes the feature "state-trait" by renaming the feature to "state-in-transaction" and moving it to the "stable" meta feature.

For the main branch, these feature is removed.  The commits related to the renaming and moving it to "stable" will be back-ported to the 0-4 branch and included in a 0.4.x release.