### PR TITLE
Remove parent state root reference

### DIFF
--- a/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
@@ -81,6 +81,14 @@ impl<'a> MerkleRadixPruneEntriesOperation for MerkleRadixOperations<'a, SqliteCo
             .set(merkle_radix_change_log_deletion::pruned_at.eq(sql(SQLITE_NOW_MILLIS)))
             .execute(self.conn)?;
 
+            // Remove the parent relationship on its successors
+            update(
+                merkle_radix_change_log_addition::table
+                    .filter(merkle_radix_change_log_addition::parent_state_root.eq(state_root)),
+            )
+            .set(merkle_radix_change_log_addition::parent_state_root.eq(NULL_PARENT))
+            .execute(self.conn)?;
+
             let mut deleted_values = vec![];
             for hash in deletion_candidates.into_iter() {
                 update(


### PR DESCRIPTION
This change fixes an issue during state pruning in SQLite where the parent_state_root for change logs was not being unlinked. This causes a foreign key constraint violation when cleaning up pruned items.

The postgres implementation already has this unlinking code.
