### PR TITLE
Add remove_pruned_entries to in-txn variants

### DIFF
--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -333,6 +333,16 @@ impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
         Ok(())
     }
 
+    /// Removes all entries that have been marked as pruned.
+    ///
+    /// After calling this method, any records that have been marked as pruned will have been
+    /// deleted from the database.
+    pub fn remove_pruned_entries(&self) -> Result<(), InternalError> {
+        let store = self.new_store();
+        store.remove_pruned_entries(self.tree_id)?;
+        Ok(())
+    }
+
     fn new_store(
         &self,
     ) -> SqlMerkleRadixStore<InTransactionPostgresBackend<'a>, diesel::pg::PgConnection> {

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -308,6 +308,16 @@ impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
         Ok(())
     }
 
+    /// Removes all entries that have been marked as pruned.
+    ///
+    /// After calling this method, any records that have been marked as pruned will have been
+    /// deleted from the database.
+    pub fn remove_pruned_entries(&self) -> Result<(), InternalError> {
+        let store = self.new_store();
+        store.remove_pruned_entries(self.tree_id)?;
+        Ok(())
+    }
+
     fn new_store(
         &self,
     ) -> SqlMerkleRadixStore<InTransactionSqliteBackend<'a>, diesel::SqliteConnection> {


### PR DESCRIPTION
This change adds the remove_pruned_entries function to the InTransaction- variants of SqlMerklState.