### PR TITLE
Backport 0-4: Remove use of immediate_transaction

### DIFF
--- a/libtransact/src/state/merkle/sql/store/operations/delete_tree.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/delete_tree.rs
@@ -38,7 +38,7 @@ pub trait MerkleRadixDeleteTreeOperation {
 #[cfg(feature = "sqlite")]
 impl<'a> MerkleRadixDeleteTreeOperation for MerkleRadixOperations<'a, SqliteConnection> {
     fn delete_tree(&self, tree_id: i64) -> Result<(), InternalError> {
-        self.conn.immediate_transaction(|| {
+        self.conn.transaction(|| {
             delete(
                 merkle_radix_change_log_addition::table
                     .filter(merkle_radix_change_log_addition::tree_id.eq(tree_id)),

--- a/libtransact/src/state/merkle/sql/store/operations/get_or_create_tree.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/get_or_create_tree.rs
@@ -50,7 +50,7 @@ impl<'a> MerkleRadixGetOrCreateTreeOperation for MerkleRadixOperations<'a, Sqlit
         tree_name: &str,
         initial_state_root: &str,
     ) -> Result<i64, InternalError> {
-        self.conn.immediate_transaction::<_, InternalError, _>(|| {
+        self.conn.transaction::<_, InternalError, _>(|| {
             if let Some(tree_id) = merkle_radix_tree::table
                 .filter(merkle_radix_tree::name.eq(tree_name))
                 .select(merkle_radix_tree::id)

--- a/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
@@ -46,7 +46,7 @@ const SQLITE_NOW_MILLIS: &str = "strftime('%s') * 1000";
 #[cfg(feature = "sqlite")]
 impl<'a> MerkleRadixPruneEntriesOperation for MerkleRadixOperations<'a, SqliteConnection> {
     fn prune_entries(&self, tree_id: i64, state_root: &str) -> Result<Vec<String>, InternalError> {
-        self.conn.immediate_transaction(|| {
+        self.conn.transaction(|| {
             let deletion_candidates = get_deletion_candidates(self.conn, tree_id, state_root)?;
 
             // Remove the change logs for this root

--- a/libtransact/src/state/merkle/sql/store/operations/write_changes.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/write_changes.rs
@@ -64,7 +64,7 @@ impl<'a> MerkleRadixWriteChangesOperation for MerkleRadixOperations<'a, SqliteCo
         parent_state_root: &str,
         update: &TreeUpdate,
     ) -> Result<(), InternalError> {
-        self.conn.immediate_transaction::<_, InternalError, _>(|| {
+        self.conn.transaction::<_, InternalError, _>(|| {
             // We manually increment the id, so we don't have to insert one at a time and fetch
             // back the resulting id.
             let initial_id: i64 = merkle_radix_leaf::table


### PR DESCRIPTION
Backport of #358 