### PR TITLE
Fix midpoint pruning

### DIFF
--- a/libtransact/src/state/error.rs
+++ b/libtransact/src/state/error.rs
@@ -141,3 +141,30 @@ impl From<InvalidStateError> for StateError {
         Self::InvalidState(err)
     }
 }
+
+impl From<StateError> for StateWriteError {
+    fn from(err: StateError) -> Self {
+        match err {
+            StateError::Internal(err) => Self::StorageError(Box::new(err)),
+            StateError::InvalidState(err) => Self::InvalidStateId(err.to_string()),
+        }
+    }
+}
+
+impl From<StateError> for StateReadError {
+    fn from(err: StateError) -> Self {
+        match err {
+            StateError::Internal(err) => Self::StorageError(Box::new(err)),
+            StateError::InvalidState(err) => Self::InvalidStateId(err.to_string()),
+        }
+    }
+}
+
+impl From<StateError> for StatePruneError {
+    fn from(err: StateError) -> Self {
+        match err {
+            StateError::Internal(err) => Self::StorageError(Box::new(err)),
+            StateError::InvalidState(err) => Self::InvalidStateId(err.to_string()),
+        }
+    }
+}

--- a/libtransact/src/state/merkle/sql/sqlite.rs
+++ b/libtransact/src/state/merkle/sql/sqlite.rs
@@ -144,17 +144,7 @@ impl Write for SqlMerkleState<SqliteBackend> {
         state_id: &Self::StateId,
         state_changes: &[StateChange],
     ) -> Result<Self::StateId, StateWriteError> {
-        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
-
-        let (next_state_id, tree_update) = overlay
-            .generate_updates(state_changes)
-            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
-
-        overlay
-            .write_updates(&next_state_id, tree_update)
-            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
-
-        Ok(next_state_id)
+        Committer::commit(self, state_id, state_changes).map_err(StateWriteError::from)
     }
 
     fn compute_state_id(
@@ -162,13 +152,8 @@ impl Write for SqlMerkleState<SqliteBackend> {
         state_id: &Self::StateId,
         state_changes: &[StateChange],
     ) -> Result<Self::StateId, StateWriteError> {
-        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
-
-        let (next_state_id, _) = overlay
-            .generate_updates(state_changes)
-            .map_err(|e| StateWriteError::StorageError(Box::new(e)))?;
-
-        Ok(next_state_id)
+        DryRunCommitter::dry_run_commit(self, state_id, state_changes)
+            .map_err(StateWriteError::from)
     }
 }
 
@@ -182,18 +167,7 @@ impl Read for SqlMerkleState<SqliteBackend> {
         state_id: &Self::StateId,
         keys: &[Self::Key],
     ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
-        let overlay = MerkleRadixOverlay::new(self.tree_id, &*state_id, self.new_store());
-
-        if !overlay
-            .has_root()
-            .map_err(|e| StateReadError::StorageError(Box::new(e)))?
-        {
-            return Err(StateReadError::InvalidStateId(state_id.into()));
-        }
-
-        overlay
-            .get_entries(keys)
-            .map_err(|e| StateReadError::StorageError(Box::new(e)))
+        Reader::get(self, state_id, keys).map_err(StateReadError::from)
     }
 
     fn clone_box(
@@ -209,11 +183,7 @@ impl Prune for SqlMerkleState<SqliteBackend> {
     type Value = Vec<u8>;
 
     fn prune(&self, state_ids: Vec<Self::StateId>) -> Result<Vec<Self::Key>, StatePruneError> {
-        let overlay = MerkleRadixPruner::new(self.tree_id, self.new_store());
-
-        overlay
-            .prune(&state_ids)
-            .map_err(|e| StatePruneError::StorageError(Box::new(e)))
+        Pruner::prune(self, state_ids).map_err(StatePruneError::from)
     }
 }
 

--- a/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
+++ b/libtransact/src/state/merkle/sql/store/operations/prune_entries.rs
@@ -50,6 +50,10 @@ impl<'a> MerkleRadixPruneEntriesOperation for MerkleRadixOperations<'a, SqliteCo
             let Candidates { deletions, .. } =
                 get_deletion_candidates(self.conn, tree_id, state_root)?;
 
+            if deletions.is_empty() {
+                return Ok(vec![]);
+            }
+
             update_changelogs(self.conn, tree_id, state_root, SQLITE_NOW_MILLIS)?;
 
             let mut deleted_values = vec![];
@@ -94,6 +98,10 @@ impl<'a> MerkleRadixPruneEntriesOperation for MerkleRadixOperations<'a, PgConnec
         self.conn.transaction(|| {
             let Candidates { deletions, .. } =
                 get_deletion_candidates(self.conn, tree_id, state_root)?;
+
+            if deletions.is_empty() {
+                return Ok(vec![]);
+            }
 
             update_changelogs(self.conn, tree_id, state_root, POSTGRES_NOW_MILLIS)?;
 

--- a/libtransact/tests/state/merkle/btree.rs
+++ b/libtransact/tests/state/merkle/btree.rs
@@ -18,6 +18,12 @@ use transact::{database::btree::BTreeDatabase, state::merkle::INDEXES};
 
 use super::*;
 
+impl AutoCleanPrunedData for MerkleState {
+    fn remove_pruned_entries(&self) -> Result<(), transact::error::InternalError> {
+        Ok(())
+    }
+}
+
 fn new_btree_state_and_root() -> (MerkleState, String) {
     let btree_db = Box::new(BTreeDatabase::new(&INDEXES));
     let merkle_state = MerkleState::new(btree_db.clone());
@@ -124,6 +130,12 @@ fn merkle_trie_prune_successor_duplicate_leaves() {
 fn merkle_trie_prune_deep_successor_tree() {
     let (state, orig_root) = new_btree_state_and_root();
     test_merkle_trie_prune_deep_successor_tree(orig_root, state);
+}
+
+#[test]
+fn merkle_trie_prune_late_pruning() {
+    let (state, orig_root) = new_btree_state_and_root();
+    test_merkle_trie_prune_late_pruning(orig_root, state);
 }
 
 #[test]

--- a/libtransact/tests/state/merkle/mod.rs
+++ b/libtransact/tests/state/merkle/mod.rs
@@ -1462,6 +1462,7 @@ fn test_produce_same_state<L, R>(
     assert_eq!(merkle_left_root_del, merkle_right_root_del);
 }
 
+#[track_caller]
 fn assert_value_at_address(merkle_db: &MerkleRadixTree, address: &str, expected_value: &str) {
     let value = merkle_db.get_value(address);
     match value {
@@ -1474,6 +1475,7 @@ fn assert_value_at_address(merkle_db: &MerkleRadixTree, address: &str, expected_
     }
 }
 
+#[track_caller]
 fn assert_read_value_at_address<R>(
     merkle_read: &R,
     root_hash: &str,
@@ -1496,6 +1498,7 @@ fn assert_read_value_at_address<R>(
     }
 }
 
+#[track_caller]
 fn expect_change_log(db: &dyn Database, root_hash: &[u8]) -> ChangeLogEntry {
     let reader = db.get_reader().unwrap();
     protobuf::Message::parse_from_bytes(
@@ -1507,6 +1510,7 @@ fn expect_change_log(db: &dyn Database, root_hash: &[u8]) -> ChangeLogEntry {
     .expect("The change log entry to have bytes")
 }
 
+#[track_caller]
 fn assert_has_successors(change_log: &ChangeLogEntry, successor_roots: &[&[u8]]) {
     assert_eq!(successor_roots.len(), change_log.successors.len());
     for successor_root in successor_roots {

--- a/libtransact/tests/state/merkle/sql_postgres.rs
+++ b/libtransact/tests/state/merkle/sql_postgres.rs
@@ -24,6 +24,12 @@ use transact::{database::btree::BTreeDatabase, state::merkle::INDEXES};
 
 use super::*;
 
+impl AutoCleanPrunedData for SqlMerkleState<PostgresBackend> {
+    fn remove_pruned_entries(&self) -> Result<(), transact::error::InternalError> {
+        SqlMerkleState::<PostgresBackend>::remove_pruned_entries(&self)
+    }
+}
+
 #[test]
 fn merkle_trie_empty_changes() -> Result<(), Box<dyn Error>> {
     run_postgres_test(|db_url| {
@@ -119,6 +125,15 @@ fn merkle_trie_prune_deep_successor_tree() -> Result<(), Box<dyn Error>> {
     run_postgres_test(|db_url| {
         let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
         test_merkle_trie_prune_deep_successor_tree(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_prune_late_pruning() -> Result<(), Box<dyn Error>> {
+    run_postgres_test(|db_url| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_url)?;
+        test_merkle_trie_prune_late_pruning(orig_root, state);
         Ok(())
     })
 }

--- a/libtransact/tests/state/merkle/sql_sqlite.rs
+++ b/libtransact/tests/state/merkle/sql_sqlite.rs
@@ -28,6 +28,12 @@ use super::*;
 
 static GLOBAL_THREAD_COUNT: AtomicUsize = AtomicUsize::new(1);
 
+impl AutoCleanPrunedData for SqlMerkleState<SqliteBackend> {
+    fn remove_pruned_entries(&self) -> Result<(), transact::error::InternalError> {
+        SqlMerkleState::<SqliteBackend>::remove_pruned_entries(&self)
+    }
+}
+
 #[test]
 fn merkle_trie_empty_changes() -> Result<(), Box<dyn Error>> {
     run_test(|db_path| {
@@ -123,6 +129,15 @@ fn merkle_trie_prune_deep_successor_tree() -> Result<(), Box<dyn Error>> {
     run_test(|db_path| {
         let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
         test_merkle_trie_prune_deep_successor_tree(orig_root, state);
+        Ok(())
+    })
+}
+
+#[test]
+fn merkle_trie_prune_late_pruning() -> Result<(), Box<dyn Error>> {
+    run_test(|db_path| {
+        let (state, orig_root) = new_sql_merkle_state_and_root(db_path)?;
+        test_merkle_trie_prune_late_pruning(orig_root, state);
         Ok(())
     })
 }


### PR DESCRIPTION
This PR updates the changelog after pruning by taking into account pruning occurring in the middle of a chain of state roots.  The changelog is updated such that the parent and successor nodes are properly re-linked with the removal of the intermediate node.  It also limits the pruning of changelog additions to those candidates that were deleted.