### PR TITLE
Stabilize "state-merkle-sql-in-transaction"

### DIFF
--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -95,6 +95,7 @@ stable = [
     "protocol-sabre",
     "sqlite",
     "state-merkle-sql",
+    "state-merkle-sql-in-transaction",
     "workload",
     "workload-batch-gen",
     "workload-runner"
@@ -114,7 +115,6 @@ experimental = [
     "family-smallbank-workload",
     "family-xo",
     "key-value-state",
-    "state-merkle-sql-in-transaction",
 ]
 
 # stable features in support of wasm

--- a/libtransact/Cargo.toml
+++ b/libtransact/Cargo.toml
@@ -95,7 +95,6 @@ stable = [
     "protocol-sabre",
     "sqlite",
     "state-merkle-sql",
-    "state-merkle-sql-in-transaction",
     "workload",
     "workload-batch-gen",
     "workload-runner"
@@ -170,7 +169,6 @@ scheduler = ["context", "log", "protocol-batch"]
 sqlite = ["diesel/sqlite", "serde", "serde_derive", "serde_json"]
 state-merkle = ["cbor-codec", "log"]
 state-merkle-sql = ["diesel", "diesel_migrations", "lru"]
-state-merkle-sql-in-transaction = []
 # This feature must be enabled to run tests using a postgres db it is not
 # enabled by default, due to its requirement of an external postgres db
 # instance.

--- a/libtransact/src/state/merkle/sql/backend/mod.rs
+++ b/libtransact/src/state/merkle/sql/backend/mod.rs
@@ -28,14 +28,15 @@ use crate::error::InternalError;
 
 #[cfg(feature = "state-merkle-sql-postgres-tests")]
 pub use postgres::test::run_postgres_test;
-#[cfg(all(feature = "postgres", feature = "state-merkle-sql-in-transaction"))]
-pub use postgres::InTransactionPostgresBackend;
 #[cfg(feature = "postgres")]
-pub use postgres::{PostgresBackend, PostgresBackendBuilder, PostgresConnection};
-#[cfg(all(feature = "sqlite", feature = "state-merkle-sql-in-transaction"))]
-pub use sqlite::InTransactionSqliteBackend;
+pub use postgres::{
+    InTransactionPostgresBackend, PostgresBackend, PostgresBackendBuilder, PostgresConnection,
+};
 #[cfg(feature = "sqlite")]
-pub use sqlite::{JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection, Synchronous};
+pub use sqlite::{
+    InTransactionSqliteBackend, JournalMode, SqliteBackend, SqliteBackendBuilder, SqliteConnection,
+    Synchronous,
+};
 
 /// A database connection.
 pub trait Connection {

--- a/libtransact/src/state/merkle/sql/backend/postgres.rs
+++ b/libtransact/src/state/merkle/sql/backend/postgres.rs
@@ -86,11 +86,9 @@ impl From<Pool<ConnectionManager<diesel::pg::PgConnection>>> for PostgresBackend
 
 /// A borrowed Postgres connection.
 ///
-/// Available if the features "state-merkle-sql-in-transaction" and "postgres" are enabled.
-#[cfg(feature = "state-merkle-sql-in-transaction")]
+/// Available if the feature "postgres" is enabled.
 pub struct BorrowedPostgresConnection<'a>(&'a diesel::pg::PgConnection);
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> Connection for BorrowedPostgresConnection<'a> {
     type ConnectionType = diesel::pg::PgConnection;
 
@@ -103,13 +101,11 @@ impl<'a> Connection for BorrowedPostgresConnection<'a> {
 ///
 /// This backend is neither `Sync` nor `Send`.
 ///
-/// Available if the features "state-merkle-sql-in-transaction" and "postgres" are enabled.
-#[cfg(feature = "state-merkle-sql-in-transaction")]
+/// Available if the feature "postgres" is enabled.
 pub struct InTransactionPostgresBackend<'a> {
     connection: &'a diesel::pg::PgConnection,
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> InTransactionPostgresBackend<'a> {
     /// Wrap a reference to a [`diesel::pg::PgConnection`].
     pub fn new(connection: &'a diesel::pg::PgConnection) -> Self {
@@ -117,7 +113,6 @@ impl<'a> InTransactionPostgresBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> Backend for InTransactionPostgresBackend<'a> {
     type Connection = BorrowedPostgresConnection<'a>;
 
@@ -126,7 +121,6 @@ impl<'a> Backend for InTransactionPostgresBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> Execute for InTransactionPostgresBackend<'a> {
     fn execute<F, T>(&self, f: F) -> Result<T, InternalError>
     where
@@ -136,7 +130,6 @@ impl<'a> Execute for InTransactionPostgresBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> From<&'a diesel::pg::PgConnection> for InTransactionPostgresBackend<'a> {
     fn from(conn: &'a diesel::pg::PgConnection) -> Self {
         Self::new(conn)

--- a/libtransact/src/state/merkle/sql/backend/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/backend/sqlite.rs
@@ -128,11 +128,9 @@ impl From<Arc<RwLock<Pool<ConnectionManager<sqlite::SqliteConnection>>>>> for Sq
 
 /// A borrowed SQLite connection.
 ///
-/// Available if the features "state-merkle-sql-in-transaction" and "sqlite" are enabled.
-#[cfg(feature = "state-merkle-sql-in-transaction")]
+/// Available if the feature "sqlite" is enabled.
 pub struct BorrowedSqliteConnection<'a>(&'a sqlite::SqliteConnection);
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> Connection for BorrowedSqliteConnection<'a> {
     type ConnectionType = sqlite::SqliteConnection;
 
@@ -145,13 +143,11 @@ impl<'a> Connection for BorrowedSqliteConnection<'a> {
 ///
 /// This backend is neither `Sync` nor `Send`.
 ///
-/// Available if the features "state-merkle-sql-in-transaction" and "sqlite" are enabled.
-#[cfg(feature = "state-merkle-sql-in-transaction")]
+/// Available if the feature "sqlite" is enabled.
 pub struct InTransactionSqliteBackend<'a> {
     connection: &'a sqlite::SqliteConnection,
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> InTransactionSqliteBackend<'a> {
     /// Wrap a reference to a [`diesel::SqliteConnection`].
     pub fn new(connection: &'a sqlite::SqliteConnection) -> Self {
@@ -159,7 +155,6 @@ impl<'a> InTransactionSqliteBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> Backend for InTransactionSqliteBackend<'a> {
     type Connection = BorrowedSqliteConnection<'a>;
 
@@ -168,7 +163,6 @@ impl<'a> Backend for InTransactionSqliteBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> WriteExclusiveExecute for InTransactionSqliteBackend<'a> {
     fn execute_write<F, T>(&self, f: F) -> Result<T, InternalError>
     where
@@ -185,7 +179,6 @@ impl<'a> WriteExclusiveExecute for InTransactionSqliteBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> Clone for InTransactionSqliteBackend<'a> {
     fn clone(&self) -> Self {
         Self {
@@ -194,7 +187,6 @@ impl<'a> Clone for InTransactionSqliteBackend<'a> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> From<&'a sqlite::SqliteConnection> for InTransactionSqliteBackend<'a> {
     fn from(connection: &'a sqlite::SqliteConnection) -> Self {
         Self::new(connection)

--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -26,7 +26,6 @@ use crate::state::{
     StatePruneError, StateReadError, StateWriteError, ValueIter, ValueIterResult, Write,
 };
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 use super::backend::InTransactionPostgresBackend;
 use super::backend::{Backend, Connection, Execute, PostgresBackend};
 use super::encode_and_hash;
@@ -53,7 +52,6 @@ impl SqlMerkleStateBuilder<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> SqlMerkleStateBuilder<InTransactionPostgresBackend<'a>> {
     /// Construct the final SqlMerkleState instance
     ///
@@ -314,7 +312,6 @@ impl Pruner for SqlMerkleState<PostgresBackend> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
     /// Deletes the complete tree
     ///
@@ -333,7 +330,6 @@ impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type Filter = str;
 
@@ -368,7 +364,6 @@ impl<'a> Reader for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type StateChange = StateChange;
 
@@ -389,7 +384,6 @@ impl<'a> Committer for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     type StateChange = StateChange;
 
@@ -408,7 +402,6 @@ impl<'a> DryRunCommitter for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Pruner for SqlMerkleState<InTransactionPostgresBackend<'a>> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -423,7 +416,6 @@ mod test {
     use super::*;
 
     use crate::state::merkle::sql::backend::{run_postgres_test, Execute, PostgresBackendBuilder};
-    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
@@ -560,7 +552,6 @@ mod test {
         })
     }
 
-    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     #[test]
     fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
         run_postgres_test(|db_url| {

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -24,7 +24,6 @@ use crate::state::{
     StatePruneError, StateReadError, StateWriteError, ValueIter, ValueIterResult, Write,
 };
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 use super::backend::InTransactionSqliteBackend;
 use super::backend::{Backend, Connection, SqliteBackend, WriteExclusiveExecute};
 use super::encode_and_hash;
@@ -51,7 +50,6 @@ impl SqlMerkleStateBuilder<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> SqlMerkleStateBuilder<InTransactionSqliteBackend<'a>> {
     /// Construct the final SqlMerkleState instance
     ///
@@ -289,7 +287,6 @@ impl Pruner for SqlMerkleState<SqliteBackend> {
     }
 }
 
-#[cfg(feature = "state-merkle-sql-in-transaction")]
 impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
     /// Deletes the complete tree
     ///
@@ -308,7 +305,6 @@ impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type Filter = str;
 
@@ -343,7 +339,6 @@ impl<'a> Reader for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type StateChange = StateChange;
 
@@ -364,7 +359,6 @@ impl<'a> Committer for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     type StateChange = StateChange;
 
@@ -383,7 +377,6 @@ impl<'a> DryRunCommitter for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     }
 }
 
-#[cfg(all(feature = "state-merkle-sql-in-transaction"))]
 impl<'a> Pruner for SqlMerkleState<InTransactionSqliteBackend<'a>> {
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StateError> {
         let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
@@ -420,11 +413,9 @@ impl MerkleRadixLeafReader for SqlMerkleState<SqliteBackend> {
 mod test {
     use super::*;
 
-    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     use crate::state::merkle::sql::backend;
     use crate::state::merkle::sql::backend::SqliteBackendBuilder;
     use crate::state::merkle::sql::migration::MigrationManager;
-    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     use crate::state::Committer;
 
     /// This test creates multiple trees in the same backend/db instance and verifies that values
@@ -562,7 +553,6 @@ mod test {
         Ok(())
     }
 
-    #[cfg(all(feature = "state-merkle-sql-in-transaction"))]
     #[test]
     fn test_in_transaction() -> Result<(), Box<dyn std::error::Error>> {
         let backend = SqliteBackendBuilder::new().with_memory_database().build()?;


### PR DESCRIPTION
This PR stabilizes the feature "state-merkle-sql-in-transaction", first by moving it to the stable meta feature, and then removing it - to be included under the "state-merkle-sql" feature. 

The first commit will be back-ported to 0-4