### PR TITLE
Backport 0-4: Add remove_pruned_entries to in-txn variants

### DIFF
--- a/libtransact/src/state/merkle/sql/postgres.rs
+++ b/libtransact/src/state/merkle/sql/postgres.rs
@@ -343,6 +343,16 @@ impl<'a> SqlMerkleState<InTransactionPostgresBackend<'a>> {
         Ok(())
     }
 
+    /// Removes all entries that have been marked as pruned.
+    ///
+    /// After calling this method, any records that have been marked as pruned will have been
+    /// deleted from the database.
+    pub fn remove_pruned_entries(&self) -> Result<(), InternalError> {
+        let store = self.new_store();
+        store.remove_pruned_entries(self.tree_id)?;
+        Ok(())
+    }
+
     fn new_store(
         &self,
     ) -> SqlMerkleRadixStore<InTransactionPostgresBackend<'a>, diesel::pg::PgConnection> {

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -317,6 +317,16 @@ impl<'a> SqlMerkleState<InTransactionSqliteBackend<'a>> {
         Ok(())
     }
 
+    /// Removes all entries that have been marked as pruned.
+    ///
+    /// After calling this method, any records that have been marked as pruned will have been
+    /// deleted from the database.
+    pub fn remove_pruned_entries(&self) -> Result<(), InternalError> {
+        let store = self.new_store();
+        store.remove_pruned_entries(self.tree_id)?;
+        Ok(())
+    }
+
     fn new_store(
         &self,
     ) -> SqlMerkleRadixStore<InTransactionSqliteBackend<'a>, diesel::SqliteConnection> {


### PR DESCRIPTION
Backport of #362 